### PR TITLE
Record landmark visits on their real dates

### DIFF
--- a/src/lib/travel/index.ts
+++ b/src/lib/travel/index.ts
@@ -20,6 +20,14 @@ export interface Trip {
   endMonth: number | null;
   description?: string;
   destinations: Destination[];
+  // A day out from where I live rather than a journey to somewhere new. Since
+  // moving to Almaty in Jan 2023 the places around it are reached from home, so
+  // they have no trip to hang on — but they still happened on a date, and a
+  // landmark has no date of its own (it inherits the entry's). Recording them
+  // as entries keeps that date truthful; this flag keeps them distinguishable
+  // from real travel if the timeline ever wants to render them differently.
+  // Country and city stats are Sets, so a repeat entry cannot inflate them.
+  kind?: "outing";
 }
 
 // Month names for formatting

--- a/src/lib/travel/landmarks.json
+++ b/src/lib/travel/landmarks.json
@@ -59,6 +59,12 @@
     "coords": [40.3208, 43.6497],
     "kind": "village"
   },
+  "pervomayskie-prudy": {
+    "en": "Pervomayskie Ponds",
+    "ru": "Первомайские пруды",
+    "coords": [76.94, 43.3736],
+    "kind": "ponds"
+  },
   "pokrova-na-nerli": {
     "en": "Church of the Intercession on the Nerl",
     "ru": "Церковь Покрова на Нерли",

--- a/src/lib/travel/trips.json
+++ b/src/lib/travel/trips.json
@@ -209,6 +209,19 @@
   },
   {
     "year": 2025,
+    "month": 10,
+    "endMonth": null,
+    "kind": "outing",
+    "destinations": [
+      {
+        "country": ["kz", "kaz"],
+        "cities": ["Almaty"],
+        "landmarks": ["shymbulak"]
+      }
+    ]
+  },
+  {
+    "year": 2025,
     "month": 7,
     "endMonth": null,
     "destinations": [
@@ -232,6 +245,32 @@
         "country": ["gb-sct", "gbr"],
         "cities": ["Edinburgh"],
         "landmarks": ["arthurs-seat"]
+      }
+    ]
+  },
+  {
+    "year": 2024,
+    "month": 9,
+    "endMonth": null,
+    "kind": "outing",
+    "destinations": [
+      {
+        "country": ["kz", "kaz"],
+        "cities": ["Almaty"],
+        "landmarks": ["pervomayskie-prudy"]
+      }
+    ]
+  },
+  {
+    "year": 2024,
+    "month": 8,
+    "endMonth": null,
+    "kind": "outing",
+    "destinations": [
+      {
+        "country": ["kz", "kaz"],
+        "cities": ["Almaty"],
+        "landmarks": ["shymbulak"]
       }
     ]
   },
@@ -334,8 +373,7 @@
     "destinations": [
       {
         "country": ["kz", "kaz"],
-        "cities": ["Almaty"],
-        "landmarks": ["shymbulak"]
+        "cities": ["Almaty"]
       }
     ]
   },


### PR DESCRIPTION
Shymbulak was pinned to the Oct 2022 Almaty trip, but it was actually visited in **Aug 2024** and **Oct 2025** — after the move to Almaty, when trips there stopped being recorded. A landmark has no date of its own; it inherits the entry's, so the wrong entry meant the wrong date.

### Changes

- **`trips.json`** — Shymbulak removed from the Oct 2022 entry; three dated entries added in its place:

  | Date | Landmark |
  |---|---|
  | Oct 2025 | Shymbulak |
  | Sep 2024 | Pervomayskie Ponds |
  | Aug 2024 | Shymbulak |

  Inserted at the right position in the file — entries within a year aren't sorted by code, `groupTripsByYear` takes them as they come.

- **`landmarks.json`** — adds `pervomayskie-prudy`.

- **`index.ts`** — optional `kind: "outing"` on `Trip`, marking a day out from home rather than a journey. Nothing reads it yet; entries render like any other. It's there so outings stay distinguishable if the timeline ever wants to show them differently.

Country and city stats are Sets, so the repeat Almaty entries cannot inflate them.

### Note

The Pervomayskie Ponds coords point at the settlement the ponds belong to, not the water itself. Harmless for now — landmark coords go unrendered (`landmarkData` and `getLandmarks` are unused outside `index.ts`), but worth fixing before landmarks reach the map.

`bun test` 12 pass / 0 fail · `astro check` 0 errors