### PR TITLE
Bring wishlist badges, filter chips, and buttons to liquid glass style

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -737,7 +737,7 @@ a.btn-danger:active {
   background-position: right 0.85rem center;
 }
 
-/* Floating UI Tooltips */
+/* Floating UI Tooltips — dark liquid glass, tuned to stay legible in both themes */
 .floating-tooltip {
   display: none;
   position: absolute;
@@ -748,9 +748,11 @@ a.btn-danger:active {
   font-weight: 600;
   white-space: nowrap;
   color: white;
-  background: light-dark(rgba(0, 0, 0, 0.85), rgba(50, 50, 55, 0.95));
+  background: light-dark(rgba(0, 0, 0, 0.7), rgba(255, 255, 255, 0.15));
+  backdrop-filter: blur(14px) saturate(150%);
+  border: 1px solid light-dark(rgba(255, 255, 255, 0.2), rgba(255, 255, 255, 0.14));
   border-radius: 6px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.25);
   z-index: 1000;
   pointer-events: none;
 }
@@ -763,19 +765,43 @@ a.btn-danger:active {
 }
 
 .floating-tooltip-arrow--bottom {
-  border-top-color: light-dark(rgba(0, 0, 0, 0.85), rgba(50, 50, 55, 0.95));
+  border-top-color: light-dark(rgba(0, 0, 0, 0.7), rgba(255, 255, 255, 0.15));
 }
 
 .floating-tooltip-arrow--top {
-  border-bottom-color: light-dark(rgba(0, 0, 0, 0.85), rgba(50, 50, 55, 0.95));
+  border-bottom-color: light-dark(rgba(0, 0, 0, 0.7), rgba(255, 255, 255, 0.15));
 }
 
 .floating-tooltip-arrow--left {
-  border-right-color: light-dark(rgba(0, 0, 0, 0.85), rgba(50, 50, 55, 0.95));
+  border-right-color: light-dark(rgba(0, 0, 0, 0.7), rgba(255, 255, 255, 0.15));
 }
 
 .floating-tooltip-arrow--right {
-  border-left-color: light-dark(rgba(0, 0, 0, 0.85), rgba(50, 50, 55, 0.95));
+  border-left-color: light-dark(rgba(0, 0, 0, 0.7), rgba(255, 255, 255, 0.15));
+}
+
+@media (prefers-reduced-transparency: reduce) {
+  .floating-tooltip {
+    background: light-dark(#1a1a1a, #3a3a3a);
+    backdrop-filter: none;
+    border-color: transparent;
+  }
+
+  .floating-tooltip-arrow--bottom {
+    border-top-color: light-dark(#1a1a1a, #3a3a3a);
+  }
+
+  .floating-tooltip-arrow--top {
+    border-bottom-color: light-dark(#1a1a1a, #3a3a3a);
+  }
+
+  .floating-tooltip-arrow--left {
+    border-right-color: light-dark(#1a1a1a, #3a3a3a);
+  }
+
+  .floating-tooltip-arrow--right {
+    border-left-color: light-dark(#1a1a1a, #3a3a3a);
+  }
 }
 
 /* Accessibility - Reduced motion */

--- a/src/styles/kit/badge.css
+++ b/src/styles/kit/badge.css
@@ -87,37 +87,87 @@
 }
 
 /* =============================================================================
-   Solid Variants (gradient background, white text)
+   Solid Variants (tinted liquid glass, white text)
    ============================================================================= */
 
-.kit-badge--solid-success {
-  background: linear-gradient(135deg, #10b981, #059669);
+.kit-badge--solid-success,
+.kit-badge--solid-primary,
+.kit-badge--solid-info,
+.kit-badge--solid-warning,
+.kit-badge--solid-danger {
+  position: relative;
+  backdrop-filter: blur(12px) saturate(160%);
+  border: 1px solid light-dark(rgba(255, 255, 255, 0.6), rgba(255, 255, 255, 0.18));
   color: white;
-  box-shadow: 0 2px 8px rgba(16, 185, 129, 0.4);
+}
+
+.kit-badge--solid-success::after,
+.kit-badge--solid-primary::after,
+.kit-badge--solid-info::after,
+.kit-badge--solid-warning::after,
+.kit-badge--solid-danger::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  box-shadow: var(--glass-rim);
+}
+
+.kit-badge--solid-success {
+  background: light-dark(rgba(16, 185, 129, 0.55), rgba(16, 185, 129, 0.35));
+  box-shadow: 0 4px 14px rgba(16, 185, 129, 0.25);
 }
 
 .kit-badge--solid-primary {
-  background: linear-gradient(135deg, var(--accent-start), var(--accent-end));
-  color: white;
-  box-shadow: 0 2px 8px rgba(237, 87, 96, 0.4);
+  background: light-dark(rgba(237, 92, 121, 0.55), rgba(237, 92, 121, 0.35));
+  box-shadow: 0 4px 14px rgba(237, 87, 96, 0.25);
 }
 
 .kit-badge--solid-info {
-  background: linear-gradient(135deg, #6366f1, #4f46e5);
-  color: white;
-  box-shadow: 0 2px 8px rgba(99, 102, 241, 0.4);
+  background: light-dark(rgba(99, 102, 241, 0.55), rgba(99, 102, 241, 0.35));
+  box-shadow: 0 4px 14px rgba(99, 102, 241, 0.25);
 }
 
 .kit-badge--solid-warning {
-  background: linear-gradient(135deg, #f59e0b, #d97706);
-  color: white;
-  box-shadow: 0 2px 8px rgba(245, 158, 11, 0.4);
+  background: light-dark(rgba(245, 158, 11, 0.55), rgba(245, 158, 11, 0.35));
+  box-shadow: 0 4px 14px rgba(245, 158, 11, 0.25);
 }
 
 .kit-badge--solid-danger {
-  background: linear-gradient(135deg, #ef4444, #dc2626);
-  color: white;
-  box-shadow: 0 2px 8px rgba(239, 68, 68, 0.4);
+  background: light-dark(rgba(239, 68, 68, 0.55), rgba(239, 68, 68, 0.35));
+  box-shadow: 0 4px 14px rgba(239, 68, 68, 0.25);
+}
+
+@media (prefers-reduced-transparency: reduce) {
+  .kit-badge--solid-success,
+  .kit-badge--solid-primary,
+  .kit-badge--solid-info,
+  .kit-badge--solid-warning,
+  .kit-badge--solid-danger {
+    backdrop-filter: none;
+    border-color: transparent;
+  }
+
+  .kit-badge--solid-success {
+    background: linear-gradient(135deg, #10b981, #059669);
+  }
+
+  .kit-badge--solid-primary {
+    background: linear-gradient(135deg, var(--accent-start), var(--accent-end));
+  }
+
+  .kit-badge--solid-info {
+    background: linear-gradient(135deg, #6366f1, #4f46e5);
+  }
+
+  .kit-badge--solid-warning {
+    background: linear-gradient(135deg, #f59e0b, #d97706);
+  }
+
+  .kit-badge--solid-danger {
+    background: linear-gradient(135deg, #ef4444, #dc2626);
+  }
 }
 
 /* =============================================================================

--- a/src/styles/kit/toggle-group.css
+++ b/src/styles/kit/toggle-group.css
@@ -151,9 +151,22 @@ a.kit-toggle-item[aria-pressed="true"]:visited {
 }
 
 .kit-toggle-group--separated .kit-toggle-item {
-  background: transparent;
-  color: light-dark(#666, #aaa);
-  box-shadow: inset 0 0 0 2px light-dark(#ddd, #444);
+  position: relative;
+  background-color: var(--glass-bg);
+  background-image: var(--glass-sheen);
+  backdrop-filter: var(--glass-filter);
+  color: light-dark(#555, #ddd);
+  border: var(--glass-border);
+  box-shadow: var(--glass-shadow);
+}
+
+.kit-toggle-group--separated .kit-toggle-item::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  box-shadow: var(--glass-rim);
 }
 
 .kit-toggle-group--separated
@@ -161,14 +174,17 @@ a.kit-toggle-item[aria-pressed="true"]:visited {
     .is-active
   ) {
   color: light-dark(#111, #fff);
-  box-shadow: inset 0 0 0 2px light-dark(#bbb, #666);
+  border-color: light-dark(rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0.16));
 }
 
 .kit-toggle-group--separated .kit-toggle-item[aria-pressed="true"],
 .kit-toggle-group--separated .kit-toggle-item.is-active {
-  background: linear-gradient(135deg, var(--accent-start), var(--accent-end));
+  background-color: light-dark(rgba(237, 92, 121, 0.55), rgba(237, 92, 121, 0.4));
+  background-image: var(--glass-sheen);
   color: white;
-  box-shadow: 0 2px 8px rgba(237, 87, 96, 0.35);
+  box-shadow:
+    0 4px 14px rgba(237, 87, 96, 0.3),
+    0 2px 6px rgba(237, 87, 96, 0.15);
 }
 
 /* Separated sizes */
@@ -298,5 +314,18 @@ a.kit-toggle-item[aria-pressed="true"]:visited {
   .kit-toggle-item[aria-pressed="true"],
   .kit-toggle-item.is-active {
     background: light-dark(#fff, #444);
+  }
+
+  .kit-toggle-group--separated .kit-toggle-item {
+    background-color: light-dark(#fff, #2a2a2d);
+    background-image: none;
+    backdrop-filter: none;
+    border-color: light-dark(#e0e0e0, #444);
+  }
+
+  .kit-toggle-group--separated .kit-toggle-item[aria-pressed="true"],
+  .kit-toggle-group--separated .kit-toggle-item.is-active {
+    background: linear-gradient(135deg, var(--accent-start), var(--accent-end));
+    backdrop-filter: none;
   }
 }

--- a/src/styles/wishlist.css
+++ b/src/styles/wishlist.css
@@ -70,6 +70,49 @@
   min-width: 0;
 }
 
+/* "All" filter pill and random-item button — match the liquid glass filter chips */
+.kit-btn.filter-all-btn,
+.kit-btn.mobile-filter-all-btn,
+.kit-btn.filter-random,
+.kit-btn.mobile-filter-random {
+  position: relative;
+  background-color: var(--glass-bg);
+  background-image: var(--glass-sheen);
+  backdrop-filter: var(--glass-filter);
+  border: var(--glass-border);
+  box-shadow: var(--glass-shadow);
+  color: light-dark(#555, #ddd);
+}
+
+.kit-btn.filter-all-btn::after,
+.kit-btn.mobile-filter-all-btn::after,
+.kit-btn.filter-random::after,
+.kit-btn.mobile-filter-random::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  box-shadow: var(--glass-rim);
+}
+
+.kit-btn.filter-all-btn:hover:not(.is-active),
+.kit-btn.mobile-filter-all-btn:hover:not(.is-active),
+.kit-btn.filter-random:hover:not(:disabled),
+.kit-btn.mobile-filter-random:hover:not(:disabled) {
+  color: light-dark(#111, #fff);
+}
+
+.kit-btn.filter-all-btn.is-active,
+.kit-btn.mobile-filter-all-btn.is-active {
+  background-color: light-dark(rgba(237, 92, 121, 0.55), rgba(237, 92, 121, 0.4));
+  background-image: var(--glass-sheen);
+  color: white;
+  box-shadow:
+    0 4px 14px rgba(237, 87, 96, 0.3),
+    0 2px 6px rgba(237, 87, 96, 0.15);
+}
+
 /* Grid */
 .wishlist-grid {
   display: grid;
@@ -280,7 +323,10 @@
 }
 
 /* Badges */
-.wishlist-badge {
+/* Specificity note: .kit-badge.wishlist-badge (not just .wishlist-badge) so this
+   reliably wins over badge.css's `.kit-badge--solid-*  { position: relative }`
+   regardless of stylesheet load order — both are single-class rules otherwise. */
+.kit-badge.wishlist-badge {
   position: absolute;
   top: 0.75rem;
   right: 0.75rem;
@@ -389,14 +435,18 @@
 
 /* Reserve button */
 .reserve-btn {
-  background: light-dark(rgba(0, 0, 0, 0.05), rgba(255, 255, 255, 0.1));
+  position: relative;
+  background-color: var(--glass-bg);
+  background-image: var(--glass-sheen);
+  backdrop-filter: var(--glass-filter);
   color: light-dark(#333, #eee);
-  border: none;
+  border: var(--glass-border);
   padding: 0.6rem 1.25rem;
   font-size: 0.8rem;
   font-weight: 600;
   border-radius: 10px;
   cursor: pointer;
+  box-shadow: var(--glass-shadow);
   transition:
     background-color 0.3s cubic-bezier(0.16, 1, 0.3, 1),
     color 0.3s cubic-bezier(0.16, 1, 0.3, 1),
@@ -404,30 +454,47 @@
     box-shadow 0.3s cubic-bezier(0.16, 1, 0.3, 1);
 }
 
+.reserve-btn::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  box-shadow: var(--glass-rim);
+}
+
 .reserve-btn:hover {
-  background: linear-gradient(135deg, var(--accent-start), var(--accent-end));
+  background-color: light-dark(rgba(237, 92, 121, 0.55), rgba(237, 92, 121, 0.4));
+  background-image: var(--glass-sheen);
   color: white;
   transform: scale(1.05);
-  box-shadow: 0 4px 15px rgba(237, 87, 96, 0.4);
+  box-shadow:
+    0 4px 15px rgba(237, 87, 96, 0.4),
+    0 2px 6px rgba(237, 87, 96, 0.2);
 }
 
 .reserve-btn.own-reservation {
-  background: light-dark(rgba(0, 0, 0, 0.08), rgba(255, 255, 255, 0.12));
+  background-color: light-dark(rgba(0, 0, 0, 0.1), rgba(255, 255, 255, 0.14));
+  background-image: none;
   color: light-dark(#666, #aaa);
 }
 
 .reserve-btn.own-reservation:hover {
-  background: light-dark(rgba(0, 0, 0, 0.15), rgba(255, 255, 255, 0.2));
+  background-color: light-dark(rgba(0, 0, 0, 0.18), rgba(255, 255, 255, 0.22));
+  background-image: none;
   color: light-dark(#333, #fff);
   transform: scale(1.05);
-  box-shadow: none;
+  box-shadow: var(--glass-shadow);
 }
 
 .reserve-btn.received {
-  background: linear-gradient(135deg, #10b981, #059669);
+  background-color: light-dark(rgba(16, 185, 129, 0.55), rgba(16, 185, 129, 0.35));
+  background-image: var(--glass-sheen);
   color: white;
   cursor: default;
-  box-shadow: 0 4px 15px rgba(16, 185, 129, 0.3);
+  box-shadow:
+    0 4px 15px rgba(16, 185, 129, 0.3),
+    0 2px 6px rgba(16, 185, 129, 0.15);
 }
 
 .reserve-btn:disabled {
@@ -497,6 +564,19 @@
   .reserve-btn.received {
     border-color: transparent;
   }
+
+  /* "All" filter pill and random-item button — border for visibility */
+  .kit-btn.filter-all-btn,
+  .kit-btn.mobile-filter-all-btn,
+  .kit-btn.filter-random,
+  .kit-btn.mobile-filter-random {
+    border: 2px solid light-dark(#ccc, #555);
+  }
+
+  .kit-btn.filter-all-btn.is-active,
+  .kit-btn.mobile-filter-all-btn.is-active {
+    border-color: transparent;
+  }
 }
 
 /* Accessibility - Reduced transparency */
@@ -550,6 +630,12 @@
   /* Reserve button */
   .reserve-btn {
     background: light-dark(#f0f0f0, #3a3a3a);
+    background-image: none;
+    backdrop-filter: none;
+  }
+
+  .reserve-btn:hover {
+    background: linear-gradient(135deg, var(--accent-start), var(--accent-end));
   }
 
   .reserve-btn.own-reservation {
@@ -558,6 +644,26 @@
 
   .reserve-btn.own-reservation:hover {
     background: light-dark(#dcdcdc, #505050);
+  }
+
+  .reserve-btn.received {
+    background: linear-gradient(135deg, #10b981, #059669);
+  }
+
+  /* "All" filter pill and random-item button */
+  .kit-btn.filter-all-btn,
+  .kit-btn.mobile-filter-all-btn,
+  .kit-btn.filter-random,
+  .kit-btn.mobile-filter-random {
+    background-color: light-dark(#fff, #2a2a2d);
+    background-image: none;
+    backdrop-filter: none;
+    border-color: light-dark(#e0e0e0, #444);
+  }
+
+  .kit-btn.filter-all-btn.is-active,
+  .kit-btn.mobile-filter-all-btn.is-active {
+    background: linear-gradient(135deg, var(--accent-start), var(--accent-end));
   }
 }
 


### PR DESCRIPTION
Restyles item badges, category filter chips, the "All"/random-gift buttons, and the Reserve button to use the shared --glass-* tokens from global.css (blur, translucency, rim highlight) instead of flat gradients/solids, matching the liquid glass look already used for page chrome. Includes prefers-reduced-transparency and prefers-contrast fallbacks for each.