### PR TITLE
The map's dots become glass, and the language gets written down

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,10 @@
 dist/
 
 # dependencies
-node_modules/
+# No trailing slash: that form matches directories only, and a git worktree
+# borrowing the main checkout's dependencies does it with a symlink, which
+# sails straight past the rule and into a commit.
+node_modules
 
 # logs
 npm-debug.log*

--- a/src/client/travel-map.ts
+++ b/src/client/travel-map.ts
@@ -36,8 +36,10 @@ type MarkerStops = [number, number, number, number];
 
 /** Whatever MapLibre accepts for a numeric circle paint property. */
 type CircleNumberValue = NonNullable<
-  Extract<LayerSpecification, { type: "circle" }>["paint"]
->["circle-radius"];
+  NonNullable<
+    Extract<LayerSpecification, { type: "circle" }>["paint"]
+  >["circle-radius"]
+>;
 
 /**
  * A marker paint value that grows over zoom, optionally taking a second set of
@@ -72,6 +74,38 @@ function markerScale(
     at(3),
   ] as unknown as CircleNumberValue;
 }
+
+/**
+ * The opacity curves of the four marker layers, named once.
+ *
+ * These are the only marker values with two homes: the layer definitions below
+ * and applyCityTransparency, which restores them when someone turns reduced
+ * transparency back off. That branch runs on a system-settings toggle and
+ * nowhere else, so a literal drifting out of sync with its twin would go
+ * unnoticed in every ordinary pass over the page — which is the same reason
+ * markerScale exists one level down.
+ */
+const MARKER_BODY_OPACITY = markerScale(
+  [0.95, 0.78, 0.52, 0.52],
+  [1, 0.9, 0.68, 0.68],
+);
+const MARKER_RIM_OPACITY = markerScale([0, 0.5, 0.8, 0.8], [0, 0.95, 1, 1]);
+const MARKER_SPECULAR_OPACITY = markerScale(
+  [0, 0.45, 0.62, 0.62],
+  [0, 0.7, 0.85, 0.85],
+);
+const MARKER_SHADOW_OPACITY = markerScale([0, 0.18, 0.3, 0.3]);
+
+/**
+ * The two that survive prefers-reduced-transparency, since the highlight and
+ * the shadow simply go to zero there and need no curve.
+ *
+ * The body turns solid. The rim stays — it is the bead's edge, not a surface
+ * laid over content — but at full strength from the first zoom stop that can
+ * hold it, so it has no hover pair: there is nothing left to brighten.
+ */
+const MARKER_BODY_OPACITY_REDUCED = 1;
+const MARKER_RIM_OPACITY_REDUCED = markerScale([0, 1, 1, 1]);
 
 /**
  * The globe's diameter, in pixels, as chosen by the stylesheet (--globe-size on
@@ -637,6 +671,18 @@ async function initMap(): Promise<void> {
      answers a cursor everywhere else on the site (--glass-rim-lit on the
      wishlist card and the condensed title). It also keeps neighbours from
      colliding in a dense cluster, where growth is exactly what makes them.
+
+     None of these layers declares a paint transition, and none can: every
+     value here is a zoom curve over a feature-state case, and MapLibre snaps
+     data-driven properties to their new value rather than easing into it
+     (properties.ts, "Transitions to data-driven properties are not
+     supported"). The *-transition entries that used to sit beside them were
+     doing nothing. Hover is instant, and the only way to change that is to
+     stop driving these off feature-state.
+
+     Both offset layers are anchored to the viewport. The default anchor is the
+     map, which turns the offset with the bearing — and a light source that
+     swings around as you rotate the globe is the one thing glass never does.
      ========================================================================== */
 
   // Drop shadow, offset down — the bead's contact with the map.
@@ -649,10 +695,9 @@ async function initMap(): Promise<void> {
         "circle-color": "#000000",
         "circle-blur": 0.9,
         "circle-translate": [0, 1.3],
+        "circle-translate-anchor": "viewport",
         "circle-radius": markerScale([3, 5.5, 9, 9]),
-        "circle-radius-transition": { duration: 150 },
-        "circle-opacity": markerScale([0, 0.18, 0.3, 0.3]),
-        "circle-opacity-transition": { duration: 200 },
+        "circle-opacity": MARKER_SHADOW_OPACITY,
       },
     },
     "label_other",
@@ -670,14 +715,12 @@ async function initMap(): Promise<void> {
         "circle-color": CITY_GLOW_DARK,
         "circle-blur": 1,
         "circle-radius": markerScale([6, 11, 18, 18], [10, 16, 26, 26]),
-        "circle-radius-transition": { duration: 200 },
         "circle-opacity": [
           "case",
           ["boolean", ["feature-state", "hover"], false],
           0.6,
           0.32,
         ],
-        "circle-opacity-transition": { duration: 200 },
       },
     },
     "label_other",
@@ -695,28 +738,18 @@ async function initMap(): Promise<void> {
       paint: {
         "circle-color": CITY_BODY_DARK,
         "circle-radius": markerScale([3, 5.5, 9, 9], [3.4, 6.2, 10, 10]),
-        "circle-radius-transition": { duration: 150 },
         "circle-blur": [
           "case",
           ["boolean", ["feature-state", "hover"], false],
           0,
           0.08,
         ],
-        "circle-blur-transition": { duration: 150 },
-        "circle-opacity": markerScale(
-          [0.95, 0.78, 0.52, 0.52],
-          [1, 0.9, 0.68, 0.68],
-        ),
-        "circle-opacity-transition": { duration: 150 },
+        "circle-opacity": MARKER_BODY_OPACITY,
         // The rim. White in both schemes: light striking a piece of glass
         // doesn't change colour with the page.
         "circle-stroke-width": markerScale([0, 0.9, 1.3, 1.3]),
         "circle-stroke-color": CITY_RIM,
-        "circle-stroke-opacity": markerScale(
-          [0, 0.5, 0.8, 0.8],
-          [0, 0.95, 1, 1],
-        ),
-        "circle-stroke-opacity-transition": { duration: 200 },
+        "circle-stroke-opacity": MARKER_RIM_OPACITY,
       },
     },
     "label_other",
@@ -733,13 +766,9 @@ async function initMap(): Promise<void> {
         "circle-color": CITY_RIM,
         "circle-blur": 0.5,
         "circle-translate": [-1, -1.1],
+        "circle-translate-anchor": "viewport",
         "circle-radius": markerScale([0, 1.9, 3.2, 3.2], [0, 2.2, 3.6, 3.6]),
-        "circle-radius-transition": { duration: 150 },
-        "circle-opacity": markerScale(
-          [0, 0.45, 0.62, 0.62],
-          [0, 0.7, 0.85, 0.85],
-        ),
-        "circle-opacity-transition": { duration: 200 },
+        "circle-opacity": MARKER_SPECULAR_OPACITY,
       },
     },
     "label_other",
@@ -785,31 +814,35 @@ async function initMap(): Promise<void> {
   );
 
   function applyCityTransparency(reduced: boolean): void {
-    if (!map.getLayer("visited-cities")) return;
-    map.setPaintProperty(
-      "visited-cities",
-      "circle-opacity",
-      reduced
-        ? 1
-        : markerScale([0.95, 0.78, 0.52, 0.52], [1, 0.9, 0.68, 0.68]),
-    );
-    map.setPaintProperty(
-      "visited-cities",
-      "circle-stroke-opacity",
-      reduced
-        ? markerScale([0, 1, 1, 1])
-        : markerScale([0, 0.5, 0.8, 0.8], [0, 0.95, 1, 1]),
-    );
-    for (const layer of ["visited-cities-specular", "visited-cities-shadow"]) {
-      map.setPaintProperty(
-        layer,
+    const opacities: [string, string, CircleNumberValue][] = [
+      [
+        "visited-cities",
         "circle-opacity",
-        reduced
-          ? 0
-          : layer === "visited-cities-specular"
-            ? markerScale([0, 0.45, 0.62, 0.62], [0, 0.7, 0.85, 0.85])
-            : markerScale([0, 0.18, 0.3, 0.3]),
-      );
+        reduced ? MARKER_BODY_OPACITY_REDUCED : MARKER_BODY_OPACITY,
+      ],
+      [
+        "visited-cities",
+        "circle-stroke-opacity",
+        reduced ? MARKER_RIM_OPACITY_REDUCED : MARKER_RIM_OPACITY,
+      ],
+      [
+        "visited-cities-specular",
+        "circle-opacity",
+        reduced ? 0 : MARKER_SPECULAR_OPACITY,
+      ],
+      [
+        "visited-cities-shadow",
+        "circle-opacity",
+        reduced ? 0 : MARKER_SHADOW_OPACITY,
+      ],
+    ];
+
+    for (const [layer, property, value] of opacities) {
+      // Guarding each layer rather than probing one and assuming the rest:
+      // setPaintProperty on a missing layer doesn't throw, it fires an error
+      // event, which is a worse thing to leave lying around than a check.
+      if (!map.getLayer(layer)) continue;
+      map.setPaintProperty(layer, property, value);
     }
   }
 

--- a/src/client/travel-map.ts
+++ b/src/client/travel-map.ts
@@ -1,4 +1,5 @@
 import { Map as MapLibre } from "maplibre-gl";
+import type { LayerSpecification } from "maplibre-gl";
 import type { Feature, Point } from "geojson";
 import { countries, cities, cityCoordinates } from "@lib/travel";
 import { getCityName } from "@lib/travel/cities-i18n";
@@ -12,13 +13,16 @@ const HOVER_RADIUS = 14;
 /** Latitude the globe opens on — also what its zoom floor is measured from. */
 const GLOBE_LATITUDE = 50;
 const VISITED_COLOR = "#ed6292";
-// City dots adapt to color scheme: a white core glows on the dark map, while a
-// deep accent core (with a white ring) stays legible on the light map. The glow
-// halo underneath uses the site accent in both themes.
-const CITY_CORE_DARK = "#ffffff";
-const CITY_CORE_LIGHT = "#b81f54";
+// City markers adapt to the colour scheme: the bead's body is white on the dark
+// map and a deep accent on the light one, where white would have almost no
+// contrast over the pink countries. The halo underneath uses the site accent in
+// both. The rim and the highlight don't change — light striking a piece of
+// glass doesn't take the colour of the page it's on.
+const CITY_BODY_DARK = "#ffffff";
+const CITY_BODY_LIGHT = "#b81f54";
 const CITY_GLOW_DARK = "#ed6292";
 const CITY_GLOW_LIGHT = "#a01848";
+const CITY_RIM = "#ffffff";
 const BORDER_COLOR = "#c74b7a";
 const LIGHT_BG = "#f8f8ff";
 const DARK_BG = "#191919";
@@ -26,6 +30,48 @@ const LIGHT_WATER = "#cad8e6";
 const DARK_WATER = "#2a3a4a";
 const LIGHT_TEXT = "#333333";
 const DARK_TEXT = "#e0e0e0";
+
+/** Values for the four zoom stops every city-marker layer interpolates over. */
+type MarkerStops = [number, number, number, number];
+
+/** Whatever MapLibre accepts for a numeric circle paint property. */
+type CircleNumberValue = NonNullable<
+  Extract<LayerSpecification, { type: "circle" }>["paint"]
+>["circle-radius"];
+
+/**
+ * A marker paint value that grows over zoom, optionally taking a second set of
+ * values while the city is hovered.
+ *
+ * Every layer of the bead shares these stops — the globe, where a city is a
+ * plain dot, and the zoomed-in map, where it is glass — so the parts can never
+ * arrive on different schedules and leave a rim floating around a dot half its
+ * size. The cast is the one the shape needs: MapLibre types these as a union of
+ * literal expression forms, which an array built at runtime can't satisfy.
+ */
+function markerScale(
+  rest: MarkerStops,
+  hover?: MarkerStops,
+): CircleNumberValue {
+  const at = (i: number) =>
+    hover
+      ? ["case", ["boolean", ["feature-state", "hover"], false], hover[i], rest[i]]
+      : rest[i];
+
+  return [
+    "interpolate",
+    ["linear"],
+    ["zoom"],
+    1,
+    at(0),
+    3,
+    at(1),
+    5,
+    at(2),
+    8,
+    at(3),
+  ] as unknown as CircleNumberValue;
+}
 
 /**
  * The globe's diameter, in pixels, as chosen by the stylesheet (--globe-size on
@@ -569,9 +615,52 @@ async function initMap(): Promise<void> {
     },
   });
 
+  /* ==========================================================================
+     City markers — the chrome's liquid glass, transposed into circles.
+
+     A WebGL circle has no gradient fill and no backdrop-filter, so glass can't
+     be applied here the way .liquid-glass applies it to a pill. It has to be
+     rebuilt from the parts the site's other capsules are made of: a tint the
+     map shows through, a bright rim, a specular highlight in the top-left
+     corner the whole design lights from, and a shadow saying the bead sits
+     above the map rather than being printed on it. Four layers over one
+     source, so a single hover feature-state lights all of them together.
+
+     The material arrives with zoom. On the globe a city is three pixels
+     across: a rim and a highlight are sub-pixel there, and a body wide enough
+     to hold them turns Europe into a chain of touching beads. So the globe
+     keeps the plain dot it always had, and the glass assembles itself as the
+     map is zoomed in — every part of it is a paint property that interpolates
+     over zoom anyway, so this costs a curve rather than a mechanism.
+
+     Hover lights the rim instead of inflating the bead, which is how glass
+     answers a cursor everywhere else on the site (--glass-rim-lit on the
+     wishlist card and the condensed title). It also keeps neighbours from
+     colliding in a dense cluster, where growth is exactly what makes them.
+     ========================================================================== */
+
+  // Drop shadow, offset down — the bead's contact with the map.
+  map.addLayer(
+    {
+      id: "visited-cities-shadow",
+      type: "circle",
+      source: "visited-cities",
+      paint: {
+        "circle-color": "#000000",
+        "circle-blur": 0.9,
+        "circle-translate": [0, 1.3],
+        "circle-radius": markerScale([3, 5.5, 9, 9]),
+        "circle-radius-transition": { duration: 150 },
+        "circle-opacity": markerScale([0, 0.18, 0.3, 0.3]),
+        "circle-opacity-transition": { duration: 200 },
+      },
+    },
+    "label_other",
+  );
+
   // Soft accent glow beneath each city — the "halo" of the beacon. Shares the
-  // visited-cities source, so the hover feature-state lights up glow + core
-  // together. Added before the core so it renders underneath it.
+  // visited-cities source, so the hover feature-state lights up glow + body
+  // together. Added before the body so it renders underneath it.
   map.addLayer(
     {
       id: "visited-cities-glow",
@@ -580,19 +669,7 @@ async function initMap(): Promise<void> {
       paint: {
         "circle-color": CITY_GLOW_DARK,
         "circle-blur": 1,
-        "circle-radius": [
-          "interpolate",
-          ["linear"],
-          ["zoom"],
-          1,
-          ["case", ["boolean", ["feature-state", "hover"], false], 10, 6],
-          3,
-          ["case", ["boolean", ["feature-state", "hover"], false], 16, 11],
-          5,
-          ["case", ["boolean", ["feature-state", "hover"], false], 26, 18],
-          8,
-          ["case", ["boolean", ["feature-state", "hover"], false], 26, 18],
-        ],
+        "circle-radius": markerScale([6, 11, 18, 18], [10, 16, 26, 26]),
         "circle-radius-transition": { duration: 200 },
         "circle-opacity": [
           "case",
@@ -606,28 +683,18 @@ async function initMap(): Promise<void> {
     "label_other",
   );
 
-  // Crisp core dot on top. Color/ring are set per color-scheme by
-  // applyCityColors below; radius/opacity react to the hover feature-state.
+  // The body: a solid dot on the globe that thins into a tint you can read the
+  // map through, wearing the rim as its stroke. Colour is set per colour-scheme
+  // by applyCityColors below. Keeps the layer id — the hover hit test queries
+  // it by name.
   map.addLayer(
     {
       id: "visited-cities",
       type: "circle",
       source: "visited-cities",
       paint: {
-        "circle-color": CITY_CORE_DARK,
-        "circle-radius": [
-          "interpolate",
-          ["linear"],
-          ["zoom"],
-          1,
-          ["case", ["boolean", ["feature-state", "hover"], false], 5, 3],
-          3,
-          ["case", ["boolean", ["feature-state", "hover"], false], 8, 5],
-          5,
-          ["case", ["boolean", ["feature-state", "hover"], false], 12, 8],
-          8,
-          ["case", ["boolean", ["feature-state", "hover"], false], 12, 8],
-        ],
+        "circle-color": CITY_BODY_DARK,
+        "circle-radius": markerScale([3, 5.5, 9, 9], [3.4, 6.2, 10, 10]),
         "circle-radius-transition": { duration: 150 },
         "circle-blur": [
           "case",
@@ -636,39 +703,57 @@ async function initMap(): Promise<void> {
           0.08,
         ],
         "circle-blur-transition": { duration: 150 },
-        "circle-opacity": [
-          "case",
-          ["boolean", ["feature-state", "hover"], false],
-          1,
-          0.95,
-        ],
+        "circle-opacity": markerScale(
+          [0.95, 0.78, 0.52, 0.52],
+          [1, 0.9, 0.68, 0.68],
+        ),
         "circle-opacity-transition": { duration: 150 },
-        "circle-stroke-width": 0,
-        "circle-stroke-color": "rgba(0, 0, 0, 0)",
-        "circle-stroke-opacity": 0.9,
+        // The rim. White in both schemes: light striking a piece of glass
+        // doesn't change colour with the page.
+        "circle-stroke-width": markerScale([0, 0.9, 1.3, 1.3]),
+        "circle-stroke-color": CITY_RIM,
+        "circle-stroke-opacity": markerScale(
+          [0, 0.5, 0.8, 0.8],
+          [0, 0.95, 1, 1],
+        ),
+        "circle-stroke-opacity-transition": { duration: 200 },
       },
     },
     "label_other",
   );
 
-  // White core glows on the dark map; on the light map a white core would be
-  // invisible, so switch to a deep accent core with a thin white ring.
+  // Specular highlight, offset toward the top-left — the same corner every
+  // glass capsule on the site catches its light from.
+  map.addLayer(
+    {
+      id: "visited-cities-specular",
+      type: "circle",
+      source: "visited-cities",
+      paint: {
+        "circle-color": CITY_RIM,
+        "circle-blur": 0.5,
+        "circle-translate": [-1, -1.1],
+        "circle-radius": markerScale([0, 1.9, 3.2, 3.2], [0, 2.2, 3.6, 3.6]),
+        "circle-radius-transition": { duration: 150 },
+        "circle-opacity": markerScale(
+          [0, 0.45, 0.62, 0.62],
+          [0, 0.7, 0.85, 0.85],
+        ),
+        "circle-opacity-transition": { duration: 200 },
+      },
+    },
+    "label_other",
+  );
+
+  // A white body reads on the dark map; over the light map's pink countries it
+  // has almost no contrast, so the tint goes to a deep accent there. The rim
+  // and the highlight stay white either way — only the glass itself is tinted.
   function applyCityColors(isDark: boolean): void {
     if (!map.getLayer("visited-cities")) return;
     map.setPaintProperty(
       "visited-cities",
       "circle-color",
-      isDark ? CITY_CORE_DARK : CITY_CORE_LIGHT,
-    );
-    map.setPaintProperty(
-      "visited-cities",
-      "circle-stroke-width",
-      isDark ? 0 : 1.5,
-    );
-    map.setPaintProperty(
-      "visited-cities",
-      "circle-stroke-color",
-      isDark ? "rgba(0, 0, 0, 0)" : "#ffffff",
+      isDark ? CITY_BODY_DARK : CITY_BODY_LIGHT,
     );
     // On the light map a same-hue glow washes out over the pink countries, so
     // the glow goes deeper and a touch stronger; the dark map keeps the airy
@@ -689,6 +774,48 @@ async function initMap(): Promise<void> {
   applyCityColors(colorSchemeQuery.matches);
   colorSchemeQuery.addEventListener("change", (e) =>
     applyCityColors(e.matches),
+  );
+
+  // Reduced transparency: the bead goes back to being a dot. The tint turns
+  // solid and the two layers that exist only to fake depth — the highlight and
+  // the shadow — go away. The halo stays: it is the map's own beacon, not a
+  // surface laid over content, and nothing has to be read through it.
+  const reducedTransparencyQuery = window.matchMedia(
+    "(prefers-reduced-transparency: reduce)",
+  );
+
+  function applyCityTransparency(reduced: boolean): void {
+    if (!map.getLayer("visited-cities")) return;
+    map.setPaintProperty(
+      "visited-cities",
+      "circle-opacity",
+      reduced
+        ? 1
+        : markerScale([0.95, 0.78, 0.52, 0.52], [1, 0.9, 0.68, 0.68]),
+    );
+    map.setPaintProperty(
+      "visited-cities",
+      "circle-stroke-opacity",
+      reduced
+        ? markerScale([0, 1, 1, 1])
+        : markerScale([0, 0.5, 0.8, 0.8], [0, 0.95, 1, 1]),
+    );
+    for (const layer of ["visited-cities-specular", "visited-cities-shadow"]) {
+      map.setPaintProperty(
+        layer,
+        "circle-opacity",
+        reduced
+          ? 0
+          : layer === "visited-cities-specular"
+            ? markerScale([0, 0.45, 0.62, 0.62], [0, 0.7, 0.85, 0.85])
+            : markerScale([0, 0.18, 0.3, 0.3]),
+      );
+    }
+  }
+
+  applyCityTransparency(reducedTransparencyQuery.matches);
+  reducedTransparencyQuery.addEventListener("change", (e) =>
+    applyCityTransparency(e.matches),
   );
 
   // City hover: track hovered feature and show label tooltip.

--- a/src/components/travel/TravelMap.astro
+++ b/src/components/travel/TravelMap.astro
@@ -200,8 +200,8 @@ const { mode = "globe" } = Astro.props;
   }
 
   @media (prefers-reduced-transparency: reduce) {
+    /* The opaque tint comes from --glass-bg-on-media, which goes solid here. */
     .city-label-overlay {
-      background: rgb(24, 24, 28);
       backdrop-filter: none;
     }
   }

--- a/src/components/wishlist/MobileFilterBar.astro
+++ b/src/components/wishlist/MobileFilterBar.astro
@@ -79,10 +79,15 @@ const hasEndSlot = Astro.slots.has("end");
       transition: transform 0.4s cubic-bezier(0.32, 0.72, 0, 1);
     }
 
+    /* The feature query stays a literal — @supports can't test a custom
+       property — but the frost itself comes from the shared token, so this bar
+       blurs and saturates exactly like every other floating capsule. Its tint
+       stays its own: heavier than the chrome's, because it sits at the edge of
+       the screen with content running right up under it. */
     @supports (backdrop-filter: blur(20px)) {
       .mobile-filter-bar {
         background: light-dark(rgba(255, 255, 255, 0.8), rgba(30, 30, 32, 0.8));
-        backdrop-filter: blur(20px);
+        backdrop-filter: var(--glass-filter);
       }
     }
 

--- a/src/pages/kit/index.astro
+++ b/src/pages/kit/index.astro
@@ -240,9 +240,20 @@ import { Icon } from "astro-icon/components";
         <h3>Reduced transparency</h3>
         <p>
           Under <code>prefers-reduced-transparency: reduce</code> every surface
-          drops its frost for an opaque fallback. The tokens handle the card and
-          the veil; <code>.liquid-glass</code> handles itself. Anything that
-          re-declares the recipe by hand owes its own fallback — check it.
+          drops its frost for an opaque fallback. The <strong>tint</strong> is
+          handled at the token: <code>--card-bg</code>, <code>--veil-bg</code>
+          and <code>--glass-bg-on-media</code> all go solid there, so no
+          consumer needs to name a colour twice. <code>.liquid-glass</code>
+          handles itself entirely.
+        </p>
+        <p>
+          What a hand-rolled recipe still owes is the
+          <strong>frost</strong>: <code>--glass-filter</code> deliberately stays
+          a blur, because a few chrome surfaces have no opaque tint of their own
+          yet, and taking the frost off a 0.55 tint would leave them more
+          transparent rather than less. So anything setting
+          <code>backdrop-filter: var(--glass-filter)</code> by hand owes a
+          <code>backdrop-filter: none</code> — the demo tile above included.
         </p>
       </section>
 
@@ -1025,7 +1036,10 @@ import { Icon } from "astro-icon/components";
   .glass-demo__veil {
     position: sticky;
     top: 0;
-    padding: 0.5rem 0;
+    /* Spans the scroller's own padding, or content would slide past it up the
+       left and right edges — with a veil that is the whole thing being shown. */
+    margin-inline: -0.9rem;
+    padding: 0.5rem 0.9rem;
     background-color: var(--veil-bg);
     backdrop-filter: var(--veil-filter);
     border-bottom: var(--glass-border);
@@ -1034,12 +1048,12 @@ import { Icon } from "astro-icon/components";
     color: light-dark(#333, #fafafa);
   }
 
-  /* The demo re-declares the recipe by hand, so it owes its own fallback —
-     exactly the rule this section states. The card and the veil need none:
-     theirs live on the tokens. */
+  /* The tints all live on the tokens and go solid on their own. What a
+     hand-rolled recipe still owes is the frost: --glass-filter stays a blur
+     under reduced transparency, because a couple of chrome consumers have no
+     opaque fallback yet and would come out worse without it. */
   @media (prefers-reduced-transparency: reduce) {
     .glass-demo__tile--media {
-      background-color: #2a2a2e;
       backdrop-filter: none;
     }
   }

--- a/src/pages/kit/index.astro
+++ b/src/pages/kit/index.astro
@@ -19,6 +19,7 @@ import { Icon } from "astro-icon/components";
           <h3>Foundations</h3>
           <ul>
             <li><a href="#colors">Colors</a></li>
+            <li><a href="#liquid-glass">Liquid glass</a></li>
             <li><a href="#typography">Typography</a></li>
             <li><a href="#links">Links</a></li>
           </ul>
@@ -147,6 +148,102 @@ import { Icon } from "astro-icon/components";
             </div>
           </div>
         </div>
+      </section>
+
+      <!-- ================================================================
+           LIQUID GLASS
+           ================================================================ -->
+      <section id="liquid-glass">
+        <h2>Liquid glass</h2>
+        <p>
+          Every translucent surface on the site is one of four materials, all
+          declared once in <code>global.css</code>. They are not
+          interchangeable: each answers a different question about what is
+          behind the surface. Reach for a token, never a fresh
+          <code>blur()</code> — a second dialect of the same material is how
+          this system went wrong the first time.
+        </p>
+
+        <h3>The four materials</h3>
+        <div class="glass-demo">
+          <div class="glass-demo__stage">
+            <div class="glass-demo__tile liquid-glass">Chrome</div>
+            <div class="glass-demo__tile glass-demo__tile--card">Card</div>
+            <div class="glass-demo__tile glass-demo__tile--media">On media</div>
+            <div class="glass-demo__scroller">
+              <div class="glass-demo__veil">Veil</div>
+              <p>Content passes</p>
+              <p>under the veil</p>
+              <p>and dissolves</p>
+              <p>into the page.</p>
+              <p>Scroll me.</p>
+            </div>
+          </div>
+        </div>
+
+        <dl class="glass-tokens">
+          <dt><code>--glass-*</code> — chrome</dt>
+          <dd>
+            Floating capsules you look <em>through</em>: the nav dock, the home
+            pill, the language switcher, the condensed page title. Light tint
+            (0.55), frost, and a refractive rim. Apply with the
+            <code>.liquid-glass</code> utility.
+          </dd>
+
+          <dt><code>--card-bg</code> — card</dt>
+          <dd>
+            Content you read, not chrome you look past. Heavier tint (0.7),
+            borrows the border, shadow and rim from the chrome tokens, and
+            deliberately carries <strong>no frost</strong> — blur earns its keep
+            over content, and a card <em>is</em> the content.
+          </dd>
+
+          <dt><code>--glass-*-on-media</code> — on media</dt>
+          <dd>
+            Glass over a photograph, where the backdrop is arbitrary. It cannot
+            follow the colour scheme: a light tint would drop dark text onto a
+            dark photo. So the tint stays dark in both themes, the label stays
+            white, and it is heavy enough to carry the label with the frost
+            gone — see the transform trap below.
+          </dd>
+
+          <dt><code>--veil-*</code> — veil</dt>
+          <dd>
+            Not glass at all: the page's own colour closing over what scrolls
+            beneath it. Used by the pinned header strip and
+            <code>/travel</code>'s sticky year. A capsule is a neutral tint you
+            look through; this one belongs to the page.
+          </dd>
+        </dl>
+
+        <h3>The utility</h3>
+        <p>
+          <code>.liquid-glass</code> paints the tint, sheen, frost, border and
+          shadow, and adds the rim as an <code>::after</code>. Two things it
+          leaves to the consumer: the <strong>border-radius</strong>, which the
+          rim inherits, and <strong>position</strong> — the rim needs a
+          positioned host, but forcing <code>relative</code> here would fight
+          consumers that position themselves.
+        </p>
+
+        <h3>The transform trap</h3>
+        <p>
+          A <code>transform</code> on an <em>ancestor</em> resets the
+          backdrop-filter root and silently kills the frost — including the
+          identity matrix a finished transform animation leaves behind. Animate
+          the glass element itself, never a wrapper around it. This is why the
+          header's entrance animation sits on the switcher rather than its
+          shell, and why the badge tint is heavy enough to survive a card
+          lifting on hover.
+        </p>
+
+        <h3>Reduced transparency</h3>
+        <p>
+          Under <code>prefers-reduced-transparency: reduce</code> every surface
+          drops its frost for an opaque fallback. The tokens handle the card and
+          the veil; <code>.liquid-glass</code> handles itself. Anything that
+          re-declares the recipe by hand owes its own fallback — check it.
+        </p>
       </section>
 
       <!-- ================================================================
@@ -830,6 +927,136 @@ import { Icon } from "astro-icon/components";
     font-size: 0.65rem;
     font-family: var(--font-fira-code);
     color: light-dark(#888, #666);
+  }
+
+  /* Liquid glass demo — the four materials over one busy backdrop, because
+     glass only shows what it is when there is something behind it to disturb.
+     The stage carries the pattern; each tile is the real material, taking the
+     same tokens the site uses, so this page can never drift from it. */
+  .glass-demo {
+    margin-bottom: 1.5rem;
+  }
+
+  .glass-demo__stage {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-start;
+    gap: 1rem;
+    padding: 1.5rem;
+    border-radius: 16px;
+    background-color: light-dark(#e8e6ff, #241f2e);
+    background-image:
+      radial-gradient(
+        circle at 18% 30%,
+        var(--accent-start) 0,
+        transparent 42%
+      ),
+      radial-gradient(circle at 78% 70%, #4fc3f7 0, transparent 45%),
+      repeating-linear-gradient(
+        45deg,
+        light-dark(rgba(0, 0, 0, 0.06), rgba(255, 255, 255, 0.06)) 0 8px,
+        transparent 8px 16px
+      );
+  }
+
+  .glass-demo__tile {
+    position: relative; /* hosts the .liquid-glass rim */
+    display: inline-flex;
+    align-items: center;
+    padding: 0 1.1rem;
+    min-height: 3rem;
+    border-radius: 999px;
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: light-dark(#333, #fafafa);
+  }
+
+  /* Card: the chrome's edge and shadow, its own heavier tint, and no frost. */
+  .glass-demo__tile--card {
+    background: var(--card-bg);
+    border: var(--glass-border);
+    box-shadow: var(--glass-shadow);
+    border-radius: 14px;
+  }
+
+  .glass-demo__tile--card::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    pointer-events: none;
+    box-shadow: var(--glass-rim);
+  }
+
+  /* On media: the one material that ignores the colour scheme. */
+  .glass-demo__tile--media {
+    background-color: var(--glass-bg-on-media);
+    backdrop-filter: var(--glass-filter);
+    border: var(--glass-border-on-media);
+    color: #fff;
+  }
+
+  .glass-demo__tile--media::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    pointer-events: none;
+    box-shadow: var(--glass-rim-on-media);
+  }
+
+  /* Veil: needs something to scroll under it, so it gets a box of its own. */
+  .glass-demo__scroller {
+    flex: 1 1 12rem;
+    min-width: 10rem;
+    height: 8rem;
+    overflow-y: auto;
+    border-radius: 14px;
+    background: light-dark(var(--light-bg), var(--dark-bg));
+    padding: 0 0.9rem 0.9rem;
+  }
+
+  .glass-demo__scroller p {
+    margin: 0.4rem 0;
+    font-size: 0.8rem;
+    color: light-dark(#555, #b4b4b8);
+  }
+
+  .glass-demo__veil {
+    position: sticky;
+    top: 0;
+    padding: 0.5rem 0;
+    background-color: var(--veil-bg);
+    backdrop-filter: var(--veil-filter);
+    border-bottom: var(--glass-border);
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: light-dark(#333, #fafafa);
+  }
+
+  /* The demo re-declares the recipe by hand, so it owes its own fallback —
+     exactly the rule this section states. The card and the veil need none:
+     theirs live on the tokens. */
+  @media (prefers-reduced-transparency: reduce) {
+    .glass-demo__tile--media {
+      background-color: #2a2a2e;
+      backdrop-filter: none;
+    }
+  }
+
+  .glass-tokens {
+    margin: 0 0 1.5rem;
+  }
+
+  .glass-tokens dt {
+    margin-top: 1rem;
+    font-weight: 600;
+    color: light-dark(#111, #fafafa);
+  }
+
+  .glass-tokens dd {
+    margin: 0.35rem 0 0;
+    color: light-dark(#333, #e0e0e0);
   }
 
   /* Typography demo */

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -119,6 +119,14 @@
 @media (prefers-reduced-transparency: reduce) {
   :root {
     --card-bg: light-dark(#ffffff, #2a2a2d);
+
+    /* The veil is the page's own colour closing over what scrolls beneath it,
+       so at full strength it is simply the page — there is no tint to invent,
+       and nothing left for a blur to do. Overriding the tokens rather than the
+       two consumers keeps the header's strip and /travel's sticky year from
+       each needing a fallback of their own. */
+    --veil-bg: light-dark(var(--light-bg), var(--dark-bg));
+    --veil-filter: none;
   }
 
   .liquid-glass {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -127,6 +127,18 @@
        each needing a fallback of their own. */
     --veil-bg: light-dark(var(--light-bg), var(--dark-bg));
     --veil-filter: none;
+
+    /* Glass over a photograph is the one material whose fallback can't be
+       derived from the page: the tint stays dark whatever the scheme, exactly
+       as it does at full transparency. This is the value its three consumers —
+       the wishlist badge, the map's city label, and /kit's own demo — had each
+       arrived at separately, one of them at a different number.
+
+       Only the tint moves here. --glass-filter stays a blur on purpose: a
+       couple of chrome consumers still have no opaque fallback of their own,
+       and taking the frost off a 0.55 tint would leave them more transparent
+       than they are today, not less. */
+    --glass-bg-on-media: rgb(24, 24, 28);
   }
 
   .liquid-glass {

--- a/src/styles/kit/badge.css
+++ b/src/styles/kit/badge.css
@@ -181,8 +181,8 @@
 }
 
 @media (prefers-reduced-transparency: reduce) {
+  /* The opaque tint comes from --glass-bg-on-media, which goes solid here. */
   .kit-badge--glass {
-    background-color: rgb(24, 24, 28);
     backdrop-filter: none;
   }
 }


### PR DESCRIPTION
Four changes, all the same argument: the site has a glass vocabulary, and three places had not been told about it.

## The city markers

A flat white disc with a pink blur under it, on a page whose every capsule is glass. A WebGL circle has no gradient fill and no backdrop-filter, so the material can't be *applied* here the way `.liquid-glass` applies it to a pill — it is rebuilt from parts. Four layers over one source: a shadow offset down, the accent halo, a body wearing the rim as its stroke, and a specular highlight offset toward the top-left, the corner every other capsule takes its light from. One source means one hover feature-state lights all of them together.

**The material arrives with zoom.** On the globe a city is three pixels across: a rim and a highlight are sub-pixel there, and a body wide enough to hold them turns Europe into a chain of touching beads. So the globe keeps its plain dot and the glass assembles as the map is zoomed in — every part of it is a paint property that interpolates over zoom anyway, which makes this a curve rather than a mechanism. `markerScale()` holds the four stops in one place, because parts that arrive on different schedules leave a rim floating around a dot half its size.

**Hover lights the rim instead of inflating the bead**, which is how glass answers a cursor everywhere else here, and which stops neighbours colliding in a dense cluster — growth is exactly what makes them collide.

The tint still swaps by colour scheme, since white has almost no contrast over the light map's pink countries. The rim and the highlight don't: light striking a piece of glass doesn't take the colour of the page it's on. That shrinks `applyCityColors` to the body and the halo.

## Reduced transparency

The gap underneath all of this. The two veils — the pinned header strip and `/travel`'s sticky year — kept their blur, the only surfaces on the site that did. Fixed on the tokens rather than the two consumers: at full strength the veil is simply the page, so there is no tint to invent and nothing left for a blur to do.

The markers get the same answer from a listener beside the one already watching the colour scheme: the body turns solid, the highlight and the shadow go. The halo stays — it is the map's own beacon, not a surface laid over content.

## MobileFilterBar

Blurring by hand at the same radius the token already names. The `@supports` test stays a literal, since it can't ask about a custom property.

## /kit documents the system

The page is meant to be the reference for the UI kit, and the glass system was the one thing missing from it. Now: the four materials over one busy backdrop, because glass only shows what it is when there is something behind it to disturb, plus the utility, the transform trap, and the reduced-transparency rule.

Writing it caught the demo tile breaking the rule stated three paragraphs above it — the hand-rolled recipe had no reduced-transparency fallback of its own.

## Verification

`astro check` 0 errors, `bun test` 12/12, production build passes. Markers checked live in both colour schemes, on the globe and zoomed in, on hover, and under `prefers-reduced-transparency: reduce`.

🤖 Generated with [Claude Code](https://claude.ai/code)