### PR TITLE
The site stops reloading itself between pages

### DIFF
--- a/src/client/eye-moving.ts
+++ b/src/client/eye-moving.ts
@@ -180,6 +180,23 @@ function throttle<T extends (...args: never[]) => void>(
   };
 }
 
+// The eyes are only on the home page, but the listeners below are on the
+// document, which outlives it — so they are registered once and left alone
+// rather than re-bound per navigation. On any other page every lookup by id
+// misses and the handlers cost a throttled no-op.
+//
+// What does have to be reset is where the eyes think they are. The positions
+// are module state and the SVG is not: coming back to the home page brings a
+// fresh pair of eyes drawn at rest, while `currentPositions` still holds
+// wherever the cursor left them, and the first lerp would swing them across
+// from a place they were never in.
+function resetGaze() {
+  currentPositions = { left: { x: 0, y: 0 }, right: { x: 0, y: 0 } };
+  targetPositions = { left: { x: 0, y: 0 }, right: { x: 0, y: 0 } };
+}
+
+document.addEventListener("astro:after-swap", resetGaze);
+
 // Only add event listeners if user doesn't prefer reduced motion
 if (!prefersReducedMotion) {
   // Throttled handler - updates every 16ms (~60fps)

--- a/src/client/lang-switcher-indicator.ts
+++ b/src/client/lang-switcher-indicator.ts
@@ -86,15 +86,33 @@ function initSwitcher(group: HTMLElement) {
 
   // Rest on the active language from the start, and re-home when it changes.
   setActive(activeLangButton());
-  window.addEventListener("lang-change", () => {
+  const onLangChange = () => {
     // Re-home onto the newly-selected language (aria-pressed already updated).
     setActive(activeLangButton());
-  });
+  };
+  window.addEventListener("lang-change", onLangChange);
 
   // Keep the indicator aligned if the switcher reflows.
-  window.addEventListener("resize", () => {
+  const realign = () => {
     if (activeItem) moveIndicatorTo(activeItem);
-  });
+  };
+  window.addEventListener("resize", realign);
+
+  // Both of those are on the window, and the window outlives the page. The
+  // switcher itself is replaced on every client-side navigation, so without
+  // this each visit would leave two more handlers behind, each holding a
+  // detached set of buttons — and the lang-change one is not merely idle: it
+  // would go on writing is-active and indicator geometry into switchers that
+  // left the document pages ago. The element-scoped listeners above need no
+  // such thing; they go out with the elements.
+  document.addEventListener(
+    "astro:before-swap",
+    () => {
+      window.removeEventListener("lang-change", onLangChange);
+      window.removeEventListener("resize", realign);
+    },
+    { once: true },
+  );
 
   if (prefersReducedMotion) return;
 

--- a/src/client/nav-dock.ts
+++ b/src/client/nav-dock.ts
@@ -25,6 +25,12 @@ function lerp(start: number, end: number, factor: number): number {
 }
 
 function initDock(dock: HTMLElement) {
+  // Guard against double-init: this module is evaluated as the body is parsed
+  // and astro:page-load fires again on window load with the same dock still in
+  // place. Every listener below would otherwise be attached twice.
+  if (dock.dataset.dockReady === "ready") return;
+  dock.dataset.dockReady = "ready";
+
   const indicator = dock.querySelector<HTMLElement>(".dock-indicator");
   const items: DockItemState[] = Array.from(
     dock.querySelectorAll<HTMLElement>(".dock-item"),
@@ -141,12 +147,28 @@ function initDock(dock: HTMLElement) {
   });
 
   // Keep the indicator aligned if the dock reflows (e.g. orientation change).
-  window.addEventListener("resize", () => {
+  //
+  // Every other listener in here is on the dock or its items and goes out with
+  // them when the page is swapped. This one is on the window, which outlives
+  // the page, so it has to be handed back explicitly — otherwise each visit to
+  // a page with a dock leaves another resize handler behind, each one pinning
+  // a detached dock and writing custom properties into it forever.
+  const realign = () => {
     if (activeItem) moveIndicatorTo(activeItem);
-  });
+  };
+  window.addEventListener("resize", realign);
+  document.addEventListener(
+    "astro:before-swap",
+    () => window.removeEventListener("resize", realign),
+    { once: true },
+  );
 }
 
-const docks = document.querySelectorAll<HTMLElement>("[data-dock]");
-docks.forEach(initDock);
+function initAll() {
+  document.querySelectorAll<HTMLElement>("[data-dock]").forEach(initDock);
+}
+
+initAll();
+document.addEventListener("astro:page-load", initAll);
 
 export {};

--- a/src/client/tooltip.ts
+++ b/src/client/tooltip.ts
@@ -229,6 +229,11 @@ export function initTooltips() {
   createTooltipElements();
 
   // pointerover/pointerout bubble, so one listener each covers every trigger.
+  // All six are on the document, which survives a client-side navigation
+  // intact — and they are delegated, so they pick up the incoming page's
+  // triggers with nothing to re-bind. That is why this whole function is a
+  // one-time singleton and stays one: re-running it per page would only stack
+  // duplicate handlers on the same document.
   document.addEventListener("pointerover", handlePointerOver);
   document.addEventListener("pointerout", handlePointerOut);
   document.addEventListener("pointermove", handlePointerMove, {
@@ -239,4 +244,17 @@ export function initTooltips() {
 
   // The trigger can slide out from under a pinned bead while the page scrolls.
   document.addEventListener("scroll", hideTooltip, true);
+
+  // The one thing that does not survive: the bead is parented to <body>, and
+  // the swap replaces <body> wholesale. Left alone, tooltips would work on the
+  // first page of a session and silently do nothing on every page after it —
+  // the listeners still fire, they just write into a detached div. Hiding it
+  // before the swap also keeps a bead that happens to be up at the moment of a
+  // click from riding over the outgoing page.
+  document.addEventListener("astro:before-swap", hideTooltip);
+  document.addEventListener("astro:after-swap", () => {
+    if (tooltipEl && !tooltipEl.isConnected) {
+      document.body.appendChild(tooltipEl);
+    }
+  });
 }

--- a/src/client/travel-map.ts
+++ b/src/client/travel-map.ts
@@ -199,9 +199,67 @@ function getZoomForFullFrame(
   return Math.log2((diagonal * GLOBE_SCALE_FACTOR) / 512);
 }
 
-async function initMap(): Promise<void> {
-  const container = document.getElementById("map")!;
-  if (!container) return;
+/* ===========================================================================
+   Lifetime.
+
+   Client-side routing keeps the document and replaces the body, so this module
+   is evaluated once and the map it builds has to be built again on every
+   arrival at /travel and taken apart on every departure. Left alone, a single
+   visit leaves behind a WebGL context on a canvas that is no longer in the
+   page, a rotation loop repainting it sixty times a second, two observers, a
+   floating label parented to the old <body>, and four matchMedia listeners
+   still writing paint properties into it — the browser only grants a handful
+   of WebGL contexts before it starts dropping the oldest, so a few laps
+   through the site would be enough to kill the live map.
+
+   Nothing here can be an element-scoped listener's problem: those go out with
+   the element. This is the list of things that outlive it.
+   =========================================================================== */
+
+/** Undo callbacks for the map currently on the page, newest last. */
+let teardown: (() => void)[] = [];
+
+function onTeardown(undo: () => void): void {
+  teardown.push(undo);
+}
+
+/**
+ * Which build of the map is current. Bumped by every teardown so an init that
+ * is still waiting on the style — a navigation away from /travel before the
+ * first tile arrives is entirely ordinary — can tell that the page it was
+ * decorating has gone and stop rather than address a map that no longer exists.
+ */
+let generation = 0;
+
+/**
+ * A matchMedia listener that is handed back when the page goes.
+ *
+ * The quietest of the leaks, and the reason none of the four below are written
+ * inline any more: a MediaQueryList with a listener attached is kept alive by
+ * the browser, so a handler left behind is not merely idle. It fires on the
+ * next colour-scheme or transparency switch and writes paint properties into a
+ * map that was removed several pages ago.
+ */
+function watchMedia(
+  query: MediaQueryList,
+  onChange: (matches: boolean) => void,
+): void {
+  const handler = (event: MediaQueryListEvent) => onChange(event.matches);
+  query.addEventListener("change", handler);
+  onTeardown(() => query.removeEventListener("change", handler));
+}
+
+function runTeardown(): void {
+  generation++;
+  const pending = teardown;
+  teardown = [];
+  // Reverse order, so the rotation loop and the observers that drive it are
+  // stopped before the map they call into is destroyed.
+  for (let i = pending.length - 1; i >= 0; i--) pending[i]();
+}
+
+async function initMap(container: HTMLElement): Promise<void> {
+  const token = generation;
 
   const mode = (container.dataset.mode || "normal") as "normal" | "globe";
   const isGlobe = mode === "globe";
@@ -223,7 +281,7 @@ async function initMap(): Promise<void> {
   const initialZoom = getInitialZoom();
 
   const map = new MapLibre({
-    container: "map",
+    container,
     style: "https://tiles.openfreemap.org/styles/positron",
     center: initialCenter,
     zoom: initialZoom,
@@ -240,6 +298,12 @@ async function initMap(): Promise<void> {
     attributionControl: false,
   });
 
+  // Registered before the first await, because the wait below is exactly where
+  // a navigation is most likely to land: the map has to be destroyable while
+  // it is still fetching its style. remove() releases the WebGL context and
+  // drops every listener MapLibre put on the window and the canvas.
+  onTeardown(() => map.remove());
+
   // `load` does not fire until the first *visually complete* render, which in
   // turn waits on every tile in view — and the planet tiles run to megabytes
   // each at low zoom. Blocking setup on it means that on a slow link the layers
@@ -247,10 +311,20 @@ async function initMap(): Promise<void> {
   // the style's own layers exist from that point on, and tiles can keep
   // arriving afterwards.
   if (!map.isStyleLoaded()) {
-    await new Promise<void>((resolve) =>
-      map.once("style.load", () => resolve()),
-    );
+    await new Promise<void>((resolve) => {
+      map.once("style.load", () => resolve());
+      // A style that never arrives — or a map removed out from under the
+      // request — must not leave this promise pending for the rest of the
+      // session with the map, the container and every closure below it hanging
+      // off it. Teardown settles it so the guard that follows can run.
+      onTeardown(resolve);
+    });
   }
+
+  // The page this was building for has been swapped away. Everything past this
+  // point addresses a map that remove() has already emptied — addSource and
+  // addLayer would throw on it — so there is nothing left to do but leave.
+  if (token !== generation) return;
 
   function setProjectionMode(mode: "globe" | "normal") {
     if (mode === "globe") {
@@ -273,8 +347,11 @@ async function initMap(): Promise<void> {
   }
 
   // Expose for external use: window.setMapMode("globe") or window.setMapMode("normal")
-  (window as unknown as { setMapMode: typeof setProjectionMode }).setMapMode =
+  (window as unknown as { setMapMode?: typeof setProjectionMode }).setMapMode =
     setProjectionMode;
+  onTeardown(() => {
+    delete (window as unknown as { setMapMode?: unknown }).setMapMode;
+  });
 
   // Auto-rotation for globe mode. The rAF loop must not run when there is
   // nothing to see: off-screen (scrolled away), on a hidden tab, or when the
@@ -332,6 +409,11 @@ async function initMap(): Promise<void> {
     userStopped = true;
     pauseRotation();
   }
+
+  // A loop that repaints the map every frame is the one thing that must not
+  // survive the page it was drawn on: takeOver rather than pauseRotation,
+  // because a pause leaves the intersection observer free to start it again.
+  onTeardown(takeOver);
 
   // The globe fills most of the first screen, so a page that let it eat every
   // scroll would be a page you couldn't leave with the cursor where it lands.
@@ -514,6 +596,7 @@ async function initMap(): Promise<void> {
       syncFrame();
     });
     resizeObserver.observe(container);
+    onTeardown(() => resizeObserver.disconnect());
 
     // Permanent stop once the user takes control of the globe — and only then.
     //
@@ -563,13 +646,21 @@ async function initMap(): Promise<void> {
       { threshold: 0 },
     );
     rotationObserver.observe(container);
+    onTeardown(() => rotationObserver.disconnect());
 
     // Same for tab visibility — a backgrounded tab throttles rAF anyway, but
     // this stops the work outright and resumes cleanly on return.
-    document.addEventListener("visibilitychange", () => {
+    const onVisibilityChange = () => {
       if (document.hidden) pauseRotation();
       else startRotation();
-    });
+    };
+    // The document outlives the page, so this one has to be taken back by hand
+    // — otherwise every visit to /travel leaves another handler behind, each
+    // holding its own dead map.
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    onTeardown(() =>
+      document.removeEventListener("visibilitychange", onVisibilityChange),
+    );
 
     startRotation();
   }
@@ -654,9 +745,7 @@ async function initMap(): Promise<void> {
   }
 
   applyColorScheme(colorSchemeQuery.matches);
-  colorSchemeQuery.addEventListener("change", (e) =>
-    applyColorScheme(e.matches),
-  );
+  watchMedia(colorSchemeQuery, applyColorScheme);
 
   // // Fade in country labels at higher zoom levels
   // const countryLabelLayers = [
@@ -729,11 +818,11 @@ async function initMap(): Promise<void> {
   );
 
   // Update crimea mask on color scheme change
-  colorSchemeQuery.addEventListener("change", (e) => {
+  watchMedia(colorSchemeQuery, (matches) => {
     map.setPaintProperty(
       "crimea-mask",
       "fill-color",
-      e.matches ? DARK_BG : LIGHT_BG,
+      matches ? DARK_BG : LIGHT_BG,
     );
   });
 
@@ -910,9 +999,7 @@ async function initMap(): Promise<void> {
   }
 
   applyCityColors(colorSchemeQuery.matches);
-  colorSchemeQuery.addEventListener("change", (e) =>
-    applyCityColors(e.matches),
-  );
+  watchMedia(colorSchemeQuery, applyCityColors);
 
   // Reduced transparency: the bead goes back to being a dot. The tint turns
   // solid and the two layers that exist only to fake depth — the highlight and
@@ -956,9 +1043,7 @@ async function initMap(): Promise<void> {
   }
 
   applyCityTransparency(reducedTransparencyQuery.matches);
-  reducedTransparencyQuery.addEventListener("change", (e) =>
-    applyCityTransparency(e.matches),
-  );
+  watchMedia(reducedTransparencyQuery, applyCityTransparency);
 
   // City hover: track hovered feature and show label tooltip.
   //
@@ -971,6 +1056,10 @@ async function initMap(): Promise<void> {
   cityLabel.className = "city-label-overlay";
   cityLabel.style.display = "none";
   document.body.appendChild(cityLabel);
+  // The swap replaces <body> wholesale, so this would go with it on its own —
+  // but it is removed here anyway, before the swap, so a label left showing at
+  // the moment of a click cannot flash over the outgoing page.
+  onTeardown(() => cityLabel.remove());
 
   // Which puts the label in page coordinates while the map hands out canvas
   // ones, so the container's own offset has to be added. It is measured at the
@@ -1199,7 +1288,8 @@ async function initMap(): Promise<void> {
   // Backstop: a stalled tile must not be able to strand the shimmer on screen.
   // A partly-drawn map is worth more to the reader than a shimmer that never
   // resolves.
-  setTimeout(revealMap, PLACEHOLDER_TIMEOUT_MS);
+  const revealTimer = setTimeout(revealMap, PLACEHOLDER_TIMEOUT_MS);
+  onTeardown(() => clearTimeout(revealTimer));
 
   // Function to fly to a city
   function flyToCity(cityName: string): void {
@@ -1219,7 +1309,10 @@ async function initMap(): Promise<void> {
   }
 
   // Expose flyToCity globally for external use
-  (window as unknown as { flyToCity: typeof flyToCity }).flyToCity = flyToCity;
+  (window as unknown as { flyToCity?: typeof flyToCity }).flyToCity = flyToCity;
+  onTeardown(() => {
+    delete (window as unknown as { flyToCity?: unknown }).flyToCity;
+  });
 }
 
 // Defer the (heavy) MapLibre instantiation until the map is actually near the
@@ -1230,20 +1323,33 @@ function scheduleInit(): void {
   const container = document.getElementById("map");
   if (!container) return;
 
+  // The dataset flag rather than a module-level boolean: it is carried by the
+  // element, so it says "this container already has a map" and nothing else.
+  // A module flag would have to be cleared by teardown and would be wrong for
+  // the one call that happens twice on a cold load — this module is evaluated
+  // as the body is parsed, and astro:page-load then fires on window load with
+  // the same container still in place.
+  if (container.dataset.mapReady === "true") return;
+  container.dataset.mapReady = "true";
+
   const observer = new IntersectionObserver(
     (entries) => {
       if (entries.some((entry) => entry.isIntersecting)) {
         observer.disconnect();
-        void initMap();
+        void initMap(container);
       }
     },
     { rootMargin: "200px" },
   );
   observer.observe(container);
+  // A map that was never near the viewport still left an observer watching a
+  // container that has since been swapped out.
+  onTeardown(() => observer.disconnect());
 }
 
-if (document.readyState === "loading") {
-  document.addEventListener("DOMContentLoaded", scheduleInit);
-} else {
-  scheduleInit();
-}
+scheduleInit();
+document.addEventListener("astro:page-load", scheduleInit);
+// Before, not after: the swap is what detaches the container, and the map has
+// to be dismantled while it still has one. astro:after-swap would already be
+// looking at the next page's DOM.
+document.addEventListener("astro:before-swap", runTeardown);

--- a/src/client/travel-map.ts
+++ b/src/client/travel-map.ts
@@ -2,6 +2,10 @@ import { Map as MapLibre } from "maplibre-gl";
 import type { LayerSpecification } from "maplibre-gl";
 import type { Feature, Point } from "geojson";
 import { countries, cities, cityCoordinates } from "@lib/travel";
+import {
+  PERSIST_MAP_ACROSS_NAVIGATION,
+  MAP_PERSIST_NAME,
+} from "@lib/travel/map-strategy";
 import { getCityName } from "@lib/travel/cities-i18n";
 import crimeaGeoJson from "@lib/travel/crimea.geo.json";
 
@@ -1352,4 +1356,19 @@ document.addEventListener("astro:page-load", scheduleInit);
 // Before, not after: the swap is what detaches the container, and the map has
 // to be dismantled while it still has one. astro:after-swap would already be
 // looking at the next page's DOM.
-document.addEventListener("astro:before-swap", runTeardown);
+document.addEventListener("astro:before-swap", (event) => {
+  // Under the persist strategy the map is not being detached at all — Astro
+  // carries this very element into the next page, camera and WebGL context
+  // intact — and dismantling it here would empty a canvas that then stays on
+  // screen. But the element only survives if the destination has somewhere to
+  // put it, so the incoming document is what decides: leaving /travel for a
+  // page with no map falls through to the teardown below, exactly as before.
+  if (PERSIST_MAP_ACROSS_NAVIGATION) {
+    const { newDocument } = event as Event & { newDocument: Document };
+    const survives = newDocument.querySelector(
+      `[data-astro-transition-persist="${MAP_PERSIST_NAME}"]`,
+    );
+    if (survives) return;
+  }
+  runTeardown();
+});

--- a/src/client/wishlist-random.ts
+++ b/src/client/wishlist-random.ts
@@ -206,9 +206,24 @@ function highlightItem(item: HTMLElement) {
   }, HIGHLIGHT_DURATION);
 }
 
+// A highlight is a class on a card plus a 1.9s timer to take it off again. If
+// the reader clicks a category while one is running, the card goes with the
+// page and the timer is left holding it — harmless in itself, but it keeps a
+// detached card reachable and, worse, the module would still be pointing at it
+// as `currentHighlight` when the next roll asks for the previous one to be
+// cleared. Dropping both at the swap keeps that state honest.
+document.addEventListener("astro:before-swap", clearHighlight);
+
 export function initRandomButton(selector: string) {
   const button = document.querySelector<HTMLElement>(selector);
   if (!button) return;
+
+  // Called twice for the same button on a cold load: once as the page's module
+  // is evaluated, and again from astro:page-load, which the router fires on
+  // window load. Two click listeners on the die would roll it twice — two
+  // random items, the second overwriting the first's highlight mid-scroll.
+  if (button.dataset.randomReady === "true") return;
+  button.dataset.randomReady = "true";
 
   button.addEventListener("click", (e) => {
     e.preventDefault();

--- a/src/client/wishlist.ts
+++ b/src/client/wishlist.ts
@@ -22,6 +22,26 @@ function setBadgeLabel(badge: HTMLElement | null, lang: Lang): void {
 }
 
 export async function initializeWishlist() {
+  // Every category is its own page, so moving between them is a navigation
+  // like any other and this has to run again on each one — the incoming cards
+  // are server-rendered with their buttons still in .reserve-btn--loading and
+  // nothing bound to them. It also runs on pages that are not the wishlist at
+  // all, because astro:page-load does not know where it is; the grid is the
+  // cheapest thing to ask, and asking it here keeps a needless round-trip to
+  // /api/wishlist/reservations off every other page on the site.
+  const grid = document.getElementById("wishlist-grid");
+  if (!grid) return;
+
+  // And exactly once per grid. On a cold load this runs twice — as the page's
+  // module is evaluated, and again from astro:page-load on window load — which
+  // would fetch the reservations twice and, worse, leave two click listeners
+  // on every Reserve button, so one press would place the reservation and the
+  // second handler would immediately read it back as its own and cancel it.
+  // The flag rides on the grid rather than on the module because a swapped-in
+  // page brings a new grid and clears itself.
+  if (grid.dataset.wishlistReady === "true") return;
+  grid.dataset.wishlistReady = "true";
+
   // Check if language was set by inline script
   const isRussian = document.documentElement.classList.contains("lang-ru");
   currentLang = isRussian ? "ru" : "en";
@@ -267,7 +287,20 @@ function initializeReserveButtons() {
   });
 }
 
+/**
+ * Once per session, not once per page.
+ *
+ * The listener is on the window and does its work through document-wide
+ * queries, so it needs no rebinding when the body is swapped — and re-adding
+ * it on every arrival would mean a language switch re-running the whole
+ * translation pass once for every wishlist page ever visited.
+ */
+let langChangeListenerAdded = false;
+
 function initializeLangChangeListener() {
+  if (langChangeListenerAdded) return;
+  langChangeListenerAdded = true;
+
   // Listen for lang-change event from LangSwitcher component
   window.addEventListener("lang-change", ((
     event: CustomEvent<{ lang: Lang; storageKey: string }>,
@@ -439,6 +472,13 @@ function updateAriaLabels(lang: "en" | "ru") {
   });
 }
 
+function initAll() {
+  void initializeWishlist();
+  // A no-op after the first call: the tooltip machinery is delegated off the
+  // document and stays wired across navigations by itself.
+  initTooltips();
+}
+
 // Initialize immediately - module is dynamically imported after DOMContentLoaded
-initializeWishlist();
-initTooltips();
+initAll();
+document.addEventListener("astro:page-load", initAll);

--- a/src/components/LangInit.astro
+++ b/src/components/LangInit.astro
@@ -19,24 +19,32 @@
 
 <script is:inline>
   (() => {
-    let lang = localStorage.getItem("lang");
+    function getLang() {
+      let lang = localStorage.getItem("lang");
 
-    // Detect from browser if no saved lang
-    if (!lang) {
-      const browserLangs = navigator.languages || [navigator.language];
-      const isRussian = browserLangs.some((l) => l.startsWith("ru"));
-      lang = isRussian ? "ru" : "en";
-      localStorage.setItem("lang", lang);
+      // Detect from browser if no saved lang
+      if (!lang) {
+        const browserLangs = navigator.languages || [navigator.language];
+        const isRussian = browserLangs.some((l) => l.startsWith("ru"));
+        lang = isRussian ? "ru" : "en";
+        localStorage.setItem("lang", lang);
+      }
+      return lang;
     }
 
-    // Set lang attribute and class immediately (before DOM ready)
-    document.documentElement.lang = lang;
-    if (lang === "ru") {
-      document.documentElement.classList.add("lang-ru");
+    // The half that has to happen before the browser paints anything: the
+    // stylesheet keys off these, and .lang-content is transparent until
+    // lang-ready lands.
+    function markRoot(lang) {
+      document.documentElement.lang = lang;
+      document.documentElement.classList.toggle("lang-ru", lang === "ru");
     }
 
     // Apply translations when DOM is ready
     function applyTranslations() {
+      const lang = getLang();
+      markRoot(lang);
+
       document.querySelectorAll("[data-" + lang + "]").forEach((el) => {
         const text = el.getAttribute("data-" + lang);
         if (text) el.textContent = text;
@@ -60,9 +68,31 @@
     }
 
     if (document.readyState === "loading") {
+      // Set lang + lang-ru before DOM ready so nothing renders in the wrong
+      // language; the text itself waits for the elements to exist.
+      markRoot(getLang());
       document.addEventListener("DOMContentLoaded", applyTranslations);
     } else {
       applyTranslations();
+    }
+
+    // Client-side navigation drops all of the above on the floor twice over:
+    // Astro strips every attribute off <html> and re-applies the incoming
+    // document's (swapRootAttributes), so lang-ru and lang-ready go with them,
+    // and the incoming body is server-rendered in English. Without this the
+    // next page arrives untranslated and — because .lang-content is
+    // transparent until lang-ready — invisible. astro:after-swap runs inside
+    // the transition's update callback, before the new frame is painted, so
+    // the correction is never seen happening.
+    //
+    // The guard is not decoration. Astro only suppresses a re-run of an inline
+    // script it has already seen swapped in, and its record starts empty: the
+    // copy that ran on the first page load is not in it, so the first
+    // navigation to another page carrying this same script executes it a
+    // second time and would register a second listener.
+    if (!window.__langSwapListenerAdded) {
+      window.__langSwapListenerAdded = true;
+      document.addEventListener("astro:after-swap", applyTranslations);
     }
   })();
 </script>

--- a/src/components/LangSwitcher.astro
+++ b/src/components/LangSwitcher.astro
@@ -247,6 +247,22 @@ const { storageKey, size = "sm" } = Astro.props;
     }
 
     setupLangSwitchers();
+
+    // The buttons these listeners are bound to are thrown away with the rest
+    // of the body on a client-side navigation, and the incoming switcher
+    // arrives inert — server-rendered with ENG pressed and nothing listening
+    // for a click. Re-binding after the swap is the whole fix; nothing has to
+    // be torn down first, because the listeners went out with the elements
+    // that carried them.
+    //
+    // Guarded for the same reason as LangInit's: Astro's "already executed"
+    // record does not include the copy that ran on the initial page load, so
+    // the first navigation to another page with this switcher runs this script
+    // a second time.
+    if (!window.__langSwitcherListenerAdded) {
+      window.__langSwitcherListenerAdded = true;
+      document.addEventListener("astro:after-swap", setupLangSwitchers);
+    }
   })();
 </script>
 

--- a/src/components/PageHeader.astro
+++ b/src/components/PageHeader.astro
@@ -50,7 +50,15 @@ const hasActions = Astro.slots.has("actions");
   class:list={["page-header", { "page-header--condense": condenseOnScroll }]}
 >
   {condenseOnScroll && <div class="page-header__veil" aria-hidden="true" />}
-  <div class="header-row">
+  {/* The one row that is on every page and looks the same on all of them, so
+      it gets its own view-transition layer instead of being cross-faded along
+      with the page body. Without a name the row is captured inside the root
+      snapshot at whatever scroll offset it was pinned at, and leaving a
+      scrolled page makes the pills appear to jump; named, they hold their
+      place while the content underneath changes. There is exactly one
+      PageHeader per page, which is what keeps this name unique — two elements
+      claiming the same view-transition-name abort the whole transition. */}
+  <div class="header-row" transition:name="page-header">
     <nav
       class:list={["crumbs", "liquid-glass", { "crumbs--solo": soloCrumb }]}
       aria-label="Breadcrumb"
@@ -338,6 +346,16 @@ const hasActions = Astro.slots.has("actions");
      backdrop, only an ancestor's does. */
   .lang-shell :global(.lang-switcher) {
     animation: barIn 0.7s cubic-bezier(0.16, 1, 0.3, 1) both;
+  }
+
+  /* …but only for the document that opened here. Both capsules are chrome:
+     identical on every page, and under client-side routing they are still on
+     screen when the next page's markup arrives. Sliding them down from -12px
+     again would announce a fresh arrival for something that never left. The
+     flag is stamped on <html> after each swap (PageLayout.astro). */
+  :global(html.is-navigated) .crumbs,
+  :global(html.is-navigated) .lang-shell :global(.lang-switcher) {
+    animation: none;
   }
 
   /* Hero title */

--- a/src/components/travel/TravelMap.astro
+++ b/src/components/travel/TravelMap.astro
@@ -1,6 +1,10 @@
 ---
 import "flag-icons/css/flag-icons.min.css";
 import "maplibre-gl/dist/maplibre-gl.css";
+import {
+  PERSIST_MAP_ACROSS_NAVIGATION,
+  MAP_PERSIST_NAME,
+} from "@lib/travel/map-strategy";
 
 interface Props {
   mode?: "normal" | "globe";
@@ -9,9 +13,29 @@ interface Props {
 const { mode = "globe" } = Astro.props;
 ---
 
-<div id="map" class="map" data-testid="map" data-mode={mode}>
-  <div id="placeholder" class="placeholder"></div>
-</div>
+{
+  /* The two containers are the same element; only the directive differs, and a
+     directive cannot be spread in from an object the way an attribute can — so
+     the branch is written out rather than computed. See map-strategy.ts for
+     which one runs and why. */
+}
+{
+  PERSIST_MAP_ACROSS_NAVIGATION ? (
+    <div
+      id="map"
+      class="map"
+      data-testid="map"
+      data-mode={mode}
+      transition:persist={MAP_PERSIST_NAME}
+    >
+      <div id="placeholder" class="placeholder" />
+    </div>
+  ) : (
+    <div id="map" class="map" data-testid="map" data-mode={mode}>
+      <div id="placeholder" class="placeholder" />
+    </div>
+  )
+}
 
 <style>
   /* Note the absence of `transform: translateZ(0)` here. It was an iOS Safari

--- a/src/components/wishlist/WishlistPage.astro
+++ b/src/components/wishlist/WishlistPage.astro
@@ -64,8 +64,23 @@ const allCategory = categories.find((c) => c.id === "all")!;
         applyPrices();
       }
 
-      // Re-apply prices on language change
-      window.addEventListener("lang-change", applyPrices);
+      // Each category is its own page, so switching between them replaces
+      // every card — and the incoming ones are server-rendered with the
+      // original currency. after-swap is early enough that the correction
+      // lands before the new frame is painted, so nobody sees dollars turn
+      // into roubles.
+      //
+      // Both listeners are guarded because this is an inline script, and Astro
+      // only suppresses a re-run of one it has already seen swapped in: the
+      // copy that ran on the initial page load is not in that record, so the
+      // first navigation between two wishlist pages executes this a second
+      // time and would double up on both.
+      if (!window.__wishlistPricesListenersAdded) {
+        window.__wishlistPricesListenersAdded = true;
+        document.addEventListener("astro:after-swap", applyPrices);
+        // Re-apply prices on language change
+        window.addEventListener("lang-change", applyPrices);
+      }
     })();
   </script>
 

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -2,6 +2,7 @@
 import "@styles/global.css";
 import { Font } from "astro:assets";
 import { SEO } from "astro-seo";
+import { ClientRouter } from "astro:transitions";
 
 interface AlternateLink {
   lang: string;
@@ -58,6 +59,14 @@ const ogImage = image ?? "https://orlovsky.dev/og-image.png";
         image: ogImage,
       }}
     />
+    {/* Client-side routing for every page that uses this layout. The two
+        layouts that don't — AdminLayout and MarkdownLayout — stay on ordinary
+        browser navigation, and that is deliberate rather than an oversight:
+        the router refuses to swap into a document that carries no
+        astro-view-transitions-enabled meta and falls back to a full load, so
+        /wishlist/~ keeps its no-store caching and its own CSP without this
+        file having to know about either. */}
+    <ClientRouter />
     <link rel="icon" href="/favicon.svg" />
     <link rel="mask-icon" href="/favicon.svg" color="#000000" />
     <meta
@@ -78,6 +87,22 @@ const ogImage = image ?? "https://orlovsky.dev/og-image.png";
   </head>
   <body>
     <slot />
+    <script>
+      // The chrome's entrance animations belong to a document opening, not to
+      // a click inside one. The breadcrumb pill and the language switcher each
+      // slide in over 0.7s (barIn, PageHeader.astro); replaying that on every
+      // in-site navigation would have the same two capsules re-introduce
+      // themselves while they are already sitting on screen, which is the
+      // opposite of what a persistent chrome should look like. The flag is a
+      // class rather than a one-time stylesheet swap because Astro strips
+      // every attribute off <html> on each swap (swapRootAttributes) and
+      // replaces them with the incoming document's, so it has to be re-stamped
+      // after each one — and after-swap is early enough that it lands before
+      // the new frame is painted.
+      const markNavigated = () =>
+        document.documentElement.classList.add("is-navigated");
+      document.addEventListener("astro:after-swap", markNavigated);
+    </script>
     <script
       defer
       src="https://static.cloudflareinsights.com/beacon.min.js"

--- a/src/lib/travel/map-strategy.ts
+++ b/src/lib/travel/map-strategy.ts
@@ -1,0 +1,24 @@
+/**
+ * Which of the two answers to "what happens to the map when the reader
+ * navigates away and comes back" is in force.
+ *
+ * `false` — the map is dismantled on the way out and rebuilt on the way back.
+ * The WebGL context is released, every listener is returned, and the container
+ * that arrives on the next visit is an empty one. Correct, and the cost is a
+ * full MapLibre boot plus a fresh style fetch on every return to /travel.
+ *
+ * `true` — the container is marked `transition:persist`, so Astro carries the
+ * live element across the swap instead of replacing it. The map is never
+ * rebuilt because it is never taken apart: same canvas, same WebGL context,
+ * same camera position the reader left it at. Teardown still runs when the
+ * destination has no map to carry the element into.
+ *
+ * Both paths are implemented and both are correct; this picks which one runs.
+ * The flag lives here, apart from either, because the template and the client
+ * script have to agree — a container marked persist whose script still
+ * dismantles the map would leave an emptied canvas on screen with no way back.
+ */
+export const PERSIST_MAP_ACROSS_NAVIGATION = false;
+
+/** The name the persisted container is paired by across a navigation. */
+export const MAP_PERSIST_NAME = "travel-map";

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -1026,38 +1026,69 @@ const breadcrumbSchema = {
 </style>
 
 <script>
-  // Back to top button
-  const backToTopBtn = document.getElementById("back-to-top");
+  // Both buttons belong to the post that is currently on screen, and one post
+  // links straight to the next — so this has to be re-bound on every arrival.
+  // The module itself is only ever evaluated once (Astro re-inserts the tag
+  // after a swap, but a module already in the map is not re-run), which is why
+  // the work lives in a function called from both places rather than at the
+  // top level, where it would bind the first post's buttons and leave every
+  // post after it with a dead back-to-top pill.
   const threshold = 300;
 
-  if (backToTopBtn) {
-    const prefersReducedMotion = window.matchMedia(
-      "(prefers-reduced-motion: reduce)"
-    ).matches;
+  // The scroll handler is on the window, which outlives the post. Kept in a
+  // module-level slot so each re-init can take the previous one back before
+  // adding its own — otherwise reading five posts leaves five handlers running
+  // on every scroll frame, four of them toggling classes on detached buttons.
+  let onScroll: (() => void) | null = null;
 
-    window.addEventListener("scroll", () => {
-      const shouldShow = window.scrollY > threshold;
-      backToTopBtn.classList.toggle("visible", shouldShow);
-      backToTopBtn.hidden = !shouldShow;
-    });
+  function initPostControls() {
+    // Reached twice on a cold load — once as the module is evaluated, once
+    // from astro:page-load on window load — and the click handlers below would
+    // otherwise be doubled up. The flag rides on <body>, which the swap
+    // replaces, so the next post starts clean.
+    if (document.body.dataset.postControlsReady === "true") return;
+    document.body.dataset.postControlsReady = "true";
 
-    backToTopBtn.addEventListener("click", () => {
-      window.scrollTo({
-        top: 0,
-        behavior: prefersReducedMotion ? "auto" : "smooth",
+    if (onScroll) {
+      window.removeEventListener("scroll", onScroll);
+      onScroll = null;
+    }
+
+    // Back to top button
+    const backToTopBtn = document.getElementById("back-to-top");
+
+    if (backToTopBtn) {
+      const prefersReducedMotion = window.matchMedia(
+        "(prefers-reduced-motion: reduce)"
+      ).matches;
+
+      onScroll = () => {
+        const shouldShow = window.scrollY > threshold;
+        backToTopBtn.classList.toggle("visible", shouldShow);
+        backToTopBtn.hidden = !shouldShow;
+      };
+      window.addEventListener("scroll", onScroll);
+
+      backToTopBtn.addEventListener("click", () => {
+        window.scrollTo({
+          top: 0,
+          behavior: prefersReducedMotion ? "auto" : "smooth",
+        });
       });
-    });
+    }
+
+    // Copy link button
+    const copyLinkBtn = document.getElementById("copy-link");
+
+    if (copyLinkBtn) {
+      copyLinkBtn.addEventListener("click", async () => {
+        await navigator.clipboard.writeText(window.location.href);
+        copyLinkBtn.classList.add("copied");
+        setTimeout(() => copyLinkBtn.classList.remove("copied"), 2000);
+      });
+    }
   }
 
-  // Copy link button
-  const copyLinkBtn = document.getElementById("copy-link");
-
-  if (copyLinkBtn) {
-    copyLinkBtn.addEventListener("click", async () => {
-      await navigator.clipboard.writeText(window.location.href);
-      copyLinkBtn.classList.add("copied");
-      setTimeout(() => copyLinkBtn.classList.remove("copied"), 2000);
-    });
-  }
-
+  initPostControls();
+  document.addEventListener("astro:page-load", initPostControls);
 </script>

--- a/src/pages/kit/index.astro
+++ b/src/pages/kit/index.astro
@@ -1211,26 +1211,59 @@ import { Icon } from "astro-icon/components";
   import { initTooltips } from '@client/tooltip';
   initTooltips();
 
-  // Modal demo
-  const openModalBtn = document.getElementById('open-modal-btn');
-  const closeModalBtns = document.querySelectorAll('.close-modal-btn, #close-modal-btn');
-  const modal = document.getElementById('demo-modal');
+  const toastMessages = {
+    success: { title: 'Success', message: 'Action completed successfully.' },
+    error: { title: 'Error', message: 'Something went wrong.' },
+    warning: { title: 'Warning', message: 'Please review your input.' },
+    info: { title: 'Info', message: 'Here is some information.' },
+  };
 
-  openModalBtn?.addEventListener('click', () => {
-    modal?.classList.add('is-open');
-  });
+  const toastIcons = {
+    success: '✓',
+    error: '✕',
+    warning: '!',
+    info: 'i',
+  };
 
-  closeModalBtns.forEach(btn => {
-    btn.addEventListener('click', () => {
-      modal?.classList.remove('is-open');
+  // Every demo below binds to elements of this page, and this page can be left
+  // and come back to without the document ever unloading — at which point the
+  // module is long since evaluated and will not run again on its own. So the
+  // bindings live in a function that is called on arrival, not at the top
+  // level, where a second visit would find every demo inert.
+  function initKitDemos() {
+    // …and exactly once per arrival: on a cold load this is reached twice,
+    // once as the module is evaluated and once from astro:page-load, which
+    // fires on window load. Two listeners on a toast trigger is two toasts per
+    // click. The flag rides on <body> because the swap brings a new one.
+    if (document.body.dataset.kitDemosReady === 'true') return;
+    document.body.dataset.kitDemosReady = 'true';
+
+    // Modal demo
+    const openModalBtn = document.getElementById('open-modal-btn');
+    const closeModalBtns = document.querySelectorAll('.close-modal-btn, #close-modal-btn');
+    const modal = document.getElementById('demo-modal');
+
+    openModalBtn?.addEventListener('click', () => {
+      modal?.classList.add('is-open');
     });
-  });
 
-  modal?.addEventListener('click', (e) => {
-    if (e.target === modal) {
-      modal.classList.remove('is-open');
-    }
-  });
+    closeModalBtns.forEach(btn => {
+      btn.addEventListener('click', () => {
+        modal?.classList.remove('is-open');
+      });
+    });
+
+    modal?.addEventListener('click', (e) => {
+      if (e.target === modal) {
+        modal.classList.remove('is-open');
+      }
+    });
+
+    initToggleGroup('toggle-pill-demo');
+    initToggleGroup('toggle-separated-demo');
+    initToggleGroup('toggle-icons-demo');
+    initToastDemo();
+  }
 
   // ToggleGroup demo
   function initToggleGroup(containerId: string) {
@@ -1252,67 +1285,54 @@ import { Icon } from "astro-icon/components";
     });
   }
 
-  initToggleGroup('toggle-pill-demo');
-  initToggleGroup('toggle-separated-demo');
-  initToggleGroup('toggle-icons-demo');
-
   // Toast demo
-  const toastContainer = document.getElementById('toast-container');
-  const toastTriggers = document.querySelectorAll('.toast-trigger');
-  const positionSelect = document.getElementById('toast-position-select') as HTMLSelectElement;
+  function initToastDemo() {
+    const toastContainer = document.getElementById('toast-container');
+    const toastTriggers = document.querySelectorAll('.toast-trigger');
+    const positionSelect = document.getElementById('toast-position-select') as HTMLSelectElement;
 
-  const toastMessages = {
-    success: { title: 'Success', message: 'Action completed successfully.' },
-    error: { title: 'Error', message: 'Something went wrong.' },
-    warning: { title: 'Warning', message: 'Please review your input.' },
-    info: { title: 'Info', message: 'Here is some information.' },
-  };
-
-  const toastIcons = {
-    success: '✓',
-    error: '✕',
-    warning: '!',
-    info: 'i',
-  };
-
-  // Position change handler
-  positionSelect?.addEventListener('change', () => {
-    if (!toastContainer) return;
-    // Remove all position classes
-    toastContainer.className = 'kit-toast-container';
-    // Add selected position class
-    if (positionSelect.value) {
-      toastContainer.classList.add(positionSelect.value);
-    }
-  });
-
-  toastTriggers.forEach(trigger => {
-    trigger.addEventListener('click', () => {
-      const variant = (trigger as HTMLElement).dataset.variant as keyof typeof toastMessages;
-      const { title, message } = toastMessages[variant];
-      const icon = toastIcons[variant];
-
-      const toast = document.createElement('div');
-      toast.className = `kit-toast kit-toast--${variant}`;
-      toast.innerHTML = `
-        <span class="kit-toast-icon">${icon}</span>
-        <div class="kit-toast-content">
-          <p class="kit-toast-title">${title}</p>
-          <p class="kit-toast-message">${message}</p>
-        </div>
-        <button class="kit-toast-dismiss">&times;</button>
-      `;
-
-      toastContainer?.appendChild(toast);
-
-      const dismiss = toast.querySelector('.kit-toast-dismiss');
-      const removeToast = () => {
-        toast.classList.add('is-leaving');
-        setTimeout(() => toast.remove(), 200);
-      };
-
-      dismiss?.addEventListener('click', removeToast);
-      setTimeout(removeToast, 4000);
+    // Position change handler
+    positionSelect?.addEventListener('change', () => {
+      if (!toastContainer) return;
+      // Remove all position classes
+      toastContainer.className = 'kit-toast-container';
+      // Add selected position class
+      if (positionSelect.value) {
+        toastContainer.classList.add(positionSelect.value);
+      }
     });
-  });
+
+    toastTriggers.forEach(trigger => {
+      trigger.addEventListener('click', () => {
+        const variant = (trigger as HTMLElement).dataset.variant as keyof typeof toastMessages;
+        const { title, message } = toastMessages[variant];
+        const icon = toastIcons[variant];
+
+        const toast = document.createElement('div');
+        toast.className = `kit-toast kit-toast--${variant}`;
+        toast.innerHTML = `
+          <span class="kit-toast-icon">${icon}</span>
+          <div class="kit-toast-content">
+            <p class="kit-toast-title">${title}</p>
+            <p class="kit-toast-message">${message}</p>
+          </div>
+          <button class="kit-toast-dismiss">&times;</button>
+        `;
+
+        toastContainer?.appendChild(toast);
+
+        const dismiss = toast.querySelector('.kit-toast-dismiss');
+        const removeToast = () => {
+          toast.classList.add('is-leaving');
+          setTimeout(() => toast.remove(), 200);
+        };
+
+        dismiss?.addEventListener('click', removeToast);
+        setTimeout(removeToast, 4000);
+      });
+    });
+  }
+
+  initKitDemos();
+  document.addEventListener('astro:page-load', initKitDemos);
 </script>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -923,4 +923,17 @@ a.btn-danger:active {
   *:active * {
     transform: none !important;
   }
+
+  /* The page-to-page cross-fade the ClientRouter sets up. It has to be named
+     separately because the ::view-transition pseudo-elements live outside the
+     document tree, so the `*` above never reaches them — the browser's own
+     default cross-fade would keep running under a setting that asks for no
+     animation at all. Killing the animations doesn't cancel the transition:
+     the snapshots are still taken and still swapped, they just cut over on the
+     first frame instead of blending. */
+  ::view-transition-group(*),
+  ::view-transition-old(*),
+  ::view-transition-new(*) {
+    animation: none !important;
+  }
 }


### PR DESCRIPTION
<ClientRouter /> in PageLayout, and the rest of this is what that costs.

The router keeps the document and replaces the body. Two consequences run through every file here. Scripts do not run again: a module already in the browser's module map is not re-evaluated when Astro re-inserts its tag, so anything that bound itself to elements at import time binds the first page's elements and leaves every page after it inert. And anything registered on something that outlives the body — the window, the document, a MediaQueryList, a timer — is still there on the next page, still holding the last one.

So the pattern is the one four of these files already used, applied to the rest: init on arrival, guarded per element so the double call on a cold load lands once; hand back window- and document-level listeners at astro:before-swap; leave element-scoped listeners alone, because they go out with the element.

The map was the expensive one. A visit to /travel used to leave behind a WebGL context on a detached canvas, a requestAnimationFrame loop repainting it forever, two observers, a label parented to the old body, and four matchMedia handlers writing paint properties into all of it. The browser grants a handful of WebGL contexts before it starts dropping the oldest, so a few laps through the site would have killed the live map. It now keeps an undo list, runs it before the swap, and carries a generation token so an init still waiting on the style — leaving /travel before the first tile arrives is entirely ordinary — can tell that the page it was decorating has gone.

The language was the invisible one. Astro strips every attribute off <html> on each swap and applies the incoming document's, which takes lang-ru and lang-ready with them, and the incoming body is server-rendered in English. Since .lang-content is transparent until lang-ready, the next page arrived not merely untranslated but blank. Both inline scripts re-apply after the swap, before the new frame is painted, and both guard against being registered twice: Astro's record of already-executed inline scripts starts empty, so the copy that ran on the initial page load is not in it and the first navigation runs them a second time.

Turning the router on is also what makes astro:page-load fire for the first time. Every existing `initAll(); addEventListener("astro:page-load", initAll)` pair had been running exactly once; now it runs twice on a cold load, and the three that had no per-element guard would have doubled up. Two clicks per die roll on the wishlist, and — the one that mattered — two click listeners on every Reserve button, where one press would place the reservation and the second handler would read it straight back as its own and cancel it.

The header row is the one thing given a view-transition name. Unnamed, it is captured inside the root snapshot at whatever scroll offset it was pinned at, and leaving a scrolled page makes the pills appear to jump. Named, they hold their place. The chrome's entrance animation is suppressed once anything has been navigated to, for the same reason: a capsule that never left should not introduce itself again. Nothing else animates beyond the browser's own cross-fade, and reduced motion switches that off — the ::view-transition pseudo-elements live outside the document tree, so the blanket `*` rule in global.css never reached them.

AdminLayout and MarkdownLayout deliberately keep ordinary browser navigation. The router refuses to swap into a document without the enabled meta and falls back to a full load, so /wishlist/~ keeps its no-store caching and its own CSP without either file having to know about this one.

astro check 0 errors, bun test 12/12, production build passes. The teardown and re-init paths are reasoned about statically; nothing here has been clicked through in a browser yet.