### PR TITLE
The admin panel joins the site's glass

### DIFF
--- a/src/components/wishlist/admin/AdminPanel.tsx
+++ b/src/components/wishlist/admin/AdminPanel.tsx
@@ -336,12 +336,18 @@ function AdminPanelInner({
               full
             />
 
+            {/* The separated variant is the ghost row the public wishlist
+                filters with: nothing at rest, a wash under the cursor, and the
+                accent capsule on the one that's on. The default pill variant
+                put these in a grey tray with a white active chip — a control
+                panel's filter, not this site's. */}
             <ToggleGroup
               items={statusItems}
               value={selectedStatus}
               onChange={(value) =>
                 setSelectedStatus(value as "all" | "reserved" | "received")
               }
+              variant="separated"
               ariaLabel="Filter by status"
             />
 
@@ -349,8 +355,8 @@ function AdminPanelInner({
               items={sortItems}
               value={sortMode}
               onChange={(value) => setSortMode(value as "admin" | "public")}
+              variant="separated"
               ariaLabel="Sort mode"
-              className="admin-sort-toggle"
             />
           </div>
         </div>

--- a/src/pages/wishlist/~/login.astro
+++ b/src/pages/wishlist/~/login.astro
@@ -175,29 +175,79 @@ if (!isDevMode) {
     user-select: none;
   }
 
+  /* The one control on the page, so it is the site's glass: a round capsule
+     with the accent arriving behind it, the same recipe as the random-pick die
+     and the modal's close button. It used to swap its background and scale up
+     by 8% — nothing in this chrome grows under a cursor. */
   .enter-btn {
+    position: relative;
+    isolation: isolate;
     display: flex;
     align-items: center;
     justify-content: center;
     width: 64px;
     height: 64px;
-    border: none;
+    border: var(--glass-border);
     border-radius: 50%;
-    background: light-dark(rgba(0, 0, 0, 0.04), rgba(255, 255, 255, 0.06));
+    background-color: var(--glass-bg);
+    background-image: var(--glass-sheen);
+    backdrop-filter: var(--glass-filter);
+    box-shadow: var(--glass-shadow);
     color: light-dark(#666, #888);
     cursor: pointer;
-    transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+    transition: color 0.3s ease;
   }
 
-  .enter-btn:hover:not(:disabled) {
+  .enter-btn::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
     background: linear-gradient(135deg, var(--accent-start), var(--accent-end));
-    color: white;
-    transform: scale(1.08);
     box-shadow: 0 8px 32px rgba(237, 87, 96, 0.35);
+    opacity: 0;
+    transform: scale(0.9);
+    transition:
+      transform 0.42s cubic-bezier(0.16, 1, 0.3, 1),
+      opacity 0.3s ease;
+    pointer-events: none;
+    z-index: -1;
   }
 
-  .enter-btn:active:not(:disabled) {
-    transform: scale(0.98);
+  /* The lens edge, stepping aside once the accent is lit. */
+  .enter-btn::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    pointer-events: none;
+    z-index: 5;
+    box-shadow: var(--glass-rim);
+    transition: box-shadow 0.3s ease;
+  }
+
+  .enter-btn:hover:not(:disabled),
+  .enter-btn:focus-visible:not(:disabled) {
+    color: #fff;
+  }
+
+  .enter-btn:hover:not(:disabled)::before,
+  .enter-btn:focus-visible:not(:disabled)::before {
+    opacity: 1;
+    transform: scale(1);
+  }
+
+  .enter-btn:hover:not(:disabled)::after,
+  .enter-btn:focus-visible:not(:disabled)::after {
+    box-shadow: none;
+  }
+
+  @media (prefers-reduced-transparency: reduce) {
+    .enter-btn {
+      background-color: light-dark(#f0f0f0, #2a2a2e);
+      background-image: none;
+      backdrop-filter: none;
+    }
   }
 
   .enter-btn:disabled {

--- a/src/styles/admin/forms.css
+++ b/src/styles/admin/forms.css
@@ -14,28 +14,40 @@
   color: light-dark(#444, #bbb);
 }
 
+/* The kit input's recipe, applied to the modal's raw fields. The edge is an
+   inset box-shadow rather than a border, which is what lets it thicken on
+   focus without the field growing by two pixels and nudging its neighbours —
+   the same reason .kit-input draws it that way. */
 .form-group input,
 .form-group textarea {
+  appearance: none;
+  -webkit-appearance: none;
+  border: none;
+  font-family: inherit;
   width: 100%;
   box-sizing: border-box;
   padding: 0.6rem 0.9rem;
   font-size: 0.9rem;
-  border: 2px solid light-dark(#ddd, #444);
   border-radius: 10px;
-  background: light-dark(rgba(255, 255, 255, 0.8), rgba(30, 30, 35, 0.8));
+  background-color: light-dark(rgba(255, 255, 255, 0.8), rgba(30, 30, 35, 0.8));
   color: light-dark(var(--color-text-primary), var(--color-text-primary-dark));
-  transition: all 0.25s cubic-bezier(0.16, 1, 0.3, 1);
+  box-shadow: inset 0 0 0 2px light-dark(#ddd, #444);
+  transition: all 0.2s cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 .form-group .select {
   width: 100%;
 }
 
+.form-group input:hover:not(:disabled):not(:focus),
+.form-group textarea:hover:not(:disabled):not(:focus) {
+  box-shadow: inset 0 0 0 2px light-dark(#bbb, #555);
+}
+
 .form-group input:focus,
 .form-group textarea:focus {
   outline: none;
-  border-color: var(--accent-start);
-  box-shadow: 0 0 0 3px rgba(237, 98, 146, 0.15);
+  box-shadow: inset 0 0 0 2px var(--accent-start);
 }
 
 .form-group input::placeholder,
@@ -59,27 +71,36 @@
   gap: 0.5rem;
 }
 
+/* The wishlist's ghost row, in checkbox form: nothing at rest, a wash under the
+   cursor, and the accent capsule with its glow on the ones that are on. A row
+   of bordered boxes was as loud as the categories themselves — the same reason
+   the public filter chips stopped being glass capsules each. */
 .checkbox-label {
   display: inline-flex;
   align-items: center;
   gap: 0.4rem;
-  padding: 0.45rem 0.75rem;
-  background: light-dark(rgba(0, 0, 0, 0.04), rgba(255, 255, 255, 0.06));
-  border: 2px solid light-dark(#ddd, #444);
-  border-radius: 8px;
+  padding: 0.45rem 0.85rem;
+  background: transparent;
+  border: none;
+  border-radius: 999px;
+  color: light-dark(#666, #9a9aa0);
   cursor: pointer;
-  transition: all 0.2s ease;
+  transition:
+    background-color 0.25s ease,
+    color 0.25s ease;
   user-select: none;
 }
 
-.checkbox-label:hover {
-  border-color: light-dark(#bbb, #555);
+.checkbox-label:hover:not(:has(input:checked)),
+.checkbox-label:focus-within:not(:has(input:checked)) {
+  background-color: light-dark(rgba(0, 0, 0, 0.055), rgba(255, 255, 255, 0.07));
+  color: light-dark(#111, #fff);
 }
 
 .checkbox-label:has(input:checked) {
   background: linear-gradient(135deg, var(--accent-start), var(--accent-end));
-  border-color: transparent;
   color: white;
+  box-shadow: 0 4px 16px rgba(237, 87, 96, 0.45);
 }
 
 .checkbox-label input {
@@ -196,26 +217,72 @@
   word-break: break-all;
 }
 
+/* A round glass button whose danger arrives behind it on hover — the same
+   recipe the card's own delete wears, so the two read as the same action. */
 .btn-remove-image {
+  position: relative;
+  isolation: isolate;
   display: flex;
   align-items: center;
   justify-content: center;
   width: 28px;
   height: 28px;
   padding: 0;
-  border: none;
-  border-radius: 6px;
-  background: light-dark(rgba(220, 38, 38, 0.1), rgba(239, 68, 68, 0.2));
+  border: var(--glass-border);
+  border-radius: 50%;
+  background-color: light-dark(rgba(0, 0, 0, 0.035), rgba(255, 255, 255, 0.05));
   color: light-dark(var(--color-error-dark), var(--color-error-light));
   font-size: 1.25rem;
   line-height: 1;
   cursor: pointer;
   flex-shrink: 0;
-  transition: all 0.2s;
+  transition: color 0.25s ease;
 }
 
-.btn-remove-image:hover {
-  background: light-dark(rgba(220, 38, 38, 0.2), rgba(239, 68, 68, 0.3));
+.btn-remove-image::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(
+    135deg,
+    var(--color-error),
+    var(--color-error-dark)
+  );
+  opacity: 0;
+  transform: scale(0.9);
+  transition:
+    transform 0.42s cubic-bezier(0.16, 1, 0.3, 1),
+    opacity 0.3s ease;
+  pointer-events: none;
+  z-index: -1;
+}
+
+.btn-remove-image::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  z-index: 5;
+  box-shadow: var(--glass-rim);
+  transition: box-shadow 0.3s ease;
+}
+
+.btn-remove-image:hover::before,
+.btn-remove-image:focus-visible::before {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.btn-remove-image:hover::after,
+.btn-remove-image:focus-visible::after {
+  box-shadow: none;
+}
+
+.btn-remove-image:hover,
+.btn-remove-image:focus-visible {
+  color: #fff;
 }
 
 /* Focus styles */

--- a/src/styles/admin/items.css
+++ b/src/styles/admin/items.css
@@ -42,9 +42,10 @@
 .item-card {
   display: flex;
   flex-direction: column;
-  background: light-dark(var(--glass-bg-light), var(--glass-bg-dark));
-  border: 1px solid
-    light-dark(var(--glass-border-light), var(--glass-border-dark));
+  /* The wishlist card's material, from the shared tokens: a card is content
+     you read, so it takes the heavier tint and no frost of its own. */
+  background: var(--card-bg);
+  border: var(--glass-border);
   border-radius: 14px;
   transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1);
   box-shadow:
@@ -53,9 +54,13 @@
       inset;
 }
 
+/* Frost only where there's a cursor. The admin draws a long grid of these, and
+   a phone compositing sixty blurred surfaces pays for a finish nobody is
+   hovering anyway — a trade the rest of the site doesn't make, kept here
+   because the page is a list rather than a few floating capsules. */
 @media (hover: hover) and (pointer: fine) {
   .item-card {
-    backdrop-filter: blur(16px);
+    backdrop-filter: var(--glass-filter);
   }
 
   .item-card:hover {
@@ -64,6 +69,14 @@
       0 12px 35px -1px light-dark(rgba(0, 0, 0, 0.12), rgba(0, 0, 0, 0.4)),
       0 0 0 1px light-dark(rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0.08))
         inset;
+  }
+}
+
+/* Reduced transparency: only the frost needs dropping — the tint is --card-bg,
+   which global.css already turns opaque for this case. */
+@media (prefers-reduced-transparency: reduce) {
+  .item-card {
+    backdrop-filter: none;
   }
 }
 

--- a/src/styles/admin/items.css
+++ b/src/styles/admin/items.css
@@ -38,20 +38,42 @@
   font-size: 1rem;
 }
 
-/* Item Card */
+/* Item Card — the wishlist card, at admin density.
+
+   Same material and the same recipe as the public one: the shared tint, the
+   shared edge, the refractive rim on ::before, and a hover that lifts the card
+   and brightens that rim rather than swapping a background. The radius is 20px
+   for the same reason it is there — a card this size wants a generous corner,
+   and 14px was the dashboard's corner, not the site's.
+
+   The hand-written inset highlight that used to sit in the box-shadow is gone:
+   that was the rim, approximated, before the tokens existed. */
 .item-card {
+  position: relative;
   display: flex;
   flex-direction: column;
-  /* The wishlist card's material, from the shared tokens: a card is content
-     you read, so it takes the heavier tint and no frost of its own. */
+  min-width: 0;
   background: var(--card-bg);
   border: var(--glass-border);
-  border-radius: 14px;
-  transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1);
-  box-shadow:
-    0 4px 20px -1px light-dark(rgba(0, 0, 0, 0.06), rgba(0, 0, 0, 0.25)),
-    0 0 0 1px light-dark(rgba(255, 255, 255, 0.8), rgba(255, 255, 255, 0.05))
-      inset;
+  border-radius: 20px;
+  box-shadow: var(--glass-shadow);
+  transition:
+    transform 0.4s cubic-bezier(0.16, 1, 0.3, 1),
+    box-shadow 0.4s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+/* The lens edge. On ::before, above the image and the badges, because it is
+   the card's own edge — and because ::after is spoken for by the drag markers
+   below. */
+.item-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  z-index: 3;
+  box-shadow: var(--glass-rim);
+  transition: box-shadow 0.4s cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 /* Frost only where there's a cursor. The admin draws a long grid of these, and
@@ -63,12 +85,17 @@
     backdrop-filter: var(--glass-filter);
   }
 
+  /* The lift is shallower than the public card's 8px: these sit in a six-column
+     grid where a big rise reads as the row breaking apart. */
   .item-card:hover {
-    transform: translateY(-3px);
+    transform: translateY(-4px);
     box-shadow:
-      0 12px 35px -1px light-dark(rgba(0, 0, 0, 0.12), rgba(0, 0, 0, 0.4)),
-      0 0 0 1px light-dark(rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0.08))
-        inset;
+      0 20px 40px -10px light-dark(rgba(0, 0, 0, 0.15), rgba(0, 0, 0, 0.5)),
+      0 2px 6px light-dark(rgba(20, 20, 40, 0.06), rgba(0, 0, 0, 0.28));
+  }
+
+  .item-card:hover::before {
+    box-shadow: var(--glass-rim-lit);
   }
 }
 
@@ -80,6 +107,9 @@
   }
 }
 
+/* Reserved and received are already said out loud by the badge on the photo.
+   Here they only need to be visible while scanning the grid, so the card tints
+   its own edge rather than changing colour: the glass stays glass. */
 .item-card.reserved {
   border-color: light-dark(rgba(245, 158, 11, 0.5), rgba(217, 119, 6, 0.5));
 }
@@ -102,18 +132,23 @@
   transform: scale(0.98);
 }
 
-/* Keyboard moving state */
+/* Keyboard moving state — the accent ring and glow the wishlist's random pick
+   wears, which is the site's way of saying "this one, right now". */
 .item-card.keyboard-moving {
-  outline: 3px solid var(--color-indigo);
+  outline: 3px solid var(--accent-start);
   outline-offset: 2px;
   box-shadow:
-    0 0 0 6px light-dark(rgba(99, 102, 241, 0.2), rgba(99, 102, 241, 0.3)),
-    0 4px 20px -1px light-dark(rgba(0, 0, 0, 0.06), rgba(0, 0, 0, 0.25));
+    0 0 0 6px rgba(237, 87, 96, 0.22),
+    var(--glass-shadow);
+}
+
+.item-card.keyboard-moving::before {
+  box-shadow: var(--glass-rim-lit);
 }
 
 /* Focus styles for keyboard navigation */
 .item-card.draggable:focus {
-  outline: 2px solid var(--color-indigo);
+  outline: 2px solid var(--accent-start);
   outline-offset: 2px;
 }
 
@@ -121,16 +156,17 @@
   outline: none;
 }
 
+/* Drop markers — the accent bar on the side the card would land. */
 .item-card.drag-over-before {
   box-shadow:
-    -4px 0 0 0 var(--color-indigo),
-    0 4px 20px -1px light-dark(rgba(0, 0, 0, 0.06), rgba(0, 0, 0, 0.25));
+    -4px 0 0 0 var(--accent-start),
+    var(--glass-shadow);
 }
 
 .item-card.drag-over-after {
   box-shadow:
-    4px 0 0 0 var(--color-indigo),
-    0 4px 20px -1px light-dark(rgba(0, 0, 0, 0.06), rgba(0, 0, 0, 0.25));
+    4px 0 0 0 var(--accent-start),
+    var(--glass-shadow);
 }
 
 .items-list.drag-enabled {
@@ -141,7 +177,9 @@
 .item-image {
   position: relative;
   overflow: hidden;
-  border-radius: 14px 14px 0 0;
+  /* One less than the card's 20px: an inner corner has to sit inside the
+     border to stay concentric with it, or the photo's arc crosses the edge. */
+  border-radius: 19px 19px 0 0;
 }
 
 .item-image img {
@@ -162,34 +200,65 @@
   left: 0.6rem;
 }
 
+/* The badge sits on a product photograph, which is exactly the case the
+   --glass-*-on-media tokens exist for — and exactly what the kit's glass badge
+   already says: a solid gradient chip on a photo is a second subject competing
+   with the first. So the capsule is neutral in both schemes and the state
+   travels on a dot, the same way it does on the public wishlist card.
+
+   The dot is drawn here rather than added to the markup: these badges are
+   rendered by React in two components, and a pseudo-element keeps the change
+   in one file. */
 .status-badge {
+  position: relative;
   display: inline-flex;
-  padding: 0.3rem 0.6rem;
-  border-radius: 6px;
+  align-items: center;
+  gap: 6px;
+  padding: 0.3rem 0.65rem;
+  border-radius: 999px;
   font-size: 0.65rem;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.04em;
+  color: #fff;
+  background-color: var(--glass-bg-on-media);
+  backdrop-filter: var(--glass-filter);
+  border: var(--glass-border-on-media);
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.28);
+}
+
+.status-badge::before {
+  content: "";
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--status-dot, currentColor);
+  flex: none;
+}
+
+/* The lens edge, matching every other capsule on a photo. */
+.status-badge::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  box-shadow: var(--glass-rim-on-media);
 }
 
 .status-received {
-  background: linear-gradient(
-    135deg,
-    var(--color-success),
-    var(--color-success-dark)
-  );
-  color: white;
-  box-shadow: 0 2px 8px rgba(16, 185, 129, 0.4);
+  --status-dot: #34d399;
 }
 
 .status-reserved {
-  background: linear-gradient(
-    135deg,
-    var(--color-warning),
-    var(--color-warning-dark)
-  );
-  color: white;
-  box-shadow: 0 2px 8px rgba(245, 158, 11, 0.4);
+  --status-dot: #fbbf24;
+}
+
+@media (prefers-reduced-transparency: reduce) {
+  .status-badge {
+    background-color: rgb(24, 24, 28);
+    backdrop-filter: none;
+  }
 }
 
 /* Item Content */
@@ -262,9 +331,9 @@
   font-weight: 700;
   color: light-dark(var(--color-text-primary), var(--color-text-primary-dark));
   white-space: nowrap;
-  padding: 0.2rem 0.5rem;
+  padding: 0.2rem 0.55rem;
   background: light-dark(rgba(0, 0, 0, 0.05), rgba(255, 255, 255, 0.1));
-  border-radius: 6px;
+  border-radius: 999px;
 }
 
 .item-price-rub {
@@ -288,7 +357,7 @@
   gap: 0.25rem;
   padding: 0.5rem;
   background: light-dark(rgba(0, 0, 0, 0.02), rgba(255, 255, 255, 0.03));
-  border-radius: 6px;
+  border-radius: 10px;
   margin-top: 0.25rem;
 }
 
@@ -348,43 +417,51 @@
   gap: 0.35rem;
 }
 
+/* Tags — capsules, and quiet ones. A card can carry four of these at once, so
+   only the one that ranks (priority) gets any colour, and it gets it on a dot.
+   Category used to be an indigo chip; a category is a label, not a state. */
 .tag {
   display: inline-flex;
   align-items: center;
-  padding: 0.2rem 0.45rem;
-  border-radius: 5px;
+  gap: 5px;
+  padding: 0.2rem 0.5rem;
+  border-radius: 999px;
   font-size: 0.65rem;
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.02em;
-}
-
-.tag-category {
-  background: light-dark(rgba(99, 102, 241, 0.12), rgba(99, 102, 241, 0.25));
-  color: light-dark(var(--color-indigo-dark), var(--color-indigo-light));
+  background: light-dark(rgba(0, 0, 0, 0.055), rgba(255, 255, 255, 0.07));
+  color: light-dark(#555, #b4b4b8);
 }
 
 .tag-priority {
   text-transform: capitalize;
 }
 
+/* Priority carries a dot; the capsule underneath stays the neutral one above. */
+.tag-priority::before {
+  content: "";
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--tag-dot, transparent);
+  flex: none;
+}
+
 .tag-priority-high {
-  background: linear-gradient(135deg, var(--accent-start), var(--accent-end));
-  color: white;
+  --tag-dot: var(--accent-start);
+  color: light-dark(#333, #fff);
 }
 
 .tag-priority-medium {
-  background: light-dark(rgba(245, 158, 11, 0.15), rgba(245, 158, 11, 0.3));
-  color: light-dark(var(--color-warning-dark), var(--color-warning-light));
+  --tag-dot: #fbbf24;
 }
 
 .tag-priority-low {
-  background: light-dark(rgba(0, 0, 0, 0.06), rgba(255, 255, 255, 0.1));
-  color: light-dark(#666, #999);
+  --tag-dot: light-dark(#bbb, #666);
 }
 
 .tag-weight {
-  background: light-dark(rgba(0, 0, 0, 0.06), rgba(255, 255, 255, 0.08));
   color: light-dark(#888, #777);
   font-family: ui-monospace, monospace;
   font-size: 0.6rem;
@@ -400,76 +477,139 @@
     light-dark(rgba(0, 0, 0, 0.06), rgba(255, 255, 255, 0.06));
 }
 
+/* Four buttons in a row, one per card, sixty-four cards on screen: two hundred
+   and fifty saturated blocks, which is what made the grid read as a control
+   panel rather than a list of things. They are glass capsules now, and the
+   colour they used to be filled with lives in the icon instead.
+
+   The recipe is the wishlist's reserve button: a neutral capsule with a
+   coloured indicator behind it that glides in on hover, its own rim stepping
+   aside as the fill arrives. Each button names its own indicator colour, so
+   destructive still reads as destructive the moment the cursor is on it. */
 .action-btn {
+  position: relative;
+  /* Own stacking context: the z-index:-1 indicator has to land above the card
+     but below the icon. */
+  isolation: isolate;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   gap: 0.35rem;
   padding: 0.45rem 0.65rem;
-  border: none;
-  border-radius: 8px;
+  border: var(--glass-border);
+  border-radius: 999px;
   font-size: 0.7rem;
   font-weight: 600;
   cursor: pointer;
-  transition: all 0.2s ease;
+  background-color: light-dark(rgba(0, 0, 0, 0.035), rgba(255, 255, 255, 0.05));
+  color: light-dark(#555, #b4b4b8);
+  transition:
+    color 0.25s ease,
+    background-color 0.25s ease;
+}
+
+.action-btn::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: var(--action-fill);
+  opacity: 0;
+  transform: scale(0.9);
+  transition:
+    transform 0.42s cubic-bezier(0.16, 1, 0.3, 1),
+    opacity 0.3s ease;
+  pointer-events: none;
+  z-index: -1;
+}
+
+/* The lens edge, above the indicator and stepping aside once it is lit. */
+.action-btn::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  z-index: 5;
+  box-shadow: var(--glass-rim);
+  transition: box-shadow 0.3s ease;
+}
+
+.action-btn:hover::before,
+.action-btn:focus-visible::before {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.action-btn:hover,
+.action-btn:focus-visible {
+  color: #fff;
+}
+
+.action-btn:hover::after,
+.action-btn:focus-visible::after {
+  box-shadow: none;
+}
+
+.action-btn:focus-visible {
+  outline: 2px solid light-dark(#333, #fff);
+  outline-offset: 2px;
 }
 
 .action-edit {
   flex: 1;
-  background: light-dark(rgba(0, 0, 0, 0.05), rgba(255, 255, 255, 0.1));
-  color: light-dark(#333, #ddd);
-}
-
-.action-edit:hover {
-  background: light-dark(rgba(0, 0, 0, 0.1), rgba(255, 255, 255, 0.15));
+  --action-fill: linear-gradient(
+    135deg,
+    var(--accent-start),
+    var(--accent-end)
+  );
 }
 
 .action-reserved {
   width: 34px;
-  background: light-dark(rgba(245, 158, 11, 0.1), rgba(245, 158, 11, 0.15));
-  color: light-dark(var(--color-warning-dark), var(--color-warning-light));
-}
-
-.action-reserved:hover {
-  background: light-dark(rgba(245, 158, 11, 0.2), rgba(245, 158, 11, 0.25));
-}
-
-.action-reserved.active {
-  background: linear-gradient(
+  --action-fill: linear-gradient(
     135deg,
     var(--color-warning),
     var(--color-warning-dark)
   );
-  color: white;
+  color: light-dark(var(--color-warning-dark), var(--color-warning-light));
 }
 
 .action-received {
   width: 34px;
-  background: light-dark(rgba(16, 185, 129, 0.1), rgba(16, 185, 129, 0.15));
-  color: light-dark(var(--color-success-dark), var(--color-success-light));
-}
-
-.action-received:hover {
-  background: light-dark(rgba(16, 185, 129, 0.2), rgba(16, 185, 129, 0.25));
-}
-
-.action-received.active {
-  background: linear-gradient(
+  --action-fill: linear-gradient(
     135deg,
     var(--color-success),
     var(--color-success-dark)
   );
-  color: white;
+  color: light-dark(var(--color-success-dark), var(--color-success-light));
 }
 
 .action-delete {
   width: 34px;
-  background: light-dark(rgba(239, 68, 68, 0.08), rgba(239, 68, 68, 0.15));
+  --action-fill: linear-gradient(
+    135deg,
+    var(--color-error),
+    var(--color-error-dark)
+  );
   color: light-dark(var(--color-error-dark), var(--color-error-light));
 }
 
-.action-delete:hover {
-  background: light-dark(rgba(239, 68, 68, 0.15), rgba(239, 68, 68, 0.25));
+/* Already reserved / already received. A toggle that is on has to look on, but
+   flooding it with its gradient puts a solid saturated disc between two panes
+   of glass — the loudest thing on a card whose photo is supposed to be the
+   subject, and said twice over, since the badge on that photo and the card's
+   own tinted edge have both already said it.
+
+   So "on" is a pressed pane: the glass darkens the way the wishlist's own
+   toggle does when you cancel a reservation, the icon keeps its colour, and
+   the rim stays lit rather than stepping aside. */
+.action-btn.active {
+  background-color: light-dark(rgba(0, 0, 0, 0.1), rgba(255, 255, 255, 0.14));
+}
+
+.action-btn.active::after {
+  box-shadow: var(--glass-rim-lit);
 }
 
 /* Reservations Modal */
@@ -485,7 +625,7 @@
 
 .reservation-group {
   background: light-dark(rgba(0, 0, 0, 0.02), rgba(255, 255, 255, 0.03));
-  border-radius: 12px;
+  border-radius: 16px;
   padding: 1rem;
 }
 
@@ -509,8 +649,8 @@
   font-size: 0.8rem;
   color: light-dark(#666, #999);
   background: light-dark(rgba(0, 0, 0, 0.05), rgba(255, 255, 255, 0.1));
-  padding: 0.25rem 0.6rem;
-  border-radius: 20px;
+  padding: 0.25rem 0.65rem;
+  border-radius: 999px;
 }
 
 .reservation-items {
@@ -525,14 +665,14 @@
   gap: 0.75rem;
   padding: 0.5rem;
   background: light-dark(rgba(255, 255, 255, 0.5), rgba(255, 255, 255, 0.05));
-  border-radius: 8px;
+  border-radius: 12px;
 }
 
 .reservation-item img {
   width: 48px;
   height: 48px;
   object-fit: cover;
-  border-radius: 6px;
+  border-radius: 10px;
   flex-shrink: 0;
 }
 

--- a/src/styles/admin/layout.css
+++ b/src/styles/admin/layout.css
@@ -30,17 +30,17 @@
     opacity: light-dark(0.12, 0.15);
   }
 
+  /* Both blobs are the site accent now. The second one used to be indigo and
+     violet, which is what made the panel's background a different room from
+     the rest of the site. Weaker and further away than the first, so the pair
+     still reads as two lights rather than one. */
   .admin-container::after {
     width: 400px;
     height: 400px;
-    background: linear-gradient(
-      135deg,
-      var(--color-indigo),
-      var(--color-violet)
-    );
+    background: linear-gradient(135deg, var(--accent-end), var(--accent-start));
     bottom: 100px;
     left: -100px;
-    opacity: light-dark(0.08, 0.12);
+    opacity: light-dark(0.07, 0.1);
   }
 }
 
@@ -48,8 +48,8 @@
 .admin-container .page-header {
   margin-bottom: 2rem;
   padding-bottom: 1.5rem;
-  border-bottom: 1px solid
-    light-dark(rgba(0, 0, 0, 0.08), rgba(255, 255, 255, 0.08));
+  border-bottom: var(--glass-border);
+  border-width: 0 0 1px;
 }
 
 /* Admin Sections */

--- a/src/styles/admin/modal.css
+++ b/src/styles/admin/modal.css
@@ -23,7 +23,9 @@
 
 .modal {
   /* Heavier than a card on purpose — a modal is read against whatever the page
-     left behind it — but the edge is the shared one. */
+     left behind it — but the edge is the shared one, and it wears the rim like
+     every other pane of glass here. */
+  position: relative;
   background: light-dark(rgba(255, 255, 255, 0.95), rgba(30, 30, 35, 0.95));
   border: var(--glass-border);
   border-radius: 20px;
@@ -33,10 +35,22 @@
   overflow-y: auto;
   transform: translateY(20px) scale(0.98);
   transition: transform 0.3s cubic-bezier(0.16, 1, 0.3, 1);
-  box-shadow:
-    0 25px 60px -10px light-dark(rgba(0, 0, 0, 0.25), rgba(0, 0, 0, 0.6)),
-    0 0 0 1px light-dark(rgba(255, 255, 255, 0.8), rgba(255, 255, 255, 0.05))
-      inset;
+  /* Deeper than --glass-shadow: a modal is further off the page than a pill. */
+  box-shadow: 0 25px 60px -10px
+    light-dark(rgba(0, 0, 0, 0.25), rgba(0, 0, 0, 0.6));
+}
+
+/* The hand-written inset highlight this used to carry was the rim, guessed at.
+   Now it is the rim. `position: sticky` on the header means the modal scrolls
+   its own body, so the edge rides above on its own layer. */
+.modal::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  z-index: 2;
+  box-shadow: var(--glass-rim);
 }
 
 @media (hover: hover) and (pointer: fine) {
@@ -76,22 +90,58 @@
   background-clip: text;
 }
 
+/* A round glass button, like the home pill and the random-pick die: it answers
+   with the accent arriving behind it rather than by growing. Nothing in the
+   chrome scales under a cursor. */
 .modal-close {
-  background: none;
+  position: relative;
+  isolation: isolate;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  flex: none;
   border: none;
-  font-size: 1.75rem;
+  border-radius: 50%;
+  background: transparent;
+  font-size: 1.5rem;
+  line-height: 1;
   cursor: pointer;
   color: light-dark(#999, #666);
-  padding: 0;
-  line-height: 1;
-  transition:
-    color 0.2s,
-    transform 0.2s;
+  transition: color 0.25s ease;
 }
 
-.modal-close:hover {
-  color: light-dark(#333, #ccc);
-  transform: scale(1.1);
+.modal-close::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(135deg, var(--accent-start), var(--accent-end));
+  box-shadow: 0 4px 16px rgba(237, 87, 96, 0.45);
+  opacity: 0;
+  transform: scale(0.9);
+  transition:
+    transform 0.42s cubic-bezier(0.16, 1, 0.3, 1),
+    opacity 0.3s ease;
+  pointer-events: none;
+  z-index: -1;
+}
+
+.modal-close:hover,
+.modal-close:focus-visible {
+  color: #fff;
+}
+
+.modal-close:hover::before,
+.modal-close:focus-visible::before {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.modal-close:focus-visible {
+  outline: 2px solid light-dark(#333, #fff);
+  outline-offset: 2px;
 }
 
 .modal-body {

--- a/src/styles/admin/modal.css
+++ b/src/styles/admin/modal.css
@@ -22,9 +22,10 @@
 }
 
 .modal {
+  /* Heavier than a card on purpose — a modal is read against whatever the page
+     left behind it — but the edge is the shared one. */
   background: light-dark(rgba(255, 255, 255, 0.95), rgba(30, 30, 35, 0.95));
-  border: 1px solid
-    light-dark(var(--glass-border-light), var(--glass-border-dark));
+  border: var(--glass-border);
   border-radius: 20px;
   width: 100%;
   max-width: 800px;
@@ -40,7 +41,16 @@
 
 @media (hover: hover) and (pointer: fine) {
   .modal {
-    backdrop-filter: blur(20px);
+    backdrop-filter: var(--glass-filter);
+  }
+}
+
+/* Reduced transparency: the modal's own tint is hand-written rather than a
+   token, so unlike the item card it has to answer for itself. */
+@media (prefers-reduced-transparency: reduce) {
+  .modal {
+    background: light-dark(#ffffff, #1e1e23);
+    backdrop-filter: none;
   }
 }
 

--- a/src/styles/admin/toast.css
+++ b/src/styles/admin/toast.css
@@ -63,7 +63,17 @@
 
 @media (hover: hover) and (pointer: fine) {
   .toast {
-    backdrop-filter: blur(12px);
+    backdrop-filter: var(--glass-filter);
+  }
+}
+
+/* Reduced transparency: the three frosted admin surfaces go solid. The success
+   and error toasts need nothing — their gradients are already opaque, and it's
+   only the neutral one that was letting the page through. */
+@media (prefers-reduced-transparency: reduce) {
+  .toast-info {
+    background: light-dark(#ffffff, #2a2a2d);
+    backdrop-filter: none;
   }
 }
 

--- a/src/styles/admin/toast.css
+++ b/src/styles/admin/toast.css
@@ -11,19 +11,47 @@
   pointer-events: none;
 }
 
+/* A toast is a capsule that floats over the page, which makes it the chrome's
+   glass and not a coloured slab. Success and error used to be flooded with a
+   saturated gradient and white text — the loudest thing on screen for a
+   message that says "saved". The state travels on a dot now, the way the kit's
+   glass badge carries it, and the capsule stays the same material every other
+   floating thing here is made of. */
 .toast {
+  position: relative;
   display: flex;
   align-items: center;
   gap: 0.75rem;
   padding: 0.85rem 1rem;
-  border-radius: 12px;
-  box-shadow:
-    0 8px 30px -5px light-dark(rgba(0, 0, 0, 0.15), rgba(0, 0, 0, 0.4)),
-    0 0 0 1px light-dark(rgba(255, 255, 255, 0.8), rgba(255, 255, 255, 0.05))
-      inset;
+  border-radius: 999px;
+  color: light-dark(#1a1a1a, #fff);
+  background-color: var(--glass-bg);
+  background-image: var(--glass-sheen);
+  border: var(--glass-border);
+  box-shadow: var(--glass-shadow);
   pointer-events: auto;
   animation: toast-slide-in 0.3s cubic-bezier(0.16, 1, 0.3, 1);
   max-width: 400px;
+}
+
+/* The lens edge. */
+.toast::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  box-shadow: var(--glass-rim);
+}
+
+/* The state, as a dot at the head of the message. */
+.toast::before {
+  content: "";
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex: none;
+  background: var(--toast-dot, light-dark(#888, #aaa));
 }
 
 @keyframes toast-slide-in {
@@ -38,27 +66,15 @@
 }
 
 .toast-success {
-  background: linear-gradient(
-    135deg,
-    var(--color-success),
-    var(--color-success-dark)
-  );
-  color: white;
+  --toast-dot: #34d399;
 }
 
 .toast-error {
-  background: linear-gradient(
-    135deg,
-    var(--color-error),
-    var(--color-error-dark)
-  );
-  color: white;
+  --toast-dot: #f87171;
 }
 
 .toast-info {
-  background: light-dark(rgba(255, 255, 255, 0.95), rgba(40, 40, 45, 0.95));
-  color: light-dark(var(--color-text-primary), var(--color-text-primary-dark));
-  border: 1px solid light-dark(rgba(0, 0, 0, 0.1), rgba(255, 255, 255, 0.1));
+  --toast-dot: var(--accent-start);
 }
 
 @media (hover: hover) and (pointer: fine) {
@@ -67,12 +83,12 @@
   }
 }
 
-/* Reduced transparency: the three frosted admin surfaces go solid. The success
-   and error toasts need nothing — their gradients are already opaque, and it's
-   only the neutral one that was letting the page through. */
+/* All three kinds are the same glass now, so the fallback is one rule rather
+   than one per kind — the dot carries the meaning and needs no help. */
 @media (prefers-reduced-transparency: reduce) {
-  .toast-info {
-    background: light-dark(#ffffff, #2a2a2d);
+  .toast {
+    background-color: light-dark(#f0f0f0, #2a2a2e);
+    background-image: none;
     backdrop-filter: none;
   }
 }
@@ -84,6 +100,8 @@
   line-height: 1.4;
 }
 
+/* One dismiss button for every kind now — it used to need a second rule to
+   undo the white-on-gradient treatment for the neutral toast. */
 .toast-dismiss {
   display: flex;
   align-items: center;
@@ -92,26 +110,21 @@
   height: 24px;
   padding: 0;
   border: none;
-  border-radius: 6px;
-  background: rgba(255, 255, 255, 0.2);
-  color: inherit;
+  border-radius: 50%;
+  background: light-dark(rgba(0, 0, 0, 0.06), rgba(255, 255, 255, 0.1));
+  color: light-dark(#555, #b4b4b8);
   font-size: 1.1rem;
   line-height: 1;
   cursor: pointer;
-  transition: background 0.2s;
+  transition:
+    background 0.2s,
+    color 0.2s;
   flex-shrink: 0;
 }
 
 .toast-dismiss:hover {
-  background: rgba(255, 255, 255, 0.3);
-}
-
-.toast-info .toast-dismiss {
-  background: light-dark(rgba(0, 0, 0, 0.05), rgba(255, 255, 255, 0.1));
-}
-
-.toast-info .toast-dismiss:hover {
-  background: light-dark(rgba(0, 0, 0, 0.1), rgba(255, 255, 255, 0.15));
+  background: light-dark(rgba(0, 0, 0, 0.12), rgba(255, 255, 255, 0.18));
+  color: light-dark(#111, #fff);
 }
 
 @media (max-width: 500px) {

--- a/src/styles/admin/toolbar.css
+++ b/src/styles/admin/toolbar.css
@@ -24,16 +24,100 @@
   gap: 0.75rem;
 }
 
+/* =============================================================================
+   The control row, in the site's language.
+
+   The kit's own metrics are right and its behaviour is right; what was wrong
+   here was that every control kept the kit's default rectangle, so the row read
+   as a dashboard's filter bar even after the cards beneath it had become glass.
+   These overrides are scoped to the panel and change two things only: the
+   corner, which becomes the capsule every control on the public side wears, and
+   the material, which becomes the chrome's glass instead of a flat fill.
+
+   Scoped rather than pushed into the kit on purpose — /kit documents the kit's
+   own rectangle, and the public pages use it. The wishlist does the same thing
+   with .filter-all-btn and .filter-random. */
+
 /* Search input - constrained width on desktop */
 .admin-filters .kit-input {
   width: 240px;
   flex-shrink: 0;
+  border-radius: 999px;
+  padding-left: 1.1rem;
+  padding-right: 1.1rem;
 }
 
-/* Category select - constrained width */
+/* Category select - constrained width. Only the left inset moves: the right
+   side belongs to the chevron, which the kit positions from that edge. */
 .admin-filters .kit-select {
   width: 180px;
   flex-shrink: 0;
+  border-radius: 999px;
+  padding-left: 1.1rem;
+}
+
+/* Two ghost rows in a row. Losing the kit's grey tray also lost the thing that
+   said where one control ended and the next began — status and sort ran
+   together into a single row of five chips. Nothing draws a box around them
+   again; they are just held further apart than the chips inside them, which is
+   the whole of what the tray was doing. */
+.admin-filters
+  .kit-toggle-group--separated
+  + .kit-toggle-group--separated {
+  margin-left: 1.25rem;
+}
+
+/* "Clear filters" sits with the heading rather than in the row, but it is the
+   same kind of control and takes the same corner. */
+.filter-header .kit-btn {
+  border-radius: 999px;
+}
+
+/* The two buttons above the filters. Primary keeps its accent gradient — it is
+   the one loud thing on the screen and should be. Secondary becomes glass, the
+   same capsule as the breadcrumb pill it sits under. */
+.toolbar-actions .kit-btn {
+  border-radius: 999px;
+}
+
+.toolbar-actions .kit-btn--secondary {
+  position: relative;
+  background-color: var(--glass-bg);
+  background-image: var(--glass-sheen);
+  backdrop-filter: var(--glass-filter);
+  border: var(--glass-border);
+  box-shadow: var(--glass-shadow);
+  color: light-dark(#555, #b4b4b8);
+}
+
+.toolbar-actions .kit-btn--secondary::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  box-shadow: var(--glass-rim);
+  transition: box-shadow 0.3s ease;
+}
+
+/* Hover lights the rim, the way glass answers a cursor everywhere else here. */
+.toolbar-actions .kit-btn--secondary:hover:not(:disabled) {
+  background-color: var(--glass-bg);
+  color: light-dark(#111, #fff);
+}
+
+.toolbar-actions .kit-btn--secondary:hover:not(:disabled)::after,
+.toolbar-actions .kit-btn--secondary:focus-visible::after {
+  box-shadow: var(--glass-rim-lit);
+}
+
+@media (prefers-reduced-transparency: reduce) {
+  .toolbar-actions .kit-btn--secondary,
+  .toolbar-actions .kit-btn--secondary:hover:not(:disabled) {
+    background-color: light-dark(#f0f0f0, #2a2a2e);
+    background-image: none;
+    backdrop-filter: none;
+  }
 }
 
 /* The sort toggle used to override the kit with an indigo tray and an

--- a/src/styles/admin/toolbar.css
+++ b/src/styles/admin/toolbar.css
@@ -36,17 +36,11 @@
   flex-shrink: 0;
 }
 
-/* Sort toggle variant (indigo/violet gradient for active) */
-.admin-sort-toggle {
-  background: light-dark(rgba(99, 102, 241, 0.08), rgba(99, 102, 241, 0.15));
-}
-
-.admin-sort-toggle .kit-toggle-item.is-active,
-.admin-sort-toggle .kit-toggle-item[aria-pressed="true"] {
-  color: white;
-  background: linear-gradient(135deg, var(--color-indigo), var(--color-violet));
-  box-shadow: 0 1px 3px light-dark(rgba(0, 0, 0, 0.15), rgba(0, 0, 0, 0.35));
-}
+/* The sort toggle used to override the kit with an indigo tray and an
+   indigo/violet active capsule. Both are gone: the kit's own toggle group
+   already puts the accent capsule on the active item, with the glow, and it is
+   the same control the public wishlist filters with. An override that only
+   changed the colour was the whole of the second accent's claim here. */
 
 /* Filter Header */
 .filter-header {
@@ -61,21 +55,45 @@
   margin: 0;
 }
 
-/* Weight Actions (save/discard reorder) */
+/* Weight Actions (save/discard reorder) — a glass capsule that appears when
+   there is unsaved order to deal with. It floats over the list, so unlike the
+   cards it earns its frost. */
 .weight-actions {
+  position: relative;
   display: flex;
   align-items: center;
   gap: 0.5rem;
   margin-left: auto;
-  padding: 0.5rem 0.75rem;
-  background: light-dark(rgba(99, 102, 241, 0.08), rgba(99, 102, 241, 0.15));
-  border-radius: 10px;
+  padding: 0.4rem 0.4rem 0.4rem 0.9rem;
+  border-radius: 999px;
+  background-color: var(--glass-bg);
+  background-image: var(--glass-sheen);
+  backdrop-filter: var(--glass-filter);
+  border: var(--glass-border);
+  box-shadow: var(--glass-shadow);
+}
+
+.weight-actions::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  box-shadow: var(--glass-rim);
 }
 
 .weight-hint {
   font-size: 0.75rem;
-  color: light-dark(var(--color-indigo), var(--color-indigo-light));
-  font-weight: 500;
+  color: light-dark(#555, #b4b4b8);
+  font-weight: 600;
+}
+
+@media (prefers-reduced-transparency: reduce) {
+  .weight-actions {
+    background-color: light-dark(#f0f0f0, #2a2a2e);
+    background-image: none;
+    backdrop-filter: none;
+  }
 }
 
 /* Toolbar Actions */

--- a/src/styles/admin/toolbar.css
+++ b/src/styles/admin/toolbar.css
@@ -67,20 +67,23 @@
   margin-left: 1.25rem;
 }
 
-/* "Clear filters" sits with the heading rather than in the row, but it is the
-   same kind of control and takes the same corner. */
+/* Every button in the panel takes the capsule corner — the toolbar's pair, the
+   Logout button up in the header, Discard inside the weight capsule, and
+   "Clear filters" beside the heading. */
+.toolbar-actions .kit-btn,
+.admin-container .page-header .kit-btn,
+.weight-actions .kit-btn,
 .filter-header .kit-btn {
   border-radius: 999px;
 }
 
-/* The two buttons above the filters. Primary keeps its accent gradient — it is
-   the one loud thing on the screen and should be. Secondary becomes glass, the
-   same capsule as the breadcrumb pill it sits under. */
-.toolbar-actions .kit-btn {
-  border-radius: 999px;
-}
-
-.toolbar-actions .kit-btn--secondary {
+/* Glass, though, only where a button floats directly on the page: the toolbar
+   pair and Logout, which sits in the header row beside the breadcrumb pill and
+   should be made of what the pill is made of. Discard is deliberately left out
+   — it lives inside .weight-actions, which is already a glass capsule, and
+   glass on glass is just a lighter rectangle. */
+.toolbar-actions .kit-btn--secondary,
+.admin-container .page-header .kit-btn--secondary {
   position: relative;
   background-color: var(--glass-bg);
   background-image: var(--glass-sheen);
@@ -90,7 +93,8 @@
   color: light-dark(#555, #b4b4b8);
 }
 
-.toolbar-actions .kit-btn--secondary::after {
+.toolbar-actions .kit-btn--secondary::after,
+.admin-container .page-header .kit-btn--secondary::after {
   content: "";
   position: absolute;
   inset: 0;
@@ -101,19 +105,24 @@
 }
 
 /* Hover lights the rim, the way glass answers a cursor everywhere else here. */
-.toolbar-actions .kit-btn--secondary:hover:not(:disabled) {
+.toolbar-actions .kit-btn--secondary:hover:not(:disabled),
+.admin-container .page-header .kit-btn--secondary:hover:not(:disabled) {
   background-color: var(--glass-bg);
   color: light-dark(#111, #fff);
 }
 
 .toolbar-actions .kit-btn--secondary:hover:not(:disabled)::after,
-.toolbar-actions .kit-btn--secondary:focus-visible::after {
+.toolbar-actions .kit-btn--secondary:focus-visible::after,
+.admin-container .page-header .kit-btn--secondary:hover:not(:disabled)::after,
+.admin-container .page-header .kit-btn--secondary:focus-visible::after {
   box-shadow: var(--glass-rim-lit);
 }
 
 @media (prefers-reduced-transparency: reduce) {
   .toolbar-actions .kit-btn--secondary,
-  .toolbar-actions .kit-btn--secondary:hover:not(:disabled) {
+  .toolbar-actions .kit-btn--secondary:hover:not(:disabled),
+  .admin-container .page-header .kit-btn--secondary,
+  .admin-container .page-header .kit-btn--secondary:hover:not(:disabled) {
     background-color: light-dark(#f0f0f0, #2a2a2e);
     background-image: none;
     backdrop-filter: none;

--- a/src/styles/admin/variables.css
+++ b/src/styles/admin/variables.css
@@ -8,13 +8,19 @@
    and the admin copy outlived it, in the global scope, on pages that load both
    stylesheets. The consumers now take the shared tokens directly. */
 
-:root {
-  /* Semantic colors */
-  --color-indigo: #6366f1;
-  --color-indigo-dark: #4f46e5;
-  --color-indigo-light: #a5b4fc;
-  --color-violet: #8b5cf6;
+/* No indigo/violet either. The panel used to carry a second accent — a gradient
+   on the Admin/Public toggle, the active sort, the drag outline, the weight
+   hint — beside the site's own. Two accents on one screen is two answers to
+   "what is the loud thing here", and the glass language already has one: the
+   accent capsule marks what's active, and everything else is glass. What the
+   indigo actually marked (states that don't exist on the public site) is now
+   marked the way the kit marks state everywhere else — a dot, or a rim.
 
+   The status colours below survive, demoted. They no longer flood a surface;
+   they tint a dot, an icon or a word, which is the whole difference between
+   this panel and a dashboard template. */
+
+:root {
   /* Text colors */
   --color-text-primary: #111;
   --color-text-primary-dark: #fafafa;

--- a/src/styles/admin/variables.css
+++ b/src/styles/admin/variables.css
@@ -1,11 +1,14 @@
 /* Admin Panel - CSS Variables */
 
-:root {
-  --glass-bg-light: rgba(255, 255, 255, 0.7);
-  --glass-bg-dark: rgba(40, 40, 45, 0.7);
-  --glass-border-light: rgba(255, 255, 255, 0.5);
-  --glass-border-dark: rgba(255, 255, 255, 0.1);
+/* No --glass-* here. This file used to declare --glass-bg-light/-dark and
+   --glass-border-light/-dark on :root — the same second dialect global.css
+   warns about, with the same names and, to the hundredth, the same values:
+   the two backgrounds were exactly the halves of --card-bg, and the borders
+   sat one hundredth away from --glass-border. The wishlist card was cleaned up
+   and the admin copy outlived it, in the global scope, on pages that load both
+   stylesheets. The consumers now take the shared tokens directly. */
 
+:root {
   /* Semantic colors */
   --color-indigo: #6366f1;
   --color-indigo-dark: #4f46e5;


### PR DESCRIPTION
Two commits. The first stops the admin *writing the material down* a second way; the second stops it *being* a different material.

## 1. The dialect (`61efd2e`)

`global.css` carries a warning: the wishlist card once declared `--glass-bg-light` and friends locally, *"one hex away from the tokens here and easy to mistake for them, which is how it ended up with a second dialect of the same material."* The card was cleaned up. **The admin copy outlived it** — same four names, on `:root`, on pages that load both stylesheets. The two backgrounds were exactly the halves of `--card-bg`; the borders sat one hundredth from `--glass-border`.

Also: three hand-written blurs (16px, 20px, 12px — none the token's 20px, none with its `saturate()`), and **no `prefers-reduced-transparency` answer anywhere in the panel**. Both fixed.

## 2. The material (`2d55776`)

What was there was a dashboard template: flat fills, five saturated colours, and twenty-five corner radii across nine values, none of them the site's capsule.

Everything follows a rule the kit already stated, above its glass badge — *a solid gradient chip on a photograph is a second subject competing with the first.* **State travels on a dot, or a rim; the surface underneath stays glass.**

| Surface | Before | Now |
|---|---|---|
| Item card | 14px, hand-drawn inset highlight | the public wishlist card entire — 20px, rim, lifting hover |
| Status badge | solid amber/green gradient on the photo | `--glass-*-on-media` capsule + coloured dot |
| Card actions | four saturated blocks × 64 cards | glass capsules; colour on the icon + indicator on hover |
| Active toggle | flooded with its gradient | pressed pane, rim staying lit |
| Tags | indigo chip per category | neutral capsules; only priority has colour, on a dot |
| Toasts | saturated slab, white text | chrome capsule + dot (collapsed two dismiss rules into one) |
| Modal | inset highlight imitating a rim | the rim; close button answers with the accent, not by scaling |
| Modal fields | 2px border | `.kit-input`'s inset edge — focus thickens without moving neighbours |
| Categories | bordered boxes | the wishlist's ghost row |
| Login button | background swap + `scale(1.08)` | glass, accent arriving behind it |

### The second accent is gone

Indigo and violet marked the Admin/Public toggle, the active sort, the drag outline and the weight hint — real states, but two accents on one screen is two answers to which thing is loud. The sort toggle's override did nothing but recolour a control the kit already paints with the accent capsule. What the indigo marked is now marked the way everything else marks state.

*(This resolves the open question from the first commit's description, in the opposite direction from what I'd guessed there — a total glass pass leaves no room for a second accent.)*

## Kept on purpose

Frost stays behind `@media (hover: hover) and (pointer: fine)`, now with a comment saying why: the panel draws sixty-four cards, and a phone compositing sixty-four blurred surfaces pays for a finish nobody is hovering. Worth considering for the public wishlist too.

## Verification

Checked on the running panel (dev login, 64 items) in both colour schemes, hovered, with the item and reservations modals open, toasts of all three kinds, and under reduced transparency:

```
              toast                          card            badge
normal   999px rgba(28,28,32,.55) frost=✓   frost=✓   rgba(18,18,22,.62) frost=✓
reduce   999px rgb(42,42,46)      frost=—   frost=—   rgb(24,24,28)      frost=—
```

`astro check` 0 errors, `bun test` 12/12, production build passes.

🤖 Generated with [Claude Code](https://claude.ai/code)