### PR TITLE
The frost leaves with the tint

### DIFF
--- a/src/components/LangSwitcher.astro
+++ b/src/components/LangSwitcher.astro
@@ -165,7 +165,6 @@ const { storageKey, size = "sm" } = Astro.props;
     .lang-switcher.kit-toggle-group {
       background-color: light-dark(#f0f0f0, #2a2a2e);
       background-image: none;
-      backdrop-filter: none;
     }
   }
 </style>

--- a/src/components/travel/TravelMap.astro
+++ b/src/components/travel/TravelMap.astro
@@ -199,13 +199,6 @@ const { mode = "globe" } = Astro.props;
     }
   }
 
-  @media (prefers-reduced-transparency: reduce) {
-    /* The opaque tint comes from --glass-bg-on-media, which goes solid here. */
-    .city-label-overlay {
-      backdrop-filter: none;
-    }
-  }
-
   /* iOS Safari specific fixes. Scope to iOS only: -webkit-touch-callout is
      iOS-exclusive, whereas -webkit-appearance also matches desktop Chrome.
      Everything in here establishes a containing block, which resets the

--- a/src/components/wishlist/MobileFilterBar.astro
+++ b/src/components/wishlist/MobileFilterBar.astro
@@ -224,7 +224,6 @@ const hasEndSlot = Astro.slots.has("end");
   @media (prefers-reduced-transparency: reduce) {
     .mobile-filter-bar {
       background: light-dark(#ffffff, #1e1e20);
-      backdrop-filter: none;
     }
   }
 

--- a/src/pages/kit/index.astro
+++ b/src/pages/kit/index.astro
@@ -250,20 +250,30 @@ import { Icon } from "astro-icon/components";
           The <strong>frost</strong> goes the same way:
           <code>--glass-filter</code> and <code>--veil-filter</code> both become
           <code>none</code> here, so anything drawing its blur from a token
-          loses it without being asked. Nothing that reaches for the tokens owes
-          a fallback at all.
+          loses it without being asked.
         </p>
         <p>
-          What still owes one is a surface that blurs with a
-          <em>literal</em> — <code>backdrop-filter: blur(10px)</code> written
-          out rather than taken from <code>--glass-filter</code>. A token can't
-          reach a value that never referred to it, so those two
-          (<code>.priority-badge</code>, the kit modal's scrim) carry their own
-          <code>backdrop-filter: none</code>. A bespoke tint owes one too: the
-          mobile filter bar and the language switcher both set a background of
-          their own, so they each name the opaque version of it. If you find
-          yourself writing a blur radius by hand, that is the moment to ask
-          whether the token would do.
+          The chrome <strong>tint</strong> is the one that doesn't follow.
+          <code>--glass-bg</code> stays translucent under this media feature, so
+          a chrome surface still names its own opaque colour — which is exactly
+          what <code>.liquid-glass</code> does on your behalf if you use the
+          utility, and what the reserve button, the random-item die, the
+          language switcher and the floating tooltip each do by hand because
+          they can't. Reach for the utility and this is already handled; write
+          the recipe out and the tint is yours to finish.
+        </p>
+        <p>
+          A blur written as a <em>literal</em> is the other case:
+          <code>backdrop-filter: blur(10px)</code> spelled out rather than taken
+          from <code>--glass-filter</code>. A token can't reach a value that
+          never referred to it, so <code>.priority-badge</code> and the kit
+          modal's scrim carry their own <code>backdrop-filter: none</code>. Four
+          more surfaces blur with a literal and have
+          <strong>no fallback at all</strong> — the admin modal, toast and item
+          card, and the blog's back-to-top button. That is a gap, not a rule;
+          they are listed here so the next person doesn't have to rediscover
+          them. If you find yourself writing a blur radius by hand, that is the
+          moment to ask whether the token would do.
         </p>
       </section>
 

--- a/src/pages/kit/index.astro
+++ b/src/pages/kit/index.astro
@@ -247,13 +247,23 @@ import { Icon } from "astro-icon/components";
           handles itself entirely.
         </p>
         <p>
-          What a hand-rolled recipe still owes is the
-          <strong>frost</strong>: <code>--glass-filter</code> deliberately stays
-          a blur, because a few chrome surfaces have no opaque tint of their own
-          yet, and taking the frost off a 0.55 tint would leave them more
-          transparent rather than less. So anything setting
-          <code>backdrop-filter: var(--glass-filter)</code> by hand owes a
-          <code>backdrop-filter: none</code> — the demo tile above included.
+          The <strong>frost</strong> goes the same way:
+          <code>--glass-filter</code> and <code>--veil-filter</code> both become
+          <code>none</code> here, so anything drawing its blur from a token
+          loses it without being asked. Nothing that reaches for the tokens owes
+          a fallback at all.
+        </p>
+        <p>
+          What still owes one is a surface that blurs with a
+          <em>literal</em> — <code>backdrop-filter: blur(10px)</code> written
+          out rather than taken from <code>--glass-filter</code>. A token can't
+          reach a value that never referred to it, so those two
+          (<code>.priority-badge</code>, the kit modal's scrim) carry their own
+          <code>backdrop-filter: none</code>. A bespoke tint owes one too: the
+          mobile filter bar and the language switcher both set a background of
+          their own, so they each name the opaque version of it. If you find
+          yourself writing a blur radius by hand, that is the moment to ask
+          whether the token would do.
         </p>
       </section>
 
@@ -1046,16 +1056,6 @@ import { Icon } from "astro-icon/components";
     font-size: 0.85rem;
     font-weight: 600;
     color: light-dark(#333, #fafafa);
-  }
-
-  /* The tints all live on the tokens and go solid on their own. What a
-     hand-rolled recipe still owes is the frost: --glass-filter stays a blur
-     under reduced transparency, because a couple of chrome consumers have no
-     opaque fallback yet and would come out worse without it. */
-  @media (prefers-reduced-transparency: reduce) {
-    .glass-demo__tile--media {
-      backdrop-filter: none;
-    }
   }
 
   .glass-tokens {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -132,19 +132,28 @@
        derived from the page: the tint stays dark whatever the scheme, exactly
        as it does at full transparency. This is the value its three consumers —
        the wishlist badge, the map's city label, and /kit's own demo — had each
-       arrived at separately, one of them at a different number.
-
-       Only the tint moves here. --glass-filter stays a blur on purpose: a
-       couple of chrome consumers still have no opaque fallback of their own,
-       and taking the frost off a 0.55 tint would leave them more transparent
-       than they are today, not less. */
+       arrived at separately, one of them at a different number. */
     --glass-bg-on-media: rgb(24, 24, 28);
+
+    /* And the frost, which every consumer of it wanted gone here anyway. Ten
+       rules were carrying their own `backdrop-filter: none` to say so — the
+       same decision written ten times, with no way for any copy to be right
+       when another was wrong.
+
+       This is safe to do from the token precisely because none of those rules
+       was only turning off the blur: each also names an opaque tint, so no
+       surface is left translucent-without-frost, which would be a worse place
+       to land than where they started. What still needs a hand-written
+       fallback is the two surfaces that blur with a literal rather than this
+       token — .priority-badge and the kit modal's scrim — since a token can't
+       reach a value that never referred to it. */
+    --glass-filter: none;
   }
 
+  /* Just the tint and the sheen now; the frost left with the token. */
   .liquid-glass {
     background-color: light-dark(#f0f0f0, #2a2a2e);
     background-image: none;
-    backdrop-filter: none;
   }
 }
 
@@ -882,7 +891,6 @@ a.btn-danger:active {
   .floating-tooltip {
     background-color: light-dark(#f0f0f0, #2a2a2e);
     background-image: none;
-    backdrop-filter: none;
   }
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -143,10 +143,20 @@
        This is safe to do from the token precisely because none of those rules
        was only turning off the blur: each also names an opaque tint, so no
        surface is left translucent-without-frost, which would be a worse place
-       to land than where they started. What still needs a hand-written
-       fallback is the two surfaces that blur with a literal rather than this
-       token — .priority-badge and the kit modal's scrim — since a token can't
-       reach a value that never referred to it. */
+       to land than where they started.
+
+       Note what does NOT move: --glass-bg stays translucent here, so a chrome
+       surface still owes its own opaque colour. .liquid-glass pays that for
+       anything using the utility; the handful that re-declare the recipe
+       instead — the floating tooltip below, the reserve button and random-item
+       die in wishlist.css, the language switcher, the mobile filter bar — each
+       name theirs by hand.
+
+       Nor does this reach a blur written as a literal, since a token can't
+       reach a value that never referred to it. Two such surfaces have a
+       hand-written fallback (.priority-badge, the kit modal's scrim) and four
+       have none at all — the admin modal, toast and item card, and the blog's
+       back-to-top button. Those four are an existing gap, recorded on /kit. */
     --glass-filter: none;
   }
 

--- a/src/styles/kit/badge.css
+++ b/src/styles/kit/badge.css
@@ -179,4 +179,3 @@
     border: 1px solid currentColor;
   }
 }
-

--- a/src/styles/kit/badge.css
+++ b/src/styles/kit/badge.css
@@ -180,9 +180,3 @@
   }
 }
 
-@media (prefers-reduced-transparency: reduce) {
-  /* The opaque tint comes from --glass-bg-on-media, which goes solid here. */
-  .kit-badge--glass {
-    backdrop-filter: none;
-  }
-}

--- a/src/styles/wishlist.css
+++ b/src/styles/wishlist.css
@@ -889,7 +889,6 @@
   .reserve-btn {
     background: light-dark(#f0f0f0, #3a3a3a);
     background-image: none;
-    backdrop-filter: none;
   }
 
   .reserve-btn.own-reservation {
@@ -898,7 +897,6 @@
 
   .reserve-btn.own-reservation:hover {
     background: light-dark(#dcdcdc, #505050);
-    backdrop-filter: none;
   }
 
   /* Random button. The lit override matters: the lit rule re-pins the
@@ -910,7 +908,6 @@
   .kit-btn.mobile-filter-random:is(:hover, :focus-visible):not(:disabled) {
     background-color: light-dark(#fff, #2a2a2d);
     background-image: none;
-    backdrop-filter: none;
     border-color: light-dark(#e0e0e0, #444);
   }
 }


### PR DESCRIPTION
Follow-up to #39, which got this half right and then argued itself out of the other half.

## The correction

#39 moved the on-media tint onto `--glass-bg-on-media` and deliberately left `--glass-filter` alone, on the stated grounds that *"a couple of chrome consumers still have no opaque fallback of their own"* — so dropping their frost would leave them translucent-without-blur, worse than where they started.

There are no such consumers. Every surface drawing on `--glass-bg` names an opaque tint under `prefers-reduced-transparency`:

| Surface | Its fallback |
|---|---|
| `.liquid-glass` | `global.css` |
| `.floating-tooltip` | `global.css` |
| `.reserve-btn` (+ own-reservation states) | `wishlist.css` |
| `.kit-btn.filter-random` / `.mobile-filter-random` (+ hover/focus) | `wishlist.css` |
| `.lang-switcher` | `LangSwitcher.astro` |

The claim in #39 came from reading the first twenty-five lines of a ninety-line media query and assuming the rest of it wasn't there. The comment stating it and the `/kit` paragraph repeating it both shipped, so this PR is partly about deleting two pieces of documentation that are false about the codebase they document.

## What changes

`--glass-filter: none` under reduced transparency, and the **ten** rules that each carried their own `backdrop-filter: none` to say the same thing stop carrying it. One decision in one place instead of ten copies, none of which could be right while another was wrong.

This is safe from the token precisely because none of those ten was *only* turning off a blur — each also names an opaque tint. Nothing lands translucent-with-no-frost, which is the state the original worry was actually about.

Four of the ten were the entire body of their media query, so the query goes too: the wishlist badge, the map's city label, `/kit`'s demo tile, and — the one that shows the rule working — the demo tile #39 added specifically to demonstrate that a hand-rolled recipe owes its own fallback. It no longer owes one.

## What still owes a fallback

Two surfaces blur with a **literal** rather than the token, and a token can't reach a value that never referred to it:

- `.priority-badge` — `blur(10px)`, inside a `(hover: hover)` query
- the kit modal's scrim — `blur(4px)`

Both keep their `backdrop-filter: none`, and `/kit` now names them and says why. A bespoke *tint* still owes one as well — the mobile filter bar and the language switcher each set their own background, so each names the opaque version.

(`.reserve-btn.received` also keeps a `backdrop-filter: none`, but that one was never a reduced-transparency fallback — it's a normal-state override for the solid success pill.)

## Verification

`astro check` 0 errors, `bun test` 12/12, production build passes. No behavioural change intended: every surface renders the same at full transparency, and the same opaque way under `prefers-reduced-transparency: reduce` — reached from one place instead of ten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017hJgQNc5hnV9pMqE7u9z6e