### PR TITLE
Bring /travel into the liquid glass language

### DIFF
--- a/src/client/travel-map.ts
+++ b/src/client/travel-map.ts
@@ -5,6 +5,8 @@ import { getCityName } from "@lib/travel/cities-i18n";
 import crimeaGeoJson from "@lib/travel/crimea.geo.json";
 
 const MOBILE_BREAKPOINT = 480;
+/** Latitude the globe opens on — also what its zoom floor is measured from. */
+const GLOBE_LATITUDE = 50;
 const VISITED_COLOR = "#ed6292";
 // City dots adapt to color scheme: a white core glows on the dark map, while a
 // deep accent core (with a white ring) stays legible on the light map. The glow
@@ -53,6 +55,49 @@ function getZoomForGlobe(diameter: number): number {
 }
 
 /**
+ * Mercator's scale factor at a latitude, in zoom levels.
+ *
+ * Under the globe projection getZoom()/setZoom() speak in mercator-equivalent
+ * units for the centre's latitude, while the transform — and with it the size
+ * the sphere is drawn at — does not. The two differ by exactly this: 0.64 zoom
+ * levels at 50°N, 2.5 at 80°N. Anything comparing a zoom against a size has to
+ * account for it, or it holds at one latitude and drifts everywhere else.
+ */
+function latitudeZoomOffset(latitude: number): number {
+  return Math.log2(1 / Math.cos((latitude * Math.PI) / 180));
+}
+
+/**
+ * The reported zoom, restated in the units the sphere's size was measured in —
+ * those of GLOBE_LATITUDE — so a threshold in those units means the same thing
+ * wherever the globe has been dragged to. At GLOBE_LATITUDE it changes nothing.
+ */
+function sizeZoom(map: MapLibre): number {
+  return (
+    map.getZoom() +
+    latitudeZoomOffset(map.getCenter().lat) -
+    latitudeZoomOffset(GLOBE_LATITUDE)
+  );
+}
+
+/**
+ * The floor to hand to setMinZoom so gestures can enlarge the globe but never
+ * shrink it below `diameter` on screen.
+ *
+ * minZoom is compared against the transform's zoom, so the offset above has to
+ * be added to a value that came from getZoomForGlobe. Measured: a floor of
+ * 1.382 let the sphere shrink to a reported 0.745, while 1.382 + 0.637 stops it
+ * at exactly 1.382.
+ *
+ * Apply it only once the globe projection is active. In the constructor, where
+ * the map is still mercator, the same number clamps the opening view instead
+ * and the globe starts half again too large.
+ */
+function getGlobeZoomFloor(diameter: number, latitude: number): number {
+  return getZoomForGlobe(diameter) + latitudeZoomOffset(latitude);
+}
+
+/**
  * Zoom at which the sphere reaches into the container's corners — the point
  * where the map has filled its frame and a border stops being a box drawn
  * around empty space. Derived from the container's diagonal with the same
@@ -85,7 +130,9 @@ async function initMap(): Promise<void> {
   };
 
   // For globe mode, start further west so rotation immediately shows Western Europe
-  const initialCenter: [number, number] = isGlobe ? [-10, 50] : [43, 55];
+  const initialCenter: [number, number] = isGlobe
+    ? [-10, GLOBE_LATITUDE]
+    : [43, 55];
 
   const initialZoom = getInitialZoom();
 
@@ -94,7 +141,7 @@ async function initMap(): Promise<void> {
     style: "https://tiles.openfreemap.org/styles/positron",
     center: initialCenter,
     zoom: initialZoom,
-    minZoom: isGlobe ? initialZoom : 1,
+    minZoom: 1,
     attributionControl: false,
   });
 
@@ -104,8 +151,10 @@ async function initMap(): Promise<void> {
     if (mode === "globe") {
       map.setProjection({ type: "globe" });
       const newZoom = getZoomForGlobe(getGlobeSize(container));
-      map.setMinZoom(newZoom);
       map.setZoom(newZoom);
+      map.setMinZoom(
+        getGlobeZoomFloor(getGlobeSize(container), GLOBE_LATITUDE),
+      );
     } else {
       map.setProjection({ type: "mercator" });
       map.setMinZoom(1);
@@ -128,22 +177,33 @@ async function initMap(): Promise<void> {
     container.clientHeight,
   );
   const syncFrame = () => {
-    container.classList.toggle("is-framed", map.getZoom() >= frameFromZoom);
+    // Compared in size units, not reported ones: dragging to a pole shifts the
+    // reported zoom by two and a half levels without changing how big anything
+    // is drawn, and the frame used to wait that much longer to appear there.
+    const zoom = isGlobe ? sizeZoom(map) : map.getZoom();
+    container.classList.toggle("is-framed", zoom >= frameFromZoom);
   };
   map.on("zoom", syncFrame);
+  // Latitude changes what the reported zoom means, so panning matters too.
+  map.on("move", syncFrame);
   syncFrame();
 
   if (isGlobe) {
     map.setProjection({ type: "globe" });
+    map.setMinZoom(getGlobeZoomFloor(getGlobeSize(container), GLOBE_LATITUDE));
 
     // Recalculate zoom on container resize
     const resizeObserver = new ResizeObserver((entries) => {
       const { width, height } = entries[0].contentRect;
       if (width === 0 || height === 0) return;
       const newZoom = getZoomForGlobe(getGlobeSize(container));
-      map.setMinZoom(newZoom);
       map.setZoom(newZoom);
-      // A resized container fills at a different zoom.
+      // A resized container gives the globe a new size, and that size is also
+      // the new floor.
+      map.setMinZoom(
+        getGlobeZoomFloor(getGlobeSize(container), GLOBE_LATITUDE),
+      );
+      // It fills at a different zoom too.
       frameFromZoom = getZoomForFullFrame(width, height);
       syncFrame();
     });

--- a/src/client/travel-map.ts
+++ b/src/client/travel-map.ts
@@ -37,11 +37,16 @@ function getGlobeSize(container: HTMLElement): number {
   return Math.min(container.clientWidth, container.clientHeight);
 }
 
-// Calculate zoom level to fit globe in container
-// MapLibre globe visual size ≈ 512 * 2^zoom / 2.7 (empirically determined)
-// So: visualDiameter = 512 * 2^zoom / 2.7
-// Solving for zoom: zoom = log2(visualDiameter * 2.7 / 512)
-const GLOBE_SCALE_FACTOR = 2.7;
+// MapLibre's rendered globe is ≈ 512 * 2^zoom / GLOBE_SCALE_FACTOR pixels
+// across, so zoom = log2(diameter * GLOBE_SCALE_FACTOR / 512).
+//
+// The factor is measured, not derived. It was 2.7, which asked for a diameter
+// and got about 97% of it — invisible while the container had 50px of padding
+// to hide the shortfall, and plain once the container became the globe. Read
+// off the rendered sphere's width at its widest point at three container
+// sizes: 480→466, 440→428, 280→272, all landing within 0.002 of the same
+// ratio.
+const GLOBE_SCALE_FACTOR = 2.78;
 
 function getZoomForGlobe(diameter: number): number {
   return Math.log2((diameter * GLOBE_SCALE_FACTOR) / 512);

--- a/src/client/travel-map.ts
+++ b/src/client/travel-map.ts
@@ -20,13 +20,21 @@ const LIGHT_WATER = "#cad8e6";
 const DARK_WATER = "#2a3a4a";
 const LIGHT_TEXT = "#333333";
 const DARK_TEXT = "#e0e0e0";
-const GLOBE_PADDING_DESKTOP = 50;
-const GLOBE_PADDING_MOBILE = 0;
 
-function getGlobePadding(containerWidth: number): number {
-  return containerWidth <= MOBILE_BREAKPOINT
-    ? GLOBE_PADDING_MOBILE
-    : GLOBE_PADDING_DESKTOP;
+/**
+ * The globe's diameter, in pixels, as chosen by the stylesheet (--globe-size on
+ * .map). The container's height is that plus a gap above and below, so reading
+ * it here keeps one number in one place instead of a padding constant on this
+ * side and a fixed height on the other, each implying a different globe.
+ */
+function getGlobeSize(container: HTMLElement): number {
+  const declared = parseFloat(
+    getComputedStyle(container).getPropertyValue("--globe-size"),
+  );
+  if (Number.isFinite(declared) && declared > 0) return declared;
+  // No custom property (a container styled elsewhere): fall back to fitting the
+  // sphere into whichever way the box is tighter.
+  return Math.min(container.clientWidth, container.clientHeight);
 }
 
 // Calculate zoom level to fit globe in container
@@ -35,16 +43,8 @@ function getGlobePadding(containerWidth: number): number {
 // Solving for zoom: zoom = log2(visualDiameter * 2.7 / 512)
 const GLOBE_SCALE_FACTOR = 2.7;
 
-function getZoomForGlobe(
-  containerWidth: number,
-  containerHeight: number,
-  padding: number,
-): number {
-  const targetDiameter = Math.min(
-    containerWidth,
-    containerHeight - padding * 2,
-  );
-  return Math.log2((targetDiameter * GLOBE_SCALE_FACTOR) / 512);
+function getZoomForGlobe(diameter: number): number {
+  return Math.log2((diameter * GLOBE_SCALE_FACTOR) / 512);
 }
 
 /**
@@ -74,12 +74,7 @@ async function initMap(): Promise<void> {
   // For globe mode, calculate zoom to fit globe in container with padding
   const getInitialZoom = (): number => {
     if (isGlobe) {
-      const padding = getGlobePadding(container.clientWidth);
-      return getZoomForGlobe(
-        container.clientWidth,
-        container.clientHeight,
-        padding,
-      );
+      return getZoomForGlobe(getGlobeSize(container));
     }
     return isMobile ? 1 : 2;
   };
@@ -103,12 +98,7 @@ async function initMap(): Promise<void> {
   function setProjectionMode(mode: "globe" | "normal") {
     if (mode === "globe") {
       map.setProjection({ type: "globe" });
-      const padding = getGlobePadding(container.clientWidth);
-      const newZoom = getZoomForGlobe(
-        container.clientWidth,
-        container.clientHeight,
-        padding,
-      );
+      const newZoom = getZoomForGlobe(getGlobeSize(container));
       map.setMinZoom(newZoom);
       map.setZoom(newZoom);
     } else {
@@ -145,8 +135,7 @@ async function initMap(): Promise<void> {
     const resizeObserver = new ResizeObserver((entries) => {
       const { width, height } = entries[0].contentRect;
       if (width === 0 || height === 0) return;
-      const padding = getGlobePadding(width);
-      const newZoom = getZoomForGlobe(width, height, padding);
+      const newZoom = getZoomForGlobe(getGlobeSize(container));
       map.setMinZoom(newZoom);
       map.setZoom(newZoom);
       // A resized container fills at a different zoom.

--- a/src/client/travel-map.ts
+++ b/src/client/travel-map.ts
@@ -166,6 +166,32 @@ async function initMap(): Promise<void> {
   (window as unknown as { setMapMode: typeof setProjectionMode }).setMapMode =
     setProjectionMode;
 
+  // The globe fills most of the first screen, so a page that let it eat every
+  // scroll would be a page you couldn't leave with the cursor where it lands.
+  //
+  // Plain wheel and two-finger scroll therefore belong to the page. Zoom stays
+  // on the pinch, which reaches the browser as a wheel event with ctrlKey set
+  // by the operating system — the gesture people already use to zoom a map, and
+  // nothing anyone has to hold down. Stopping the event here in the capture
+  // phase means MapLibre's own handler, which sits on a descendant, never runs
+  // and never calls preventDefault, so the page scrolls exactly as it would
+  // over any other element.
+  container.addEventListener(
+    "wheel",
+    (event) => {
+      if (!event.ctrlKey) event.stopPropagation();
+    },
+    { capture: true },
+  );
+
+  // Touch has the same trap and less room to escape it: a finger landing on the
+  // globe would drag the map instead of the page. One finger scrolls, two
+  // fingers still zoom and turn it. The globe spins by itself until touched, so
+  // the page keeps its animation either way.
+  if (window.matchMedia("(pointer: coarse)").matches) {
+    map.dragPan.disable();
+  }
+
   // The frame only earns its place once the map fills it. Around the globe it
   // would be drawing a box around mostly empty space — a sphere in a 2.7:1
   // container leaves the majority of the frame dark — while zoomed in the map

--- a/src/client/travel-map.ts
+++ b/src/client/travel-map.ts
@@ -47,6 +47,22 @@ function getZoomForGlobe(
   return Math.log2((targetDiameter * GLOBE_SCALE_FACTOR) / 512);
 }
 
+/**
+ * Zoom at which the sphere reaches into the container's corners — the point
+ * where the map has filled its frame and a border stops being a box drawn
+ * around empty space. Derived from the container's diagonal with the same
+ * empirical scale factor as above, rather than a number picked by eye, so it
+ * follows the viewport instead of being right at one width only. The 0.9 gives
+ * it a little lead: the frame should be there as the corners fill, not after.
+ */
+function getZoomForFullFrame(
+  containerWidth: number,
+  containerHeight: number,
+): number {
+  const diagonal = Math.hypot(containerWidth, containerHeight) * 0.9;
+  return Math.log2((diagonal * GLOBE_SCALE_FACTOR) / 512);
+}
+
 async function initMap(): Promise<void> {
   const container = document.getElementById("map")!;
   if (!container) return;
@@ -106,6 +122,22 @@ async function initMap(): Promise<void> {
   (window as unknown as { setMapMode: typeof setProjectionMode }).setMapMode =
     setProjectionMode;
 
+  // The frame only earns its place once the map fills it. Around the globe it
+  // would be drawing a box around mostly empty space — a sphere in a 2.7:1
+  // container leaves the majority of the frame dark — while zoomed in the map
+  // runs edge to edge and the border reads as a window onto it. The threshold
+  // is cached rather than measured per zoom event, since reading the
+  // container's size on every frame of a pinch would cost a layout each time.
+  let frameFromZoom = getZoomForFullFrame(
+    container.clientWidth,
+    container.clientHeight,
+  );
+  const syncFrame = () => {
+    container.classList.toggle("is-framed", map.getZoom() >= frameFromZoom);
+  };
+  map.on("zoom", syncFrame);
+  syncFrame();
+
   if (isGlobe) {
     map.setProjection({ type: "globe" });
 
@@ -117,6 +149,9 @@ async function initMap(): Promise<void> {
       const newZoom = getZoomForGlobe(width, height, padding);
       map.setMinZoom(newZoom);
       map.setZoom(newZoom);
+      // A resized container fills at a different zoom.
+      frameFromZoom = getZoomForFullFrame(width, height);
+      syncFrame();
     });
     resizeObserver.observe(container);
 

--- a/src/components/LangInit.astro
+++ b/src/components/LangInit.astro
@@ -49,6 +49,13 @@
         const label = el.getAttribute("data-aria-label-" + lang);
         if (label) el.setAttribute("aria-label", label);
       });
+      // data-tooltip drives the site's own tooltip (client/tooltip.ts). It used
+      // to be translated only by the wishlist's script, which left every other
+      // page's tooltips in English.
+      document.querySelectorAll("[data-tooltip-" + lang + "]").forEach((el) => {
+        const tooltip = el.getAttribute("data-tooltip-" + lang);
+        if (tooltip) el.setAttribute("data-tooltip", tooltip);
+      });
       document.documentElement.classList.add("lang-ready");
     }
 

--- a/src/components/LangSwitcher.astro
+++ b/src/components/LangSwitcher.astro
@@ -200,6 +200,13 @@ const { storageKey, size = "sm" } = Astro.props;
           var label = el.getAttribute("data-aria-label-" + lang);
           if (label) el.setAttribute("aria-label", label);
         });
+      // Matches LangInit's first pass, so tooltips follow a switch mid-page.
+      document
+        .querySelectorAll("[data-tooltip-en][data-tooltip-ru]")
+        .forEach(function (el) {
+          var tooltip = el.getAttribute("data-tooltip-" + lang);
+          if (tooltip) el.setAttribute("data-tooltip", tooltip);
+        });
     }
 
     function setupLangSwitchers() {

--- a/src/components/ListItem.astro
+++ b/src/components/ListItem.astro
@@ -27,10 +27,10 @@ const Element = href ? "a" : "div";
 </Element>
 
 <style>
+  /* The accent tokens used to be redeclared here with the same two values
+     global.css already holds — the drift that put the wishlist card on its own
+     dialect, in miniature. */
   .list-item {
-    --accent-start: rgb(237, 98, 146);
-    --accent-end: rgb(237, 87, 96);
-
     display: grid;
     grid-template-columns: 80px 1fr;
     gap: 0.5rem;
@@ -43,19 +43,28 @@ const Element = href ? "a" : "div";
     color: inherit;
   }
 
+  /* The wash a row answers a cursor with is the one the filter chips use — the
+     same alpha, the same easing — so "the thing being pointed at" reads the
+     same everywhere. It used to be half as strong at a 4px radius, which was
+     faint enough that the country tints inside a travel row seemed to appear
+     out of nowhere. The radius is generous rather than a capsule: rows wrap to
+     several lines, and a 999px pill on a three-line block bows outward. */
   .list-item.interactive {
-    padding: 0.5rem;
-    border-radius: 4px;
-    transition: background-color 0.15s ease;
+    padding: 0.5rem 0.75rem;
+    margin-inline: -0.75rem;
+    border-radius: 14px;
+    transition: background-color 0.25s ease;
   }
 
   .list-item.interactive:hover {
-    background-color: light-dark(rgba(0, 0, 0, 0.03), rgba(255, 255, 255, 0.05));
+    background-color: light-dark(rgba(0, 0, 0, 0.055), rgba(255, 255, 255, 0.07));
   }
 
   .list-item-date {
     font-size: 0.9rem;
-    color: light-dark(#888, #666);
+    /* The chrome's muted colour. Dark mode had #666, which on a near-black page
+       sat right at the edge of legible. */
+    color: light-dark(#888, #9a9aa0);
   }
 
   .list-item-title {

--- a/src/components/PageHeader.astro
+++ b/src/components/PageHeader.astro
@@ -49,6 +49,7 @@ const hasActions = Astro.slots.has("actions");
 <header
   class:list={["page-header", { "page-header--condense": condenseOnScroll }]}
 >
+  {condenseOnScroll && <div class="page-header__veil" aria-hidden="true" />}
   <div class="header-row">
     <nav
       class:list={["crumbs", "liquid-glass", { "crumbs--solo": soloCrumb }]}
@@ -390,31 +391,46 @@ const hasActions = Astro.slots.has("actions");
     margin-top: 0;
   }
 
-  /* Progressive veil behind the floating pills. The pills leave open gaps
-     where page content would otherwise scroll past at full strength; this
-     fixed, masked backdrop-blur dissolves whatever approaches the top edge —
-     sharp at the year row, frosted mist at the viewport edge — so rows melt
-     away instead of colliding with the capsules. Sits at the bottom of the
-     row's stacking context (z-index: -1), under all three pills. */
-  .page-header--condense .header-row::before {
-    content: "";
+  /* Progressive veil behind the floating pills. The pills leave open gaps where
+     page content would otherwise scroll past at full strength; this fixed,
+     masked backdrop-blur dissolves whatever approaches the top edge, so rows
+     melt away instead of colliding with the capsules.
+
+     It's a real element rather than the row's ::before, and that's the point.
+     As a pseudo-element it lived inside the row's stacking context (z-index 30)
+     and so painted above everything else pinned to the top — including
+     /travel's sticky year, which meant the veil had to stop dead at the year's
+     top edge and fade out well before it. That left a band with no veil and no
+     year in it, where content scrolled past perfectly sharp. On its own layer
+     at z-index 5 it sits above the page but below the year (10) and the pills
+     (30), so it can run on behind the year and dissolve there instead. */
+  .page-header__veil {
     position: fixed;
     top: 0;
     left: 0;
     right: 0;
-    /* Ends exactly where docked sticky content (the year rows) begins, so the
-       veil never blurs their text — only the strip the pills float over. */
-    height: var(--sticky-header-offset, 5.5rem);
+    /* Solid for the strip the pills float over, then a dissolve. On /travel the
+       dissolve happens behind the sticky year, which is opaque and covers it, so
+       the blur runs unbroken from the top edge to the end of the year's bar;
+       with no year docked the same fade is simply a soft bottom. One shape does
+       both the tint and the blur — they used to fade on two different curves,
+       25% for the colour against 45%-96% for the mask. */
+    --veil-fade: 2.75rem;
+    height: calc(var(--sticky-header-offset, 5.5rem) + var(--veil-fade));
     pointer-events: none;
-    z-index: -1;
-    background: linear-gradient(to bottom, var(--veil-bg) 25%, transparent);
+    z-index: 5;
+    background: var(--veil-bg);
     backdrop-filter: var(--veil-filter);
-    mask-image: linear-gradient(to bottom, black 45%, transparent 96%);
+    mask-image: linear-gradient(
+      to bottom,
+      black calc(100% - var(--veil-fade)),
+      transparent
+    );
     opacity: 0;
     transition: opacity 0.4s ease;
   }
 
-  .page-header--condense.is-condensed .header-row::before {
+  .page-header--condense.is-condensed .page-header__veil {
     opacity: 1;
   }
 
@@ -502,7 +518,7 @@ const hasActions = Astro.slots.has("actions");
   }
 
   @media (prefers-reduced-motion: reduce) {
-    .page-header--condense .header-row::before,
+    .page-header__veil,
     .condensed-title {
       transition: none;
     }

--- a/src/components/PageHeader.astro
+++ b/src/components/PageHeader.astro
@@ -407,12 +407,8 @@ const hasActions = Astro.slots.has("actions");
     height: var(--sticky-header-offset, 5.5rem);
     pointer-events: none;
     z-index: -1;
-    background: linear-gradient(
-      to bottom,
-      light-dark(rgba(248, 248, 255, 0.9), rgba(25, 25, 25, 0.9)) 25%,
-      transparent
-    );
-    backdrop-filter: blur(16px);
+    background: linear-gradient(to bottom, var(--veil-bg) 25%, transparent);
+    backdrop-filter: var(--veil-filter);
     mask-image: linear-gradient(to bottom, black 45%, transparent 96%);
     opacity: 0;
     transition: opacity 0.4s ease;

--- a/src/components/YearGroup.astro
+++ b/src/components/YearGroup.astro
@@ -30,16 +30,18 @@ const { year, class: className } = Astro.props;
        year docks just below the floating pills instead of colliding with
        them. Elsewhere the variable is unset and the year sticks to the top. */
     top: var(--sticky-header-offset, 0px);
-    background-color: light-dark(
-      rgba(248, 248, 255, 0.85),
-      rgba(25, 25, 25, 0.85)
-    );
-    backdrop-filter: blur(12px);
+    /* The same veil as the pinned header's strip: both are the page closing
+       over what scrolls beneath them, and they used to say so with two sets of
+       hand-written values. */
+    background-color: var(--veil-bg);
+    backdrop-filter: var(--veil-filter);
     font-weight: 600;
     font-size: 1.25rem;
+    /* Years are numbers first: tabular figures keep them aligned down the page
+       as the eye scans the column. */
+    font-variant-numeric: tabular-nums;
     padding: 0.5rem 0;
-    border-bottom: 1px solid
-      light-dark(rgba(0, 0, 0, 0.1), rgba(255, 255, 255, 0.1));
+    border-bottom: var(--glass-border);
     margin-bottom: 0.5rem;
     z-index: 10;
     color: light-dark(#333, #fafafa);

--- a/src/components/kit/ProgressBar.astro
+++ b/src/components/kit/ProgressBar.astro
@@ -33,25 +33,51 @@ const percent = Math.floor((value / max) * 100);
     gap: 0.5em;
   }
 
+  /* A groove cut into the surface it sits on, rather than a flat grey slot.
+     Glass at 8px tall can't be frost — a backdrop-filter on a strip this thin,
+     lying on a card that is nearly flat behind it, costs a layer and shows
+     nothing. What reads at this size is the light: --glass-rim is a lens edge
+     lit from the top left, so a channel sunk into that same surface is the
+     inverse — shadow at the top left, a catch of light along the bottom right. */
   .progress-bar {
     flex: 1;
-    height: 6px;
-    min-height: 6px;
-    background-color: light-dark(rgba(0, 0, 0, 0.1), rgba(255, 255, 255, 0.15));
-    border-radius: 3px;
+    height: 8px;
+    min-height: 8px;
+    background-color: light-dark(rgba(0, 0, 0, 0.06), rgba(0, 0, 0, 0.28));
+    border-radius: 999px;
+    box-shadow:
+      inset 1.5px 1.5px 2px -1px light-dark(rgba(0, 0, 0, 0.28), rgba(0, 0, 0, 0.6)),
+      inset -1px -1px 1px -0.5px
+        light-dark(rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0.07));
     overflow: hidden;
   }
 
+  /* The fill lies in the groove and catches light along its top edge. */
   .progress-fill {
     height: 100%;
-    background-color: light-dark(rgba(0, 0, 0, 0.4), rgba(255, 255, 255, 0.6));
-    border-radius: 3px;
+    background-color: light-dark(rgba(0, 0, 0, 0.38), rgba(255, 255, 255, 0.55));
+    background-image: linear-gradient(
+      to bottom,
+      rgba(255, 255, 255, 0.35),
+      rgba(255, 255, 255, 0) 55%
+    );
+    border-radius: 999px;
+    box-shadow: inset 0 -1px 1px light-dark(rgba(0, 0, 0, 0.15), rgba(0, 0, 0, 0.3));
     transition: width 0.3s ease;
-    min-width: 2px;
+    min-width: 3px;
   }
 
+  /* Accent fill glows the way every other lit thing in the chrome does. */
   .progress-fill.accent {
-    background: linear-gradient(135deg, var(--accent-start), var(--accent-end));
+    background-color: transparent;
+    background-image:
+      linear-gradient(
+        to bottom,
+        rgba(255, 255, 255, 0.3),
+        rgba(255, 255, 255, 0) 55%
+      ),
+      linear-gradient(135deg, var(--accent-start), var(--accent-end));
+    box-shadow: 0 0 8px rgba(237, 87, 96, 0.45);
   }
 
   .percent {

--- a/src/components/travel/TravelMap.astro
+++ b/src/components/travel/TravelMap.astro
@@ -44,7 +44,12 @@ const { mode = "globe" } = Astro.props;
      in exactly one place. */
   .map {
     --globe-size: clamp(280px, 40vw, 480px);
-    --globe-gap: 1.75rem;
+    /* Zero: the container is the globe. Whatever air the globe needs comes from
+       the page's own grid gap, which already separates it from the title above
+       and the stats below — the container adding its own would be a second
+       margin nobody asked for. Kept as a variable because the geometry below
+       reads better stated in full, and a phone may yet want a hair of it. */
+    --globe-gap: 0px;
     height: calc(var(--globe-size) + var(--globe-gap) * 2);
     border: 1px solid transparent;
     border-radius: 20px;
@@ -91,8 +96,6 @@ const { mode = "globe" } = Astro.props;
 
   @media (max-width: 480px) {
     .map {
-      /* A phone has less to spare above and below than it does across. */
-      --globe-gap: 1rem;
       -webkit-overflow-scrolling: touch;
     }
   }

--- a/src/components/travel/TravelMap.astro
+++ b/src/components/travel/TravelMap.astro
@@ -14,15 +14,49 @@ const { mode = "globe" } = Astro.props;
 </div>
 
 <style>
+  /* Note the absence of `transform: translateZ(0)` here. It was an iOS Safari
+     fix applied to every browser, and an ancestor's transform resets the
+     backdrop root — which killed the frost on the city labels everywhere. It
+     now lives in the iOS-only block at the bottom of this file, next to the
+     `perspective` whose identical effect was already documented there. */
   .map {
     height: 500px;
-    border-radius: 5px;
+    border: 1px solid transparent;
+    border-radius: 20px;
     overflow: hidden;
     position: relative;
-    /* iOS Safari fixes */
-    -webkit-transform: translateZ(0);
-    transform: translateZ(0);
     width: 100%;
+    transition:
+      border-color 0.4s ease,
+      box-shadow 0.4s ease;
+  }
+
+  /* Framed like a card — border, shadow, rim and radius from the shared tokens
+     — but only once the map fills the frame. Around the globe the border would
+     be drawing a box around mostly empty space; zoomed in, the map runs edge to
+     edge and the same border reads as a window onto it. travel-map.ts sets
+     `is-framed` as the globe flattens. The transparent border above holds the
+     space either way, so nothing shifts when it arrives. */
+  .map.is-framed {
+    border: var(--glass-border);
+    box-shadow: var(--glass-shadow);
+  }
+
+  /* The lens edge, above the canvas but below the city labels (z-index 10000). */
+  .map::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    pointer-events: none;
+    z-index: 2;
+    opacity: 0;
+    transition: opacity 0.4s ease;
+    box-shadow: var(--glass-rim);
+  }
+
+  .map.is-framed::after {
+    opacity: 1;
   }
 
   .map:has(canvas:focus-visible) {
@@ -50,7 +84,12 @@ const { mode = "globe" } = Astro.props;
     pointer-events: none;
     z-index: 1;
     border-radius: inherit;
-    background: linear-gradient(90deg, #2a2a2a 0%, #3a3a3a 50%, #2a2a2a 100%);
+    background: linear-gradient(
+      90deg,
+      light-dark(#e0e0e0, #2a2a2a) 0%,
+      light-dark(#f0f0f0, #3a3a3a) 50%,
+      light-dark(#e0e0e0, #2a2a2a) 100%
+    );
     background-size: 200% 100%;
     animation: shimmer 1.5s infinite ease-in-out;
   }
@@ -63,107 +102,6 @@ const { mode = "globe" } = Astro.props;
       background-position: -200% 0;
     }
   }
-
-  @media (prefers-color-scheme: light) {
-    .placeholder {
-      background: linear-gradient(90deg, #e0e0e0 0%, #f0f0f0 50%, #e0e0e0 100%);
-      background-size: 200% 100%;
-    }
-  }
-
-  .cities-toggle {
-    position: absolute;
-    top: 10px;
-    right: 10px;
-    z-index: 1000;
-  }
-
-  .toggle-label {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    cursor: pointer;
-    background: rgba(0, 0, 0, 0.6);
-    backdrop-filter: blur(8px);
-    padding: 8px 12px;
-    border-radius: 6px;
-    font-size: 16px;
-    color: white;
-    user-select: none;
-  }
-
-  @media (prefers-color-scheme: light) {
-    .toggle-label {
-      background: rgba(255, 255, 255, 0.7);
-      backdrop-filter: blur(8px);
-      color: black;
-      border: 1px solid rgba(0, 0, 0, 0.2);
-    }
-  }
-
-  .toggle-input {
-    display: none;
-  }
-
-  .toggle-slider {
-    position: relative;
-    width: 32px;
-    height: 18px;
-    background: #666;
-    border-radius: 9px;
-    transition: background 0.3s ease;
-  }
-
-  .toggle-slider::before {
-    content: "";
-    position: absolute;
-    top: 2px;
-    left: 2px;
-    width: 14px;
-    height: 14px;
-    background: white;
-    border-radius: 50%;
-    transition: transform 0.3s ease;
-  }
-
-  .toggle-input:checked + .toggle-slider {
-    background: #00d4ff;
-  }
-
-  .toggle-input:checked + .toggle-slider::before {
-    transform: translateX(14px);
-  }
-
-  @media (prefers-color-scheme: light) {
-    .toggle-slider {
-      background: #ccc;
-    }
-  }
-
-  @media (max-width: 480px) {
-    .cities-toggle {
-      top: 5px;
-      right: 5px;
-    }
-
-    .toggle-label {
-      padding: 6px 10px;
-    }
-
-    .toggle-slider {
-      width: 28px;
-      height: 16px;
-    }
-
-    .toggle-slider::before {
-      width: 12px;
-      height: 12px;
-    }
-
-    .toggle-input:checked + .toggle-slider::before {
-      transform: translateX(12px);
-    }
-  }
 </style>
 
 <style is:global>
@@ -171,16 +109,24 @@ const { mode = "globe" } = Astro.props;
     outline: none;
   }
 
+  /* A label lying on the map is glass over media — the same case as a badge on
+     a wishlist photo, and it uses the same tokens. They stay dark in both
+     schemes on purpose: this one used to flip to white with black text in the
+     light scheme, over a map that is dark blue and pink either way. */
   .city-label-overlay {
     position: absolute;
     display: flex;
     align-items: center;
     gap: 6px;
-    background: rgba(0, 0, 0, 0.6);
-    backdrop-filter: blur(6px);
-    color: white;
-    padding: 4px 8px;
-    border-radius: 4px;
+    background: var(--glass-bg-on-media);
+    backdrop-filter: var(--glass-filter);
+    border: var(--glass-border-on-media);
+    box-shadow:
+      var(--glass-rim-on-media),
+      0 2px 10px rgba(0, 0, 0, 0.28);
+    color: #fff;
+    padding: 4px 10px;
+    border-radius: 999px;
     font-size: 16px;
     white-space: nowrap;
     pointer-events: none;
@@ -199,28 +145,29 @@ const { mode = "globe" } = Astro.props;
     border-radius: 3px;
   }
 
-  @media (prefers-color-scheme: light) {
+  @media (max-width: 480px) {
     .city-label-overlay {
-      background: rgba(255, 255, 255, 0.7);
-      backdrop-filter: blur(6px);
-      color: black;
-      border: 1px solid rgba(0, 0, 0, 0.2);
+      padding: 3px 8px;
     }
   }
 
-  @media (max-width: 480px) {
+  @media (prefers-reduced-transparency: reduce) {
     .city-label-overlay {
-      padding: 3px 6px;
+      background: rgb(24, 24, 28);
+      backdrop-filter: none;
     }
   }
 
   /* iOS Safari specific fixes. Scope to iOS only: -webkit-touch-callout is
-     iOS-exclusive, whereas -webkit-appearance also matches desktop Chrome,
-     where the perspective below establishes a containing block that breaks
-     backdrop-filter on the city tooltip. */
+     iOS-exclusive, whereas -webkit-appearance also matches desktop Chrome.
+     Everything in here establishes a containing block, which resets the
+     backdrop root and takes the frost off the city labels — a fair trade for
+     the rendering bugs it avoids on iOS, but only there. */
   @supports (-webkit-touch-callout: none) {
     .map {
       /* Force hardware acceleration */
+      -webkit-transform: translateZ(0);
+      transform: translateZ(0);
       -webkit-backface-visibility: hidden;
       backface-visibility: hidden;
       /* Prevent iOS Safari rendering issues */

--- a/src/components/travel/TravelMap.astro
+++ b/src/components/travel/TravelMap.astro
@@ -19,8 +19,33 @@ const { mode = "globe" } = Astro.props;
      backdrop root — which killed the frost on the city labels everywhere. It
      now lives in the iOS-only block at the bottom of this file, next to the
      `perspective` whose identical effect was already documented there. */
+  /* Registered so the script can read them: getComputedStyle hands back an
+     unregistered custom property exactly as written — "clamp(280px, 40vw,
+     480px)" — while a registered <length> resolves to pixels. */
+  @property --globe-size {
+    syntax: "<length>";
+    inherits: false;
+    initial-value: 0px;
+  }
+
+  @property --globe-gap {
+    syntax: "<length>";
+    inherits: false;
+    initial-value: 0px;
+  }
+
+  /* The geometry runs one way: the globe's diameter is the input, the container
+     is that plus a gap above and below, and the breathing room is what falls
+     out. It used to run the other way — a fixed 500px box and a hardcoded 50px
+     of padding, which left the globe whatever height remained (400px) without
+     anyone choosing it.
+
+     travel-map.ts reads --globe-size to work out the zoom, so the number lives
+     in exactly one place. */
   .map {
-    height: 500px;
+    --globe-size: clamp(280px, 40vw, 480px);
+    --globe-gap: 1.75rem;
+    height: calc(var(--globe-size) + var(--globe-gap) * 2);
     border: 1px solid transparent;
     border-radius: 20px;
     overflow: hidden;
@@ -66,9 +91,8 @@ const { mode = "globe" } = Astro.props;
 
   @media (max-width: 480px) {
     .map {
-      height: 300px;
-      /* iOS Safari mobile fixes */
-      min-height: 300px;
+      /* A phone has less to spare above and below than it does across. */
+      --globe-gap: 1rem;
       -webkit-overflow-scrolling: touch;
     }
   }

--- a/src/components/travel/TravelStats.astro
+++ b/src/components/travel/TravelStats.astro
@@ -34,7 +34,7 @@ import {
         <Icon name="question" class="info-icon" aria-hidden="true" />
       </a>
     </div>
-    <ProgressBar value={countries.size} max={countryListSize} label="Countries visited progress" />
+    <ProgressBar value={countries.size} max={countryListSize} label="Countries visited progress" accent />
   </div>
   <div class="card">
     <h3 data-en="Cities" data-ru="Города">Cities</h3>
@@ -59,7 +59,7 @@ import {
         <Icon name="question" class="info-icon" aria-hidden="true" />
       </a>
     </div>
-    <ProgressBar value={continentsVisited} max={continentsTotal} label="Continents visited progress" />
+    <ProgressBar value={continentsVisited} max={continentsTotal} label="Continents visited progress" accent />
   </div>
 </div>
 
@@ -127,7 +127,7 @@ import {
     display: inline-flex;
     vertical-align: super;
     padding: 0.1rem;
-    border-radius: 4px;
+    border-radius: 999px;
     transition: color 0.2s ease;
   }
 

--- a/src/components/travel/TravelStats.astro
+++ b/src/components/travel/TravelStats.astro
@@ -27,9 +27,9 @@ import {
         aria-label="Why this number? View country list"
         data-aria-label-en="Why this number? View country list"
         data-aria-label-ru="Почему такое число? Посмотреть список стран"
-        title="Why this number? View country list"
-        data-title-en="Why this number? View country list"
-        data-title-ru="Почему такое число? Посмотреть список стран"
+        data-tooltip="Why this number? View country list"
+        data-tooltip-en="Why this number? View country list"
+        data-tooltip-ru="Почему такое число? Посмотреть список стран"
       >
         <Icon name="question" class="info-icon" aria-hidden="true" />
       </a>
@@ -52,9 +52,9 @@ import {
         aria-label="Why 7 continents? National Geographic definition"
         data-aria-label-en="Why 7 continents? National Geographic definition"
         data-aria-label-ru="Почему 7 континентов? Определение National Geographic"
-        title="Why 7 continents? National Geographic definition"
-        data-title-en="Why 7 continents? National Geographic definition"
-        data-title-ru="Почему 7 континентов? Определение National Geographic"
+        data-tooltip="Why 7 continents? National Geographic definition"
+        data-tooltip-en="Why 7 continents? National Geographic definition"
+        data-tooltip-ru="Почему 7 континентов? Определение National Geographic"
       >
         <Icon name="question" class="info-icon" aria-hidden="true" />
       </a>
@@ -63,33 +63,54 @@ import {
   </div>
 </div>
 
+<script>
+  // The "?" links explain the numbers, so they get the site's own tooltip
+  // rather than the browser's — which arrives half a second late and in the
+  // operating system's styling.
+  import { initTooltips } from "@client/tooltip";
+  initTooltips();
+</script>
+
 <style>
   .stats {
     display: grid;
     grid-template-columns: repeat(4, 1fr);
-    gap: 16px;
+    /* The page's own grid gap, so the stats sit on the same rhythm as the map
+       and the trip list rather than a tighter one of their own. */
+    gap: 1.25rem;
   }
 
+  /* The same material as a wishlist card: tint, border, shadow and rim all from
+     the shared tokens, and the same 20px radius so the two read as one family
+     of surfaces. It used to be a flat #222222 with a second hardcoded colour
+     for the light scheme. */
   .card {
-    background-color: #222222;
-    padding: 1em;
-    border-radius: 5px;
+    position: relative;
+    background: var(--card-bg);
+    border: var(--glass-border);
+    border-radius: 20px;
+    box-shadow: var(--glass-shadow);
+    padding: 1rem 1.1rem;
     display: flex;
     flex-direction: column;
     gap: 0.5em;
   }
 
-  @media (prefers-color-scheme: light) {
-    .card {
-      background-color: #ebedf0;
-    }
+  /* The refractive rim — a lens edge lit from the top left. */
+  .card::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    pointer-events: none;
+    box-shadow: var(--glass-rim);
   }
 
   .card > h3 {
     margin: 0;
     font-size: 0.85rem;
     font-weight: 500;
-    color: #888;
+    color: light-dark(#666, #9a9aa0);
   }
 
   .value {
@@ -111,7 +132,7 @@ import {
   }
 
   .info-link:hover .info-icon {
-    color: #888;
+    color: light-dark(#1a1a1a, #fff);
   }
 
   .info-link:focus-visible {
@@ -119,8 +140,10 @@ import {
     outline-offset: 2px;
   }
 
+  /* Muted like the language switcher's globe — present, not competing with the
+     number it belongs to. */
   .info-icon {
-    color: #666;
+    color: light-dark(#888, #8a8a90);
     width: 14px;
     height: 14px;
     transition: color 0.2s ease;

--- a/src/components/travel/TravelTripList.module.css
+++ b/src/components/travel/TravelTripList.module.css
@@ -30,7 +30,7 @@
 
 /* Arrow between cities inside a country — lives inside the tint. */
 .separator {
-  color: #666;
+  color: light-dark(#999, #666);
   font-size: 0.85rem;
   margin: 0 0.25rem;
 }
@@ -40,7 +40,7 @@
    space after it is the wrap point for the next country. The country's own right
    padding already gaps it from the last city, so only a hair of left margin. */
 .interSep {
-  color: #666;
+  color: light-dark(#999, #666);
   font-size: 0.85rem;
   margin-left: 0.1rem;
 }
@@ -173,7 +173,7 @@
 }
 
 .flagDivider {
-  color: #666;
+  color: light-dark(#999, #666);
   margin: 0 3px 0 0;
   font-size: 0.7rem;
 }

--- a/src/pages/kit/index.astro
+++ b/src/pages/kit/index.astro
@@ -527,7 +527,12 @@ import { Icon } from "astro-icon/components";
         </div>
 
         <h3>Accent Variant</h3>
-        <p>Use <code>accent</code> prop for gradient fill.</p>
+        <p>
+          Use the <code>accent</code> prop for the gradient fill and its glow.
+          The track is a groove sunk into whatever surface it sits on — the
+          inverse of the lens edge every glass capsule wears — so the bar reads
+          as carved rather than drawn on.
+        </p>
         <div class="progress-demo">
           <ProgressBar value={42} max={195} label="Countries visited" accent />
         </div>

--- a/src/pages/travel/index.astro
+++ b/src/pages/travel/index.astro
@@ -31,6 +31,10 @@ export const prerender = true;
   <main id="main" class="lang-content">
     <PageHeader
       pageTitle={{ en: "Travel", ru: "Путешествия" }}
+      subtitle={{
+        en: "Where I've been so far",
+        ru: "Где я успел побывать",
+      }}
       langSwitcher="lang"
       condenseOnScroll
     />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -39,6 +39,18 @@
     inset 0 0 12px
       light-dark(rgba(255, 255, 255, 0.25), rgba(255, 255, 255, 0.03));
 
+  /* A card's tint. Cards take their border, shadow and rim from the tokens
+     above but keep a tint of their own, heavier than the chrome's 0.55: a card
+     is content you read through, not chrome you look past. It carries no
+     backdrop-filter for the same reason — frost pays for itself over content,
+     and a card *is* the content.
+
+     Named --card-* rather than another --glass-*: the wishlist card used to
+     declare --glass-bg-light and friends locally, one hex away from the tokens
+     here and easy to mistake for them, which is how it ended up with a second
+     dialect of the same material. */
+  --card-bg: light-dark(rgba(255, 255, 255, 0.7), rgba(40, 40, 45, 0.7));
+
   /* The same edge with the light source closer — for glass that tilts toward
      the viewer. The wishlist card is its only consumer today: it wears this
      while it's lifted on hover. In the light scheme the top-left layer is
@@ -97,6 +109,10 @@
 }
 
 @media (prefers-reduced-transparency: reduce) {
+  :root {
+    --card-bg: light-dark(#ffffff, #2a2a2d);
+  }
+
   .liquid-glass {
     background-color: light-dark(#f0f0f0, #2a2a2e);
     background-image: none;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -39,6 +39,14 @@
     inset 0 0 12px
       light-dark(rgba(255, 255, 255, 0.25), rgba(255, 255, 255, 0.03));
 
+  /* The veil: the page itself, translucent, used by anything pinned that has
+     content scrolling underneath it — the header's blurred strip and the year
+     headings on /travel. Not --glass-*: a capsule is a neutral tint you look
+     through, while this is the page's own colour closing over what passes
+     beneath. The two were separately hardcoded, a hex and a blur radius apart. */
+  --veil-bg: light-dark(rgba(248, 248, 255, 0.9), rgba(25, 25, 25, 0.9));
+  --veil-filter: blur(16px);
+
   /* A card's tint. Cards take their border, shadow and rim from the tokens
      above but keep a tint of their own, heavier than the chrome's 0.55: a card
      is content you read through, not chrome you look past. It carries no

--- a/src/styles/wishlist.css
+++ b/src/styles/wishlist.css
@@ -1,13 +1,3 @@
-/* The card's own tint. Named --card-* on purpose: it used to be --glass-bg-light
-   and friends, one hex away from global.css's --glass-* and easy to mistake for
-   them, which is how the card ended up with a second dialect of the same
-   material. Everything else the card needs — border, shadow, rim — now comes
-   from the real tokens; only the tint is its own, and heavier (0.7 vs 0.55)
-   because a card is content you read through, not chrome you look past. */
-:root {
-  --card-bg: light-dark(rgba(255, 255, 255, 0.7), rgba(40, 40, 45, 0.7));
-}
-
 .wishlist-container {
   max-width: 1200px;
   margin: 0 auto;
@@ -852,12 +842,6 @@
 
 /* Accessibility - Reduced transparency */
 @media (prefers-reduced-transparency: reduce) {
-  /* Card tint → solid. The rest of the card's glass (border, rim) is opaque
-     already; global.css takes care of the .liquid-glass surfaces. */
-  :root {
-    --card-bg: light-dark(#ffffff, #2a2a2d);
-  }
-
   /* Ambient blobs — hide */
   .wishlist-container::before,
   .wishlist-container::after {


### PR DESCRIPTION
The wishlist page had already been rebuilt around a shared set of glass tokens; /travel had not. This brings it across, and fixes what turned up along the way.

## Surfaces

**Stat cards** were four flat rectangles in `#222222`, with a second hardcoded colour for the light scheme, a 5px radius against the site's 20px cards and 999px capsules, and no border, shadow or rim. They take the same tokens as a wishlist card at the same radius. `--card-bg` moved to `global.css` to make that possible — it was declared in `wishlist.css`, so on /travel it simply didn't exist.

**The map** is framed like a card, but only once it fills the frame: a sphere in a 2.7:1 container leaves most of it dark, so the border would have been a box drawn around empty space. The threshold comes from the container's diagonal, not a number picked by eye.

**Year headings** and the header's blurred strip are the same thing — the page closing over what scrolls beneath it — and had drifted a hundredth of an alpha and 4px of blur apart. Both take `--veil-bg` / `--veil-filter` now.

**Progress bars** are grooves cut into the surface rather than flat slots. Glass at eight pixels tall can't be frost; what reads at that size is the light, so the track is the inverse of the lens edge every capsule wears.

**Trip rows** answer a cursor with the same wash the filter chips use, so the country tints inside them land on a lit row instead of on nothing.

## Bugs found on the way

- `transform: translateZ(0)` sat on `.map` for every browser as an iOS fix, and an ancestor's transform resets the backdrop root — the city labels' blur was dead everywhere. It now lives in the iOS-only block that already documented the same hazard for `perspective`.
- `GLOBE_SCALE_FACTOR` was 2.7 and asked for a diameter it never got. Measured off the rendered sphere at three container sizes, it's 2.78.
- Under the globe projection `getZoom()` speaks in mercator-equivalent units for the centre's latitude while the transform does not. That let gestures shrink the globe below its starting size, and made the map's frame arrive late after dragging to a pole. Both now go through one helper.
- The globe filled most of the first screen and ate every scroll event, so the page couldn't be scrolled with the cursor on it. Plain wheel belongs to the page now; zoom stays on the pinch, which arrives with `ctrlKey` set by the OS rather than by anyone's finger. Touch gets the same treatment.
- The veil stopped dead at the sticky year's edge, leaving a band where content scrolled past sharp. It's on its own layer below the year now, so it can dissolve behind it.
- `data-tooltip-*` was translated only by the wishlist's script, so tooltips anywhere else stayed in English. `LangInit` and `LangSwitcher` handle it site-wide.
- `ListItem` redeclared the accent tokens `global.css` already holds.

## Also

~60 lines of dead CSS in the map (`.cities-toggle` and its cyan `#00d4ff` switch, never rendered), the `?` links moved from the browser's tooltip to the site's, and /travel gets a subtitle so it stops opening on a single word.

Checked in both colour schemes and at desktop, narrow and phone widths.

https://claude.ai/code/session_01EN2vtecSNgdbDbSwVKDNKW