### PR TITLE
A reserver can leave a message with the present

### DIFF
--- a/db/config.ts
+++ b/db/config.ts
@@ -35,6 +35,10 @@ const Reservation = defineTable({
     itemId: column.number({ references: () => WishlistItem.columns.id }),
     reservedBy: column.text(), // Name or identifier of person who reserved
     reservedAt: column.date(),
+    // An optional message the reserver leaves for the wishlist owner. Readable
+    // by its author and in the admin panel, and nowhere else — see
+    // src/pages/api/wishlist/reservations.ts.
+    message: column.text({ optional: true }),
   },
   indexes: [{ on: ["itemId"], unique: true }],
 });

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -1,6 +1,6 @@
 import { defineAction, ActionError } from "astro:actions";
 import { z } from "astro/zod";
-import { db, Reservation, WishlistItem, eq, sql } from "astro:db";
+import { db, Reservation, WishlistItem, and, eq, sql } from "astro:db";
 import { RESERVATION_MESSAGE_MAX_LENGTH } from "@lib/wishlist";
 
 const reservationsEnabled = import.meta.env.RESERVATIONS_ENABLED !== "false";
@@ -119,6 +119,13 @@ export const server = {
       message: z.string().max(RESERVATION_MESSAGE_MAX_LENGTH),
     }),
     handler: async ({ itemId, visitorId, message }) => {
+      if (!reservationsEnabled) {
+        throw new ActionError({
+          code: "FORBIDDEN",
+          message: "Reservations are currently disabled",
+        });
+      }
+
       const existingReservation = await db
         .select()
         .from(Reservation)
@@ -141,10 +148,19 @@ export const server = {
 
       const trimmed = message.trim();
 
+      // `reservedBy` is repeated in the WHERE rather than trusted from the SELECT
+      // above: between the two statements the reservation can be cancelled and
+      // the item taken by someone else, and this write would then land the first
+      // visitor's note on the second one's reservation.
       await db
         .update(Reservation)
         .set({ message: trimmed || null })
-        .where(eq(Reservation.itemId, itemId));
+        .where(
+          and(
+            eq(Reservation.itemId, itemId),
+            eq(Reservation.reservedBy, visitorId),
+          ),
+        );
 
       return { message: trimmed || null };
     },

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -1,6 +1,7 @@
 import { defineAction, ActionError } from "astro:actions";
 import { z } from "astro/zod";
 import { db, Reservation, WishlistItem, eq, sql } from "astro:db";
+import { RESERVATION_MESSAGE_MAX_LENGTH } from "@lib/wishlist";
 
 const reservationsEnabled = import.meta.env.RESERVATIONS_ENABLED !== "false";
 
@@ -97,6 +98,55 @@ export const server = {
       await db.delete(Reservation).where(eq(Reservation.itemId, itemId));
 
       return { success: true };
+    },
+  }),
+
+  /**
+   * Write (or clear) the message attached to a reservation.
+   *
+   * One action rather than a save/delete pair: an empty textarea saved over an
+   * existing message means "remove it", and splitting that across two endpoints
+   * only gives the client a way to disagree with itself about which one to call.
+   * The stored value is the trimmed message or null — never an empty string, so
+   * "has a message" is a null check everywhere downstream.
+   */
+  setReservationMessage: defineAction({
+    input: z.object({
+      itemId: z.number(),
+      // Empty is not a visitor: it would otherwise match a reservation whose
+      // reservedBy somehow ended up blank.
+      visitorId: z.string().min(1),
+      message: z.string().max(RESERVATION_MESSAGE_MAX_LENGTH),
+    }),
+    handler: async ({ itemId, visitorId, message }) => {
+      const existingReservation = await db
+        .select()
+        .from(Reservation)
+        .where(eq(Reservation.itemId, itemId));
+
+      if (existingReservation.length === 0) {
+        throw new ActionError({
+          code: "NOT_FOUND",
+          message: "Reservation not found",
+        });
+      }
+
+      // Only the visitor who reserved the item may write on it
+      if (existingReservation[0].reservedBy !== visitorId) {
+        throw new ActionError({
+          code: "FORBIDDEN",
+          message: "You can only leave a message on your own reservation",
+        });
+      }
+
+      const trimmed = message.trim();
+
+      await db
+        .update(Reservation)
+        .set({ message: trimmed || null })
+        .where(eq(Reservation.itemId, itemId));
+
+      return { message: trimmed || null };
     },
   }),
 };

--- a/src/client/reservation-message.ts
+++ b/src/client/reservation-message.ts
@@ -29,6 +29,8 @@ let saveBtn: HTMLButtonElement | null = null;
 let anchor: HTMLButtonElement | null = null;
 let stopFollowing: (() => void) | null = null;
 let closeTimer: number | undefined;
+/** A write is in flight. `setBusy` disables the buttons; this covers the rest. */
+let saving = false;
 
 /** itemId → the message this visitor saved on their own reservation. */
 const messages = new Map<number, string>();
@@ -256,6 +258,9 @@ function closePopover({ restoreFocus = true } = {}) {
 
 /** Writes the textarea's contents (or, when empty, removes what was there). */
 async function commit() {
+  // ⌘/Ctrl+Enter reaches the textarea, which `setBusy` leaves enabled, so a held
+  // shortcut would otherwise stack round trips on top of each other.
+  if (saving) return;
   if (!textarea || !anchor) return;
   const bead = anchor;
   const itemId = itemIdOf(bead);
@@ -270,27 +275,38 @@ async function commit() {
 
   setError(null);
   setBusy(true);
+  saving = true;
   const { data, error } = await actions.setReservationMessage({
     itemId,
     visitorId,
     message: value,
   });
-  setBusy(false);
+  saving = false;
+
+  // One panel serves every card, and clicking another bead re-anchors it while
+  // this request is open — only the buttons were disabled, not the beads. If
+  // that happened, the panel now belongs to a different reservation: its busy
+  // state, its error line and its unsaved text are none of this write's
+  // business. The bead and the cache still are, since both are keyed by item.
+  const stillOurs = anchor === bead;
+  if (stillOurs) setBusy(false);
 
   // Stay open on failure: the panel is holding text that exists nowhere else.
   if (error) {
-    setError(
-      lang === "ru"
-        ? "Не удалось сохранить. Попробуйте ещё раз."
-        : "Couldn't save that. Try again.",
-    );
+    if (stillOurs) {
+      setError(
+        lang === "ru"
+          ? "Не удалось сохранить. Попробуйте ещё раз."
+          : "Couldn't save that. Try again.",
+      );
+    }
     return;
   }
 
   if (data.message) messages.set(itemId, data.message);
   else messages.delete(itemId);
   syncBead(bead);
-  closePopover();
+  if (stillOurs) closePopover();
 }
 
 /* -------------------------------------------------------------------------

--- a/src/client/reservation-message.ts
+++ b/src/client/reservation-message.ts
@@ -1,0 +1,380 @@
+// The message a reserver leaves for the wishlist owner.
+//
+// One popover for the page, anchored to whichever card's bead was pressed
+// (components/wishlist/ReservationMessage.astro explains why it can't live
+// inside the card). Everything about where it lands is Floating UI's, including
+// `autoUpdate` — the anchor moves under it constantly: the grid reflows on a
+// filter change, the card lifts 8px on hover, and the page scrolls.
+//
+// Messages are held in a Map keyed by item id rather than on the DOM. They only
+// ever arrive for the visitor who wrote them, and a data attribute on a card is
+// a place for other people's scripts to read them from.
+
+import { actions } from "astro:actions";
+import { computePosition, autoUpdate, offset, flip, shift } from "@floating-ui/dom";
+import type { Placement } from "@floating-ui/dom";
+import type { Lang } from "@lib/i18n";
+import { getVisitorId } from "./visitor-id";
+
+const CLOSE_DURATION = 220; // must outlast the CSS exit transition
+
+let lang: Lang = "en";
+let popover: HTMLElement | null = null;
+let textarea: HTMLTextAreaElement | null = null;
+let counter: HTMLElement | null = null;
+let errorLine: HTMLElement | null = null;
+let dismissBtn: HTMLButtonElement | null = null;
+let saveBtn: HTMLButtonElement | null = null;
+
+let anchor: HTMLButtonElement | null = null;
+let stopFollowing: (() => void) | null = null;
+let closeTimer: number | undefined;
+
+/** itemId → the message this visitor saved on their own reservation. */
+const messages = new Map<number, string>();
+
+function itemIdOf(el: HTMLElement | null): number | null {
+  const raw = el?.dataset.itemId;
+  if (!raw) return null;
+  const id = Number.parseInt(raw, 10);
+  return Number.isNaN(id) ? null : id;
+}
+
+/* -------------------------------------------------------------------------
+   The bead in the card footer
+   ------------------------------------------------------------------------- */
+
+function beadOf(article: Element | null): HTMLButtonElement | null {
+  return article?.querySelector<HTMLButtonElement>(".message-btn") ?? null;
+}
+
+/**
+ * Reflect "does this reservation carry a message?" onto the bead: a filled
+ * state, and a tooltip that offers to edit rather than to write.
+ *
+ * The swap happens on `data-tooltip-en`/`-ru` rather than on `data-tooltip`
+ * itself. Three separate passes rewrite `data-tooltip` from those two —
+ * LangInit's first run, the language switcher's, and this page's own — and at
+ * least one of them lands after the reservation fetch resolves, so writing only
+ * the derived attribute got overwritten with "Leave a message" on a bead that
+ * already held one. Moving the state into the source keeps every pass correct
+ * without any of them knowing this feature exists.
+ */
+function syncBead(bead: HTMLButtonElement) {
+  const itemId = itemIdOf(bead);
+  const has = itemId !== null && !!messages.get(itemId);
+  bead.classList.toggle("has-message", has);
+
+  const en = has ? bead.dataset.tooltipEditEn : bead.dataset.tooltipWriteEn;
+  const ru = has ? bead.dataset.tooltipEditRu : bead.dataset.tooltipWriteRu;
+  if (!en || !ru) return;
+
+  bead.dataset.tooltipEn = en;
+  bead.dataset.tooltipRu = ru;
+  bead.setAttribute("data-tooltip", lang === "ru" ? ru : en);
+}
+
+/** Called when a reservation becomes (or is found to be) this visitor's. */
+export function showMessageBead(
+  article: Element | null,
+  { open = false } = {},
+): void {
+  const bead = beadOf(article);
+  if (!bead) return;
+  bead.hidden = false;
+  syncBead(bead);
+  // Auto-opening right after a reservation is the one moment the offer makes
+  // sense unprompted. Focus follows only on a device with a real pointer: on a
+  // phone it would throw up the keyboard over the card the visitor just acted on.
+  if (open) {
+    openPopover(bead, {
+      focus: window.matchMedia("(hover: hover) and (pointer: fine)").matches,
+    });
+  }
+}
+
+/**
+ * Called when a reservation is cancelled or turns out to be someone else's.
+ *
+ * `forget: false` takes the bead off the card but keeps the message cached, for
+ * the optimistic half of a cancel: if the server refuses, `showMessageBead`
+ * puts it back with its message intact.
+ */
+export function hideMessageBead(
+  article: Element | null,
+  { forget = true } = {},
+): void {
+  const bead = beadOf(article);
+  if (!bead) return;
+  bead.hidden = true;
+  bead.classList.remove("has-message");
+  if (anchor === bead) closePopover({ restoreFocus: false });
+  if (forget) forgetMessage(article);
+}
+
+/** Drops the cached message once the reservation holding it is really gone. */
+export function forgetMessage(article: Element | null): void {
+  const itemId = itemIdOf(beadOf(article));
+  if (itemId !== null) messages.delete(itemId);
+}
+
+/** Seeds the cache from the reservations fetch, before any bead is revealed. */
+export function primeMessages(seed: Map<number, string>): void {
+  messages.clear();
+  seed.forEach((message, itemId) => messages.set(itemId, message));
+}
+
+/* -------------------------------------------------------------------------
+   The popover
+   ------------------------------------------------------------------------- */
+
+/** Scale the panel out of the bead it belongs to, not out of its own middle. */
+function originFor(placement: Placement): string {
+  const [side, alignment] = placement.split("-");
+  const vertical = side === "top" ? "bottom" : side === "bottom" ? "top" : "center";
+  const horizontal =
+    alignment === "end" ? "right" : alignment === "start" ? "left" : "center";
+  return `${horizontal} ${vertical}`;
+}
+
+function position() {
+  if (!popover || !anchor) return;
+  computePosition(anchor, popover, {
+    strategy: "fixed",
+    placement: "top-end",
+    middleware: [
+      offset(10),
+      flip({ fallbackPlacements: ["bottom-end", "top-start", "bottom-start"] }),
+      // crossAxis too: flip only chooses a side, and on a short viewport — a
+      // phone in landscape, or a bead sitting right against the bottom edge
+      // under the mobile filter bar — neither side has room for the whole
+      // panel. Overlapping the bead beats hanging off the screen.
+      shift({ padding: 12, crossAxis: true }),
+    ],
+  }).then(({ x, y, placement }) => {
+    if (!popover) return;
+    popover.style.left = `${x}px`;
+    popover.style.top = `${y}px`;
+    popover.style.setProperty("--popover-origin", originFor(placement));
+  });
+}
+
+function setError(message: string | null) {
+  if (!errorLine) return;
+  errorLine.textContent = message ?? "";
+  errorLine.hidden = !message;
+}
+
+function setBusy(busy: boolean) {
+  if (!popover) return;
+  popover.setAttribute("aria-busy", String(busy));
+  if (dismissBtn) dismissBtn.disabled = busy;
+  if (saveBtn) saveBtn.disabled = busy;
+}
+
+function updateCounter() {
+  if (!textarea || !counter) return;
+  counter.textContent = `${textarea.value.length}/${textarea.maxLength}`;
+}
+
+/**
+ * The dismiss button is "Cancel" until there is something to remove, at which
+ * point it becomes the way to remove it. Two buttons for one slot would leave a
+ * dead "Delete" sitting there for every visitor who has yet to write anything.
+ */
+function syncDismissButton() {
+  if (!dismissBtn) return;
+  const itemId = itemIdOf(anchor);
+  const hasSaved = itemId !== null && !!messages.get(itemId);
+  const label = hasSaved
+    ? lang === "ru"
+      ? dismissBtn.dataset.ruDelete
+      : dismissBtn.dataset.enDelete
+    : lang === "ru"
+      ? dismissBtn.dataset.ruCancel
+      : dismissBtn.dataset.enCancel;
+  if (label) dismissBtn.textContent = label;
+  dismissBtn.classList.toggle("kit-btn--danger", hasSaved);
+  dismissBtn.classList.toggle("kit-btn--ghost", !hasSaved);
+}
+
+function openPopover(bead: HTMLButtonElement, { focus = true } = {}) {
+  if (!popover || !textarea) return;
+  const itemId = itemIdOf(bead);
+  if (itemId === null) return;
+
+  if (anchor && anchor !== bead) anchor.setAttribute("aria-expanded", "false");
+  window.clearTimeout(closeTimer);
+  stopFollowing?.();
+
+  anchor = bead;
+  textarea.value = messages.get(itemId) ?? "";
+  textarea.placeholder =
+    (lang === "ru"
+      ? textarea.dataset.placeholderRu
+      : textarea.dataset.placeholderEn) ?? "";
+  setError(null);
+  setBusy(false);
+  updateCounter();
+  syncDismissButton();
+
+  popover.hidden = false;
+  // The entrance transition needs a frame with the closed styles applied.
+  void popover.offsetHeight;
+  popover.classList.add("is-open");
+  bead.setAttribute("aria-expanded", "true");
+
+  stopFollowing = autoUpdate(bead, popover, position);
+
+  if (focus) {
+    textarea.focus();
+    textarea.setSelectionRange(textarea.value.length, textarea.value.length);
+  }
+}
+
+function closePopover({ restoreFocus = true } = {}) {
+  if (!popover || popover.hidden) return;
+
+  const returnTo = anchor;
+  popover.classList.remove("is-open");
+  anchor?.setAttribute("aria-expanded", "false");
+  stopFollowing?.();
+  stopFollowing = null;
+  anchor = null;
+
+  window.clearTimeout(closeTimer);
+  closeTimer = window.setTimeout(() => {
+    if (popover && !popover.classList.contains("is-open")) popover.hidden = true;
+  }, CLOSE_DURATION);
+
+  // Only pull focus back if it is still inside the panel we just dismissed —
+  // clicking elsewhere on the page has already put it where it belongs.
+  if (restoreFocus && returnTo && popover.contains(document.activeElement)) {
+    returnTo.focus();
+  }
+}
+
+/** Writes the textarea's contents (or, when empty, removes what was there). */
+async function commit() {
+  if (!textarea || !anchor) return;
+  const bead = anchor;
+  const itemId = itemIdOf(bead);
+  const visitorId = getVisitorId();
+  if (itemId === null || !visitorId) return;
+
+  const value = textarea.value.trim();
+  if (value === (messages.get(itemId) ?? "")) {
+    closePopover();
+    return;
+  }
+
+  setError(null);
+  setBusy(true);
+  const { data, error } = await actions.setReservationMessage({
+    itemId,
+    visitorId,
+    message: value,
+  });
+  setBusy(false);
+
+  // Stay open on failure: the panel is holding text that exists nowhere else.
+  if (error) {
+    setError(
+      lang === "ru"
+        ? "Не удалось сохранить. Попробуйте ещё раз."
+        : "Couldn't save that. Try again.",
+    );
+    return;
+  }
+
+  if (data.message) messages.set(itemId, data.message);
+  else messages.delete(itemId);
+  syncBead(bead);
+  closePopover();
+}
+
+/* -------------------------------------------------------------------------
+   Wiring
+   ------------------------------------------------------------------------- */
+
+export function initReservationMessages(initialLang: Lang): void {
+  lang = initialLang;
+  popover = document.getElementById("reservation-message");
+  if (!popover) return;
+
+  textarea = popover.querySelector(".message-popover-input");
+  counter = popover.querySelector(".message-popover-count");
+  errorLine = popover.querySelector(".message-popover-error");
+  dismissBtn = popover.querySelector(".message-popover-dismiss");
+  saveBtn = popover.querySelector(".message-popover-save");
+
+  // Delegated: beads are hidden at render time and revealed later, and the grid
+  // is rebuilt whenever a category filter runs.
+  document.addEventListener("click", (event) => {
+    const bead = (event.target as HTMLElement).closest<HTMLButtonElement>(
+      ".message-btn",
+    );
+    if (bead) {
+      event.preventDefault();
+      if (anchor === bead) closePopover();
+      else openPopover(bead);
+      return;
+    }
+
+    // Anywhere else outside the panel dismisses it. The Reserve button is not
+    // excluded: cancelling a reservation takes the message with it, and its own
+    // handler closes this anyway.
+    if (anchor && !popover!.contains(event.target as Node)) {
+      closePopover({ restoreFocus: false });
+    }
+  });
+
+  saveBtn?.addEventListener("click", commit);
+
+  dismissBtn?.addEventListener("click", () => {
+    const itemId = itemIdOf(anchor);
+    const hasSaved = itemId !== null && !!messages.get(itemId);
+    if (!hasSaved) {
+      closePopover();
+      return;
+    }
+    // "Delete" is "save an empty message" — same round trip, same rollback.
+    if (textarea) textarea.value = "";
+    void commit();
+  });
+
+  textarea?.addEventListener("input", () => {
+    updateCounter();
+    setError(null);
+  });
+
+  textarea?.addEventListener("keydown", (event) => {
+    // ⌘/Ctrl+Enter saves; a bare Enter belongs to the textarea.
+    if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
+      event.preventDefault();
+      void commit();
+    }
+  });
+
+  document.addEventListener("keydown", (event) => {
+    if (event.key === "Escape" && anchor) {
+      event.stopPropagation();
+      closePopover();
+    }
+  });
+}
+
+/** The language switcher fires while the popover may be open. */
+export function setReservationMessagesLang(next: Lang): void {
+  lang = next;
+  document
+    .querySelectorAll<HTMLButtonElement>(".message-btn")
+    .forEach((bead) => syncBead(bead));
+  syncDismissButton();
+  if (textarea) {
+    textarea.placeholder =
+      (next === "ru"
+        ? textarea.dataset.placeholderRu
+        : textarea.dataset.placeholderEn) ?? "";
+  }
+}

--- a/src/client/visitor-id.ts
+++ b/src/client/visitor-id.ts
@@ -1,0 +1,13 @@
+// The id that identifies a visitor to the reservation endpoints. Minted by the
+// inline script in WishlistPage.astro before anything else runs, so by the time
+// a module reads it, it exists.
+//
+// Its own module because two of them need it — the reserve buttons and the
+// message popover — and the popover is imported *by* the reserve-button module,
+// so sharing it from there would be a cycle.
+
+const VISITOR_ID_KEY = "wishlist-visitor-id";
+
+export function getVisitorId(): string {
+  return localStorage.getItem(VISITOR_ID_KEY) || "";
+}

--- a/src/client/wishlist-random.ts
+++ b/src/client/wishlist-random.ts
@@ -128,7 +128,7 @@ function isItemReserved(item: HTMLElement): boolean {
 
   // Check reserve button data attribute
   const reserveBtn = item.querySelector<HTMLElement>(".reserve-btn");
-  if (reserveBtn && reserveBtn.dataset.reservedBy) {
+  if (reserveBtn && (reserveBtn.dataset.reservation ?? "none") !== "none") {
     return true;
   }
 

--- a/src/client/wishlist.ts
+++ b/src/client/wishlist.ts
@@ -27,6 +27,16 @@ function reservationOf(button: HTMLElement): ReservationState {
   return (button.dataset.reservation as ReservationState) || "none";
 }
 
+/** Backoff between attempts at the reservations fetch, in ms. */
+const RESERVATION_RETRY_DELAYS = [300, 1000, 2500];
+
+/**
+ * False once the fetch above has given up. Nothing on the page knows whose
+ * reservations are whose at that point — the SSR attribute says "other" for
+ * everything taken, because the server has no idea who is looking.
+ */
+let reservationsKnown = true;
+
 /**
  * A badge's translations live on its inner label, not on the badge itself: the
  * badge also holds a state dot, and anything carrying data-en gets its
@@ -65,18 +75,16 @@ export async function initializeWishlist() {
 /** One row of /api/wishlist/reservations, which answers per visitor. */
 type ReservationResponse = { mine: boolean; message?: string };
 
-async function fetchAndApplyReservations() {
+async function loadReservations(): Promise<boolean> {
   const visitorId = getVisitorId();
 
   try {
-    const response = await fetch(
-      `/api/wishlist/reservations?visitor=${encodeURIComponent(visitorId)}`,
-    );
-    if (!response.ok) {
-      // Still show buttons on error, using SSR data
-      showButtons();
-      return;
-    }
+    // The id travels as a header, not a query parameter: it is this feature's
+    // only credential, and a URL ends up in every access log on the way.
+    const response = await fetch("/api/wishlist/reservations", {
+      headers: { "X-Visitor-Id": visitorId },
+    });
+    if (!response.ok) return false;
 
     const reservations: Record<number, ReservationResponse> =
       await response.json();
@@ -100,13 +108,40 @@ async function fetchAndApplyReservations() {
       });
 
     primeMessages(ownMessages);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
+async function fetchAndApplyReservations() {
+  if (await loadReservations()) {
     // Show buttons after data is loaded
     showButtons();
-  } catch {
-    // Still show buttons on error, using SSR data
-    showButtons();
+    return;
   }
+
+  for (const delay of RESERVATION_RETRY_DELAYS) {
+    await new Promise((resolve) => setTimeout(resolve, delay));
+    if (await loadReservations()) {
+      showButtons();
+      return;
+    }
+  }
+
+  // Falling back to the SSR attribute here used to tell the visitor holding a
+  // reservation that it was someone else's — disabled button, no Cancel, no
+  // bead, no way back short of a reload. Say so instead, and offer the reload.
+  reservationsKnown = false;
+  showButtons();
+}
+
+/** The retry button's label doubles as its accessible name. */
+function setRetryLabel(button: HTMLButtonElement, lang: Lang): void {
+  const text =
+    (lang === "ru" ? button.dataset.ruRetry : button.dataset.enRetry) ?? null;
+  button.textContent = text;
+  if (text) button.setAttribute("aria-label", text);
 }
 
 function showButtons() {
@@ -121,6 +156,22 @@ function showButtons() {
       const reservedBadge = article?.querySelector(
         ".reserved-badge",
       ) as HTMLElement;
+
+      // The fetch never landed, so on a taken card "whose" is unknown rather
+      // than "someone else's" — the SSR attribute only ever says the latter.
+      // The badge stays (it is true either way) but the button stays live and
+      // asks for another try instead of locking the holder out of their Cancel.
+      // A free card needs none of this: "nobody has it" is the server's to know.
+      if (!reservationsKnown && isReserved) {
+        setRetryLabel(button, currentLang);
+        button.classList.add("reserve-btn--retry");
+        if (reservedBadge) {
+          reservedBadge.hidden = false;
+          setBadgeLabel(reservedBadge, currentLang);
+        }
+        button.classList.remove("reserve-btn--loading");
+        return;
+      }
 
       // Set correct text based on language and state
       if (reservation === "mine") {
@@ -157,6 +208,13 @@ function initializeReserveButtons() {
   const visitorId = getVisitorId();
 
   reserveButtons.forEach((button) => {
+    // The reservations fetch gave up. Reserving or cancelling blind would be a
+    // guess; fetching again on a fresh page is not.
+    if (button.classList.contains("reserve-btn--retry")) {
+      button.addEventListener("click", () => location.reload());
+      return;
+    }
+
     // Skip received items
     if (button.disabled) {
       return;
@@ -408,6 +466,12 @@ function updateLanguage(lang: "en" | "ru") {
       return;
     }
 
+    // A retry button has no reservation state to render — only its own label.
+    if (btn.classList.contains("reserve-btn--retry")) {
+      setRetryLabel(btn, lang);
+      return;
+    }
+
     const reservation = reservationOf(btn);
     const isReceived =
       btn.dataset.enReceived &&
@@ -449,6 +513,9 @@ function updateAriaLabels(lang: "en" | "ru") {
     document.querySelectorAll<HTMLButtonElement>(".reserve-btn");
 
   reserveButtons.forEach((btn) => {
+    // updateLanguage already gave it one, matching what it says.
+    if (btn.classList.contains("reserve-btn--retry")) return;
+
     const reservation = reservationOf(btn);
 
     let ariaLabel: string | undefined;

--- a/src/client/wishlist.ts
+++ b/src/client/wishlist.ts
@@ -1,12 +1,30 @@
 import { actions } from "astro:actions";
 import type { Lang } from "@lib/i18n";
 import { initTooltips } from "./tooltip";
+import { getVisitorId } from "./visitor-id";
+import {
+  forgetMessage,
+  hideMessageBead,
+  initReservationMessages,
+  primeMessages,
+  setReservationMessagesLang,
+  showMessageBead,
+} from "./reservation-message";
 
-const VISITOR_ID_KEY = "wishlist-visitor-id";
 let currentLang: Lang = "en";
 
-function getVisitorId(): string {
-  return localStorage.getItem(VISITOR_ID_KEY) || "";
+/**
+ * Whose reservation a card is carrying, as the button's `data-reservation`.
+ *
+ * The server renders "other" for anything taken, because it has no idea who is
+ * looking; the per-visitor fetch below is what promotes a card to "mine". The
+ * button stays hidden (`.reserve-btn--loading`) until that lands, so the
+ * pessimistic first guess is never on screen.
+ */
+type ReservationState = "none" | "mine" | "other";
+
+function reservationOf(button: HTMLElement): ReservationState {
+  return (button.dataset.reservation as ReservationState) || "none";
 }
 
 /**
@@ -35,6 +53,8 @@ export async function initializeWishlist() {
   // Update prices based on language
   updatePricesForLanguage(currentLang);
 
+  initReservationMessages(currentLang);
+
   // Fetch fresh reservations from API and update UI
   await fetchAndApplyReservations();
 
@@ -42,16 +62,25 @@ export async function initializeWishlist() {
   initializeLangChangeListener();
 }
 
+/** One row of /api/wishlist/reservations, which answers per visitor. */
+type ReservationResponse = { mine: boolean; message?: string };
+
 async function fetchAndApplyReservations() {
+  const visitorId = getVisitorId();
+
   try {
-    const response = await fetch("/api/wishlist/reservations");
+    const response = await fetch(
+      `/api/wishlist/reservations?visitor=${encodeURIComponent(visitorId)}`,
+    );
     if (!response.ok) {
       // Still show buttons on error, using SSR data
       showButtons();
       return;
     }
 
-    const reservations: Record<number, string> = await response.json();
+    const reservations: Record<number, ReservationResponse> =
+      await response.json();
+    const ownMessages = new Map<number, string>();
 
     // Update each item's reservation status
     document
@@ -60,10 +89,17 @@ async function fetchAndApplyReservations() {
         const itemId = button.dataset.itemId;
         if (!itemId) return;
 
-        const reservedBy = reservations[parseInt(itemId)] || "";
-        // Update the data attribute with fresh data
-        button.dataset.reservedBy = reservedBy;
+        const id = parseInt(itemId);
+        const state = reservations[id];
+        button.dataset.reservation = !state
+          ? "none"
+          : state.mine
+            ? "mine"
+            : "other";
+        if (state?.mine && state.message) ownMessages.set(id, state.message);
       });
+
+    primeMessages(ownMessages);
 
     // Show buttons after data is loaded
     showButtons();
@@ -74,14 +110,11 @@ async function fetchAndApplyReservations() {
 }
 
 function showButtons() {
-  const visitorId = getVisitorId();
-
   document
     .querySelectorAll<HTMLButtonElement>(".reserve-btn")
     .forEach((button) => {
-      const reservedBy = button.dataset.reservedBy || "";
-      const isReserved = reservedBy.length > 0;
-      const isOwnReservation = isReserved && reservedBy === visitorId;
+      const reservation = reservationOf(button);
+      const isReserved = reservation !== "none";
 
       // Get badge elements
       const article = button.closest("article");
@@ -90,7 +123,7 @@ function showButtons() {
       ) as HTMLElement;
 
       // Set correct text based on language and state
-      if (isReserved && isOwnReservation) {
+      if (reservation === "mine") {
         button.textContent =
           (currentLang === "ru"
             ? button.dataset.ruCancel
@@ -129,9 +162,7 @@ function initializeReserveButtons() {
       return;
     }
 
-    const reservedBy = button.dataset.reservedBy || "";
-    const isReserved = reservedBy.length > 0;
-    const isOwnReservation = isReserved && reservedBy === visitorId;
+    const reservation = reservationOf(button);
 
     // Get badge elements (in the item-image section)
     const article = button.closest("article");
@@ -143,14 +174,15 @@ function initializeReserveButtons() {
     ) as HTMLElement;
 
     // Set initial button state
-    if (isReserved) {
-      if (isOwnReservation) {
-        // Own reservation - show Cancel and own badge
+    if (reservation !== "none") {
+      if (reservation === "mine") {
+        // Own reservation - show Cancel, own badge, and the message bead
         button.textContent =
           (currentLang === "ru"
             ? button.dataset.ruCancel
             : button.dataset.enCancel) ?? null;
         button.classList.add("own-reservation");
+        showMessageBead(article);
         if (ownBadge) {
           ownBadge.hidden = false;
           setBadgeLabel(ownBadge, currentLang);
@@ -173,9 +205,7 @@ function initializeReserveButtons() {
       const itemId = this.dataset.itemId;
       if (!itemId) return;
 
-      const currentReservedBy = this.dataset.reservedBy || "";
-      const isCurrentlyReserved = currentReservedBy.length > 0;
-      const isOwn = isCurrentlyReserved && currentReservedBy === visitorId;
+      const current = reservationOf(this);
 
       // Get badge for this item
       const itemArticle = this.closest("article");
@@ -183,23 +213,26 @@ function initializeReserveButtons() {
         ".own-reservation-badge",
       ) as HTMLElement;
 
-      if (isCurrentlyReserved && isOwn) {
+      if (current === "mine") {
         // Cancel reservation - optimistic UI
         const previousState = {
-          reservedBy: this.dataset.reservedBy,
+          reservation: this.dataset.reservation,
           textContent: this.textContent,
           hasClass: this.classList.contains("own-reservation"),
           badgeHidden: itemBadge?.hidden,
         };
 
         // Optimistically update UI
-        this.dataset.reservedBy = "";
+        this.dataset.reservation = "none";
         this.textContent =
           (currentLang === "ru"
             ? this.dataset.ruReserve
             : this.dataset.enReserve) ?? null;
         this.classList.remove("own-reservation");
         if (itemBadge) itemBadge.hidden = true;
+        // The message goes with the reservation, but only once the server has
+        // agreed to delete it — a rollback has to be able to put it back.
+        hideMessageBead(itemArticle, { forget: false });
         // Update aria-label
         const reserveAriaLabel =
           currentLang === "ru"
@@ -215,23 +248,26 @@ function initializeReserveButtons() {
 
         // Rollback on error
         if (error) {
-          this.dataset.reservedBy = previousState.reservedBy;
+          this.dataset.reservation = previousState.reservation;
           this.textContent = previousState.textContent;
           if (previousState.hasClass) this.classList.add("own-reservation");
           if (itemBadge) itemBadge.hidden = previousState.badgeHidden ?? false;
+          showMessageBead(itemArticle);
           alert(error.message || "Failed to cancel reservation");
+        } else {
+          forgetMessage(itemArticle);
         }
-      } else if (!isCurrentlyReserved) {
+      } else if (current === "none") {
         // Make reservation - optimistic UI
         const previousState = {
-          reservedBy: this.dataset.reservedBy,
+          reservation: this.dataset.reservation,
           textContent: this.textContent,
           hasClass: this.classList.contains("own-reservation"),
           badgeHidden: itemBadge?.hidden,
         };
 
         // Optimistically update UI
-        this.dataset.reservedBy = visitorId;
+        this.dataset.reservation = "mine";
         this.textContent =
           (currentLang === "ru"
             ? this.dataset.ruCancel
@@ -256,11 +292,17 @@ function initializeReserveButtons() {
 
         // Rollback on error
         if (error) {
-          this.dataset.reservedBy = previousState.reservedBy;
+          this.dataset.reservation = previousState.reservation;
           this.textContent = previousState.textContent;
           if (!previousState.hasClass) this.classList.remove("own-reservation");
           if (itemBadge) itemBadge.hidden = previousState.badgeHidden ?? true;
           alert(error.message || "Failed to reserve item");
+        } else {
+          // Offering to write on a reservation is only honest once there is one
+          // — `setReservationMessage` has nothing to attach to until the insert
+          // lands. So the bead (and the invitation) waits for the round trip
+          // even though the button itself did not.
+          showMessageBead(itemArticle, { open: true });
         }
       }
     });
@@ -281,6 +323,7 @@ function initializeLangChangeListener() {
     updateLanguage(lang);
     updateAriaLabels(lang);
     updatePricesForLanguage(lang);
+    setReservationMessagesLang(lang);
   }) as EventListener);
 }
 
@@ -353,7 +396,6 @@ function updateLanguage(lang: "en" | "ru") {
   // Update reserve buttons based on their state
   const reserveButtons =
     document.querySelectorAll<HTMLButtonElement>(".reserve-btn");
-  const visitorId = getVisitorId();
 
   reserveButtons.forEach((btn) => {
     // Skip buttons in loading state
@@ -366,9 +408,7 @@ function updateLanguage(lang: "en" | "ru") {
       return;
     }
 
-    const reservedBy = btn.dataset.reservedBy || "";
-    const isReserved = reservedBy.length > 0;
-    const isOwnReservation = isReserved && reservedBy === visitorId;
+    const reservation = reservationOf(btn);
     const isReceived =
       btn.dataset.enReceived &&
       (btn.textContent === "Received" || btn.textContent === "Получено");
@@ -377,10 +417,10 @@ function updateLanguage(lang: "en" | "ru") {
       btn.textContent =
         (lang === "ru" ? btn.dataset.ruReceived : btn.dataset.enReceived) ??
         null;
-    } else if (isReserved && isOwnReservation) {
+    } else if (reservation === "mine") {
       btn.textContent =
         (lang === "ru" ? btn.dataset.ruCancel : btn.dataset.enCancel) ?? null;
-    } else if (isReserved && !isOwnReservation) {
+    } else if (reservation === "other") {
       btn.textContent =
         (lang === "ru" ? btn.dataset.ruReserved : btn.dataset.enReserved) ??
         null;
@@ -407,21 +447,18 @@ function updateAriaLabels(lang: "en" | "ru") {
   // Update reserve buttons aria-labels based on state
   const reserveButtons =
     document.querySelectorAll<HTMLButtonElement>(".reserve-btn");
-  const visitorId = getVisitorId();
 
   reserveButtons.forEach((btn) => {
-    const reservedBy = btn.dataset.reservedBy || "";
-    const isReserved = reservedBy.length > 0;
-    const isOwnReservation = isReserved && reservedBy === visitorId;
+    const reservation = reservationOf(btn);
 
     let ariaLabel: string | undefined;
 
-    if (isReserved && isOwnReservation) {
+    if (reservation === "mine") {
       ariaLabel =
         lang === "ru"
           ? btn.dataset.ariaLabelRuCancel
           : btn.dataset.ariaLabelEnCancel;
-    } else if (isReserved) {
+    } else if (reservation === "other") {
       ariaLabel =
         lang === "ru"
           ? btn.dataset.ariaLabelRuReserved

--- a/src/components/wishlist/ReservationMessage.astro
+++ b/src/components/wishlist/ReservationMessage.astro
@@ -1,0 +1,90 @@
+---
+/**
+ * The message a reserver leaves for the wishlist owner.
+ *
+ * One popover for the whole page rather than one per card, and rendered as a
+ * direct child of <body> rather than inside the grid. Both follow from the
+ * material: the panel is liquid glass, and `backdrop-filter` is silently killed
+ * by a transform on any ancestor — the cards lift 8px on hover and the Reserve
+ * button is magnetically pulled toward the cursor, so a panel living inside a
+ * card would lose its frost exactly when it was being used. Sitting at the top
+ * of the document also puts it outside the grid's `content-visibility` and
+ * clipping, which is what the per-card version had to fight with `overflow:
+ * visible` and `contain: none` overrides.
+ *
+ * Positioning is Floating UI's job (client/reservation-message.ts), anchored to
+ * the message bead in the card's footer.
+ */
+import { RESERVATION_MESSAGE_MAX_LENGTH } from "@lib/wishlist";
+// The panel borrows the kit's field and buttons rather than growing its own;
+// neither stylesheet is pulled in by anything else the wishlist renders.
+import "@styles/kit/input.css";
+import "@styles/kit/button.css";
+---
+
+<div
+  class="message-popover liquid-glass"
+  id="reservation-message"
+  role="dialog"
+  aria-labelledby="reservation-message-title"
+  hidden
+>
+  <h2
+    class="message-popover-title"
+    id="reservation-message-title"
+    data-en="Leave a message"
+    data-ru="Оставить сообщение"
+  >
+    Leave a message
+  </h2>
+  <p
+    class="message-popover-hint"
+    data-en="Only the owner of the wishlist sees it."
+    data-ru="Его увидит только владелец вишлиста."
+  >
+    Only the owner of the wishlist sees it.
+  </p>
+
+  <textarea
+    class="kit-input kit-input--sm message-popover-input"
+    rows="3"
+    maxlength={RESERVATION_MESSAGE_MAX_LENGTH}
+    placeholder="e.g. I'll bring it to the party!"
+    data-placeholder-en="e.g. I'll bring it to the party!"
+    data-placeholder-ru="напр. Привезу на праздник!"
+    aria-describedby="reservation-message-count"
+  ></textarea>
+
+  <p class="message-popover-error" role="alert" hidden></p>
+
+  <div class="message-popover-footer">
+    <span class="message-popover-count" id="reservation-message-count"
+      >0/{RESERVATION_MESSAGE_MAX_LENGTH}</span
+    >
+    <div class="message-popover-actions">
+      {/*
+        "Skip", not "Cancel": the card underneath already has a Cancel, and it
+        cancels the reservation. Two of them side by side, one closing a panel
+        and one giving the present back, is a trap.
+      */}
+      <button
+        type="button"
+        class="kit-btn kit-btn--ghost kit-btn--sm message-popover-dismiss"
+        data-en-cancel="Skip"
+        data-ru-cancel="Пропустить"
+        data-en-delete="Delete"
+        data-ru-delete="Удалить"
+      >
+        Skip
+      </button>
+      <button
+        type="button"
+        class="kit-btn kit-btn--primary kit-btn--sm message-popover-save"
+        data-en="Save"
+        data-ru="Сохранить"
+      >
+        Save
+      </button>
+    </div>
+  </div>
+</div>

--- a/src/components/wishlist/WishlistItem.astro
+++ b/src/components/wishlist/WishlistItem.astro
@@ -221,6 +221,8 @@ const [darkAvif, lightAvif, lightWebp] = darkImageUrl
               data-ru-reserved="Зарезервировано"
               data-en-cancel="Cancel"
               data-ru-cancel="Отменить"
+              data-en-retry="Retry"
+              data-ru-retry="Повторить"
               aria-label={
                 item.isReserved
                   ? `Cancel reservation for ${item.title}`

--- a/src/components/wishlist/WishlistItem.astro
+++ b/src/components/wishlist/WishlistItem.astro
@@ -1,5 +1,6 @@
 ---
 import { Picture, getImage } from "astro:assets";
+import { Icon } from "astro-icon/components";
 import Badge from "@components/kit/Badge.astro";
 import {
   getCdnImageUrl,
@@ -187,32 +188,54 @@ const [darkAvif, lightAvif, lightWebp] = darkImageUrl
 
       {
         !item.received && reservationsEnabled && (
-          <button
-            class="reserve-btn reserve-btn--loading"
-            data-item-id={item.id}
-            data-item-title={item.title}
-            data-item-title-ru={item.titleRu || item.title}
-            data-reserved-by={item.reservedBy}
-            data-en-reserve="Reserve"
-            data-ru-reserve="Зарезервировать"
-            data-en-reserved="Reserved"
-            data-ru-reserved="Зарезервировано"
-            data-en-cancel="Cancel"
-            data-ru-cancel="Отменить"
-            aria-label={
-              item.isReserved
-                ? `Cancel reservation for ${item.title}`
-                : `Reserve ${item.title}`
-            }
-            data-aria-label-en-reserve={`Reserve ${item.title}`}
-            data-aria-label-ru-reserve={`Зарезервировать ${item.titleRu || item.title}`}
-            data-aria-label-en-cancel={`Cancel reservation for ${item.title}`}
-            data-aria-label-ru-cancel={`Отменить резервацию ${item.titleRu || item.title}`}
-            data-aria-label-en-reserved={`Reserved: ${item.title}`}
-            data-aria-label-ru-reserved={`Зарезервировано: ${item.titleRu || item.title}`}
-          >
-            {item.isReserved ? "Reserved" : "Reserve"}
-          </button>
+          <div class="reserve-actions">
+            <button
+              class="message-btn"
+              data-item-id={item.id}
+              aria-haspopup="dialog"
+              aria-expanded="false"
+              aria-controls="reservation-message"
+              aria-label={`Leave a message about ${item.title}`}
+              data-aria-label-en={`Leave a message about ${item.title}`}
+              data-aria-label-ru={`Оставить сообщение о ${item.titleRu || item.title}`}
+              data-tooltip="Leave a message"
+              data-tooltip-en="Leave a message"
+              data-tooltip-ru="Оставить сообщение"
+              data-tooltip-write-en="Leave a message"
+              data-tooltip-write-ru="Оставить сообщение"
+              data-tooltip-edit-en="Edit your message"
+              data-tooltip-edit-ru="Изменить сообщение"
+              hidden
+            >
+              <Icon name="message" width={16} height={16} />
+            </button>
+            <button
+              class="reserve-btn reserve-btn--loading"
+              data-item-id={item.id}
+              data-item-title={item.title}
+              data-item-title-ru={item.titleRu || item.title}
+              data-reservation={item.isReserved ? "other" : "none"}
+              data-en-reserve="Reserve"
+              data-ru-reserve="Зарезервировать"
+              data-en-reserved="Reserved"
+              data-ru-reserved="Зарезервировано"
+              data-en-cancel="Cancel"
+              data-ru-cancel="Отменить"
+              aria-label={
+                item.isReserved
+                  ? `Cancel reservation for ${item.title}`
+                  : `Reserve ${item.title}`
+              }
+              data-aria-label-en-reserve={`Reserve ${item.title}`}
+              data-aria-label-ru-reserve={`Зарезервировать ${item.titleRu || item.title}`}
+              data-aria-label-en-cancel={`Cancel reservation for ${item.title}`}
+              data-aria-label-ru-cancel={`Отменить резервацию ${item.titleRu || item.title}`}
+              data-aria-label-en-reserved={`Reserved: ${item.title}`}
+              data-aria-label-ru-reserved={`Зарезервировано: ${item.titleRu || item.title}`}
+            >
+              {item.isReserved ? "Reserved" : "Reserve"}
+            </button>
+          </div>
         )
       }
     </div>

--- a/src/components/wishlist/WishlistPage.astro
+++ b/src/components/wishlist/WishlistPage.astro
@@ -5,6 +5,7 @@ import LangInit from "@components/LangInit.astro";
 import WishlistItem from "@components/wishlist/WishlistItem.astro";
 import WishlistFilters from "@components/wishlist/WishlistFilters.astro";
 import MobileFilterBar from "@components/wishlist/MobileFilterBar.astro";
+import ReservationMessage from "@components/wishlist/ReservationMessage.astro";
 import Button from "@components/kit/Button.astro";
 import { Icon } from "astro-icon/components";
 import type { WishlistItemWithReservation, Category } from "@lib/wishlist";
@@ -170,9 +171,12 @@ const allCategory = categories.find((c) => c.id === "all")!;
 
   {
     reservationsEnabled && (
-      <script>
-        import("@client/wishlist");
-      </script>
+      <>
+        <ReservationMessage />
+        <script>
+          import("@client/wishlist");
+        </script>
+      </>
     )
   }
 

--- a/src/components/wishlist/admin/AdminPanel.tsx
+++ b/src/components/wishlist/admin/AdminPanel.tsx
@@ -263,6 +263,7 @@ function AdminPanelInner({
               itemId: id,
               reservedBy: "admin",
               reservedAt: new Date(),
+              message: null,
             });
           } else {
             newMap.delete(id);

--- a/src/components/wishlist/admin/ItemList.astro
+++ b/src/components/wishlist/admin/ItemList.astro
@@ -22,6 +22,7 @@ interface Reservation {
   itemId: number;
   reservedBy: string;
   reservedAt: Date;
+  message: string | null;
 }
 
 interface Props {

--- a/src/components/wishlist/admin/ReservationsModal.tsx
+++ b/src/components/wishlist/admin/ReservationsModal.tsx
@@ -78,7 +78,7 @@ export function ReservationsModal({
                     </span>
                   </div>
                   <div className="reservation-items">
-                    {userItems.map(({ item }) => (
+                    {userItems.map(({ item, reservation }) => (
                       <div key={item.id} className="reservation-item">
                         <img
                           src={`https://${cdnDomain}/${item.imageUrl}`}
@@ -91,6 +91,11 @@ export function ReservationsModal({
                           <span className="reservation-item-price">
                             {item.price}
                           </span>
+                          {reservation.message && (
+                            <p className="reservation-item-message">
+                              {reservation.message}
+                            </p>
+                          )}
                         </div>
                       </div>
                     ))}

--- a/src/components/wishlist/admin/types.ts
+++ b/src/components/wishlist/admin/types.ts
@@ -20,6 +20,8 @@ export interface Reservation {
   itemId: number;
   reservedBy: string;
   reservedAt: Date;
+  /** The note the reserver left for the owner. This panel is where it lands. */
+  message: string | null;
 }
 
 export interface ItemFormData {

--- a/src/icons/message.svg
+++ b/src/icons/message.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
+  <path d="M14 9.5C14 10.3284 13.3284 11 12.5 11H5L2 14V3.5C2 2.67157 2.67157 2 3.5 2H12.5C13.3284 2 14 2.67157 14 3.5V9.5Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/lib/wishlist.ts
+++ b/src/lib/wishlist.ts
@@ -10,6 +10,13 @@ export function getCdnImageUrl(filename: string): string {
   return `https://${cdnDomain}/${filename}`;
 }
 
+/**
+ * Length ceiling for the message a reserver may leave. Enforced by the action
+ * and mirrored onto the textarea's `maxlength`; the client reads it back off
+ * the element rather than importing this module, which is server-only.
+ */
+export const RESERVATION_MESSAGE_MAX_LENGTH = 200;
+
 // Types
 export type Currency = "USD" | "EUR" | "GBP" | "AUD" | "INR";
 
@@ -36,7 +43,13 @@ export type WishlistItemWithReservation = {
   createdAt: Date;
   weight: number;
   isReserved: boolean;
-  reservedBy: string | null;
+  /**
+   * Deliberately no `reservedBy`. A visitor id is the credential that lets its
+   * holder cancel a reservation or write on it, and this type is rendered into
+   * a page every visitor can read — the card only needs to know that the item
+   * is taken. Whose it is arrives per-visitor from
+   * /api/wishlist/reservations.
+   */
 };
 
 export type Category = {
@@ -167,7 +180,6 @@ export async function getWishlistItems(
       priceUsd,
       priceRub,
       isReserved: !!reservation,
-      reservedBy: reservation?.reservedBy ?? null,
     };
   });
 

--- a/src/pages/api/wishlist/reservations.ts
+++ b/src/pages/api/wishlist/reservations.ts
@@ -3,16 +3,43 @@ import { db, Reservation } from "astro:db";
 
 export const prerender = false;
 
-export const GET: APIRoute = async () => {
+/**
+ * Who has reserved what, from the point of view of one visitor.
+ *
+ * The response is deliberately not the reservation rows. A visitor id is the
+ * only credential this feature has — `reserve`, `unreserve` and
+ * `setReservationMessage` all authorise on "you sent the id that matches
+ * `reservedBy`" — so handing every caller the full set of ids, as this endpoint
+ * used to, let anyone cancel anyone's reservation by reading them back. Now the
+ * caller's own id goes in and only a verdict comes out.
+ *
+ * `message` rides along for the same reason it can't be server-rendered into the
+ * card: it is a note to the wishlist owner, not to the other visitors, so it
+ * only ever reaches the person who wrote it (and the admin panel, which reads
+ * the table directly).
+ */
+type ReservationState = {
+  /** True when the caller is the one holding this reservation. */
+  mine: boolean;
+  /** The caller's own message, when they left one. Absent otherwise. */
+  message?: string;
+};
+
+export const GET: APIRoute = async ({ url }) => {
   const start = Date.now();
+  const visitorId = url.searchParams.get("visitor") ?? "";
 
   const reservations = await db.select().from(Reservation);
   const dbTime = Date.now() - start;
 
-  // Return map of itemId -> visitorId
-  const reservationMap: Record<number, string> = {};
+  const reservationMap: Record<number, ReservationState> = {};
   for (const r of reservations) {
-    reservationMap[r.itemId] = r.reservedBy;
+    // An empty `visitor` (no id in localStorage yet) must not match a row, and
+    // an empty `reservedBy` must not match an empty query param either.
+    const mine = visitorId.length > 0 && r.reservedBy === visitorId;
+    reservationMap[r.itemId] = mine
+      ? { mine: true, ...(r.message ? { message: r.message } : {}) }
+      : { mine: false };
   }
 
   const totalTime = Date.now() - start;
@@ -22,7 +49,8 @@ export const GET: APIRoute = async () => {
     status: 200,
     headers: {
       "Content-Type": "application/json",
-      "Cache-Control": "no-store",
+      // Per-visitor now, so it must never be shared by a cache
+      "Cache-Control": "no-store, private",
       "Server-Timing": `db;dur=${dbTime}, total;dur=${totalTime}`,
     },
   });

--- a/src/pages/api/wishlist/reservations.ts
+++ b/src/pages/api/wishlist/reservations.ts
@@ -13,6 +13,11 @@ export const prerender = false;
  * used to, let anyone cancel anyone's reservation by reading them back. Now the
  * caller's own id goes in and only a verdict comes out.
  *
+ * It goes in as a header rather than a query parameter: a URL is written to
+ * every access log along the way — Vercel's, the edge's, any proxy's — and a
+ * credential does not belong in any of them. `no-store, private` keeps it out of
+ * caches but has nothing to say about logs.
+ *
  * `message` rides along for the same reason it can't be server-rendered into the
  * card: it is a note to the wishlist owner, not to the other visitors, so it
  * only ever reaches the person who wrote it (and the admin panel, which reads
@@ -25,9 +30,9 @@ type ReservationState = {
   message?: string;
 };
 
-export const GET: APIRoute = async ({ url }) => {
+export const GET: APIRoute = async ({ request }) => {
   const start = Date.now();
-  const visitorId = url.searchParams.get("visitor") ?? "";
+  const visitorId = request.headers.get("x-visitor-id") ?? "";
 
   const reservations = await db.select().from(Reservation);
   const dbTime = Date.now() - start;
@@ -49,8 +54,11 @@ export const GET: APIRoute = async ({ url }) => {
     status: 200,
     headers: {
       "Content-Type": "application/json",
-      // Per-visitor now, so it must never be shared by a cache
+      // Per-visitor now, so it must never be shared by a cache. Every caller
+      // hits the same URL, so `Vary` is what keeps that true if `no-store` is
+      // ever relaxed.
       "Cache-Control": "no-store, private",
+      Vary: "X-Visitor-Id",
       "Server-Timing": `db;dur=${dbTime}, total;dur=${totalTime}`,
     },
   });

--- a/src/styles/admin/items.css
+++ b/src/styles/admin/items.css
@@ -508,7 +508,9 @@
 
 .reservation-item {
   display: flex;
-  align-items: center;
+  /* Not centred: a reservation can carry a message, and a two-line block
+     centred against a 48px thumbnail floats away from it. */
+  align-items: flex-start;
   gap: 0.75rem;
   padding: 0.5rem;
   background: light-dark(rgba(255, 255, 255, 0.5), rgba(255, 255, 255, 0.05));
@@ -543,4 +545,18 @@
   font-size: 0.75rem;
   font-weight: 600;
   color: light-dark(#666, #aaa);
+}
+
+/* What the reserver wrote. Quoted rather than styled as a field: it is someone
+   else's words, and it is the only free text a visitor can put in here. */
+.reservation-item-message {
+  margin: 0.35rem 0 0;
+  padding-left: 0.6rem;
+  border-left: 2px solid
+    light-dark(rgba(0, 0, 0, 0.12), rgba(255, 255, 255, 0.16));
+  font-size: 0.8rem;
+  line-height: 1.45;
+  color: light-dark(#333, #ccc);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
 }

--- a/src/styles/wishlist.css
+++ b/src/styles/wishlist.css
@@ -1145,6 +1145,16 @@ textarea.message-popover-input:focus {
     backdrop-filter: none;
   }
 
+  /* The message bead. It carries the glass tokens itself rather than the
+     .liquid-glass class, so global.css's override never reaches it — and left
+     out, it would be the one frosted thing in a row of opaque controls. Matches
+     the reserve pill it sits against, not the .liquid-glass default. */
+  .message-btn {
+    background-color: light-dark(#f0f0f0, #3a3a3a);
+    background-image: none;
+    backdrop-filter: none;
+  }
+
   /* Random button. The lit override matters: the lit rule re-pins the
      translucent glass tokens. "All" needs nothing — it carries no frost to
      fall back from, and its accent capsule is already opaque. */
@@ -1276,7 +1286,11 @@ textarea.message-popover-input:focus {
     align-items: stretch;
   }
 
+  /* The stacked footer stretches .reserve-actions, not the pill inside it, so
+     the pill has to claim the rest of the row for itself — otherwise it shrinks
+     to its label and huddles against the bead. */
   .reserve-btn {
+    flex: 1;
     text-align: center;
   }
 }

--- a/src/styles/wishlist.css
+++ b/src/styles/wishlist.css
@@ -770,6 +770,250 @@
   }
 }
 
+/* =============================================================================
+   Reservation message — a bead beside the Reserve pill, and the panel it opens.
+
+   The bead is the random-pick die's recipe at footer scale: a round glass
+   capsule whose accent arrives as an indicator scaling up behind the glyph
+   rather than as a background swap. Round because the pill next to it is a
+   capsule and a square would be the only cornered thing in the footer.
+
+   It has no tooltip CSS of its own. The site has one tooltip — the glass bead
+   that trails the cursor (client/tooltip.ts) — and this is a `data-tooltip`
+   trigger like every other, which is also why the label can switch between
+   "Leave a message" and "Edit your message" from script.
+   ============================================================================= */
+.reserve-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.message-btn {
+  position: relative;
+  /* Own stacking context, so the z-index:-1 indicator lands above the frost and
+     below the glyph. */
+  isolation: isolate;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border-radius: 50%;
+  cursor: pointer;
+  background-color: var(--glass-bg);
+  background-image: var(--glass-sheen);
+  backdrop-filter: var(--glass-filter);
+  border: var(--glass-border);
+  box-shadow: var(--glass-shadow);
+  color: light-dark(#555, #b4b4b8);
+  transition: color 0.3s ease;
+}
+
+.message-btn[hidden] {
+  display: none;
+}
+
+.message-btn::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(135deg, var(--accent-start), var(--accent-end));
+  box-shadow: 0 4px 16px rgba(237, 87, 96, 0.45);
+  opacity: 0;
+  transform: scale(0.9);
+  transition:
+    transform 0.42s cubic-bezier(0.16, 1, 0.3, 1),
+    opacity 0.3s ease;
+  pointer-events: none;
+  z-index: -1;
+}
+
+/* The refractive rim, above the indicator — and out of the way once it's lit. */
+.message-btn::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  z-index: 5;
+  box-shadow: var(--glass-rim);
+}
+
+.message-btn:is(:hover, :focus-visible)::before,
+.message-btn[aria-expanded="true"]::before {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.message-btn:is(:hover, :focus-visible),
+.message-btn[aria-expanded="true"] {
+  color: #fff;
+}
+
+.message-btn:is(:hover, :focus-visible)::after,
+.message-btn[aria-expanded="true"]::after {
+  box-shadow: none;
+}
+
+.message-btn:focus-visible {
+  outline: 2px solid light-dark(#333, #fff);
+  outline-offset: 2px;
+}
+
+/* A message already written: the glyph takes the accent so the bead reads as
+   holding something, without lighting the full indicator that means "active". */
+.message-btn.has-message {
+  color: light-dark(var(--accent-end), var(--accent-start));
+}
+
+.message-btn.has-message:is(:hover, :focus-visible),
+.message-btn.has-message[aria-expanded="true"] {
+  color: #fff;
+}
+
+/* -----------------------------------------------------------------------------
+   The panel.
+
+   Position and entrance share the element, deliberately: the frost is on this
+   box, and a wrapper scaling it would reset the backdrop root and drop the
+   frost — the same trap the cursor tooltip documents. So Floating UI writes
+   left/top and the scale rides on a registered custom property, animated out of
+   whichever corner the bead ended up on (--popover-origin).
+   ----------------------------------------------------------------------------- */
+@property --popover-scale {
+  syntax: "<number>";
+  initial-value: 0.94;
+  inherits: false;
+}
+
+.message-popover {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 1000;
+  box-sizing: border-box;
+  width: min(320px, calc(100vw - 2rem));
+  padding: 1rem;
+  border-radius: 18px;
+  transform-origin: var(--popover-origin, center bottom);
+  transform: scale(var(--popover-scale));
+  opacity: 0;
+  --popover-scale: 0.94;
+  transition:
+    opacity 0.18s ease,
+    --popover-scale 0.42s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.message-popover.is-open {
+  opacity: 1;
+  --popover-scale: 1;
+}
+
+.message-popover[hidden] {
+  display: none;
+}
+
+/* The shared rim rides on ::after at z-index 5, which is above the label of a
+   button but above the *content* of a panel — it would lay a white inner glow
+   over the field and the copy. A negative index still paints it over the
+   panel's own frost and sheen, just under everything written on top. */
+.message-popover::after {
+  z-index: -1;
+}
+
+.message-popover-title {
+  margin: 0;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: light-dark(#111, #fafafa);
+}
+
+.message-popover-hint {
+  margin: 0.2rem 0 0.65rem;
+  font-size: 0.75rem;
+  line-height: 1.4;
+  color: light-dark(#555, #9a9aa0);
+}
+
+/* The field sits *inside* frosted glass, so it can't be the kit's opaque input:
+   a solid white box would punch a hole in the panel. Tint only, and the focus
+   ring is the kit's accent inset. */
+textarea.message-popover-input {
+  resize: none;
+  background-color: light-dark(rgba(255, 255, 255, 0.5), rgba(0, 0, 0, 0.22));
+  box-shadow: inset 0 0 0 1px
+    light-dark(rgba(0, 0, 0, 0.12), rgba(255, 255, 255, 0.14));
+}
+
+textarea.message-popover-input:hover:not(:disabled):not(:focus) {
+  box-shadow: inset 0 0 0 1px
+    light-dark(rgba(0, 0, 0, 0.22), rgba(255, 255, 255, 0.24));
+}
+
+textarea.message-popover-input:focus {
+  box-shadow: inset 0 0 0 2px var(--accent-start);
+}
+
+.message-popover-error {
+  margin: 0.5rem 0 0;
+  font-size: 0.7rem;
+  color: light-dark(#dc2626, #f87171);
+}
+
+.message-popover-error[hidden] {
+  display: none;
+}
+
+.message-popover-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-top: 0.75rem;
+}
+
+.message-popover-count {
+  font-size: 0.7rem;
+  font-variant-numeric: tabular-nums;
+  color: light-dark(#888, #777);
+}
+
+.message-popover-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+/* Dismiss keeps the ghost *row* treatment the filter chips were given, not the
+   kit's ghost button: a second ring inside a panel that already has a rim reads
+   as a box in a box. */
+.message-popover .kit-btn--ghost {
+  background: transparent;
+  box-shadow: none;
+  color: light-dark(#666, #9a9aa0);
+}
+
+.message-popover .kit-btn--ghost:is(:hover, :focus-visible):not(:disabled) {
+  background-color: light-dark(rgba(0, 0, 0, 0.055), rgba(255, 255, 255, 0.07));
+  box-shadow: none;
+  color: light-dark(#111, #fff);
+}
+
+.message-popover[aria-busy="true"] {
+  cursor: progress;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .message-btn,
+  .message-btn::before,
+  .message-popover {
+    transition: none;
+  }
+}
+
 /* Accessibility - Focus styles. The reserve pill wears the chrome's focus ring
    (same as .dock-item / .lang-switcher__btn) since its accent fill is now the
    hover/focus indicator. */


### PR DESCRIPTION
Supersedes `wishlist/message`, which branched before `/wishlist` moved to liquid glass. That branch is 170+ commits behind and its popover was written against tokens and patterns main has since removed — `--glass-bg-light`, a hand-rolled `::after` tooltip, its own `@property --glow-angle` and `glow-rotate` keyframes that now collide with the card highlight's, and `overflow: visible` / `contain: none` workarounds for clipping main already fixed. So the feature is rebuilt on current main rather than merged forward. The original branch is untouched.

## What it does

Reserving something answers "who is bringing it" and nothing else. This adds the sentence that goes with it — "I'll bring it to the party", "it's the signed edition" — written by whoever reserved the item, read by whoever owns the wishlist.

A bead appears next to Reserve the moment a reservation is yours. The panel it opens is the invitation: it opens itself once, right after the reservation lands, and after that the bead is how you come back to edit or delete. The offer waits for the server even though the button doesn't — there is nothing to write on until the row exists.

## Design

The page's own liquid glass rather than a second dialect of it.

- **The bead** is the random-pick die's recipe at footer scale: a round glass capsule whose accent arrives as an indicator scaling up behind the glyph, not as a background swap. It has no tooltip CSS of its own — it's a `data-tooltip` trigger like everything else, so the cursor-following bead does the talking.
- **The panel** is one instance for the page, living at the top of the document. `backdrop-filter` dies under a transformed ancestor, and cards lift on hover while Reserve is magnetically pulled toward the cursor, so a panel inside a card would lose its frost exactly when it was in use. Sitting outside the grid also puts it beyond `content-visibility` and clipping. Floating UI keeps it on its bead through scrolls and reflows; the entrance scales out of whichever corner the bead ended up on.
- Field and buttons come from the kit, tinted for glass — an opaque input would punch a hole in the panel.

## Security: the reservations endpoint stopped leaking

It had to change to carry the message, and while it was open it got fixed. `GET /api/wishlist/reservations` used to return a map of item → visitor id to every caller. A visitor id is the entire credential this feature has: `reserve`, `unreserve` and the new `setReservationMessage` all authorise on "you sent the id that matches `reservedBy`". So anyone could read the ids back and cancel anyone's reservation.

It now takes the caller's own id and returns a verdict — `{ mine: boolean, message?: string }` — with the message attached only for the person who wrote it. `reservedBy` is gone from `WishlistItemWithReservation` and from the server-rendered card for the same reason; whose reservation it is arrives per visitor. The card's `data-reserved-by` becomes `data-reservation` holding `none` / `mine` / `other`.

## Also fixed, against the earlier version

- An empty textarea saved over an existing message deletes it, instead of silently keeping what was there.
- A failed save keeps the panel open with the text still in it and says so — it used to `console.error` and close, dropping what you wrote.
- Cancelling a reservation only forgets its message once the server agrees, so a rollback puts it back.
- Escape, click-outside and ⌘/Ctrl+Enter work; the trigger carries `aria-expanded` and the panel is a labelled dialog.
- The bead's tooltip swaps its `data-tooltip-en`/`-ru` sources rather than the derived `data-tooltip`. Three separate passes rewrite that attribute and one of them lands after the reservation fetch, which used to undo the "Edit your message" label.
- "Skip", not "Cancel" — the card underneath already has a Cancel, and it cancels the reservation.
- The 4s conic-gradient glow that nudged you toward the bead is gone.
- The admin panel finally shows the messages. It was write-only: the note reached the database and stopped there.

## Deploying

`Reservation.message` is a new optional column — run `astro db push --remote` before deploying. Non-breaking, no data loss.

## Testing

- 27 browser scenarios driven through Chromium: own vs. other visitor, EN/RU, light/dark, 390 / 768 / 1280 viewports, message persistence across reloads, delete path, reservation-cancel path, and a forged `setReservationMessage` against someone else's reservation (403).
- Verified the visitor id appears nowhere in the SSR HTML or the API response, and that another visitor's DOM never contains the message.
- `astro check` 0 errors, `bun test` 12/12, production build passes.

One thing left out deliberately: the old branch's `db/seed.ts` also added a dev-seed item ("Begotten T-Shirt", id 67) unrelated to this feature. Say the word if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XBcMhcAhttBgGmPHcvSY5b