### PR TITLE
Two more ways to read the same trips

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+# The tests exist to catch things no reviewer would spot by reading a diff — a
+# country added to trips.json with no continent behind it disappears from the
+# continents view while every fraction on the page still adds up. Nothing ran
+# them: deploy.yml is about migrations, and Vercel's build does not run Vitest,
+# so the guard only fired if someone happened to type `bun test` locally.
+#
+# Deliberately separate from deploy.yml. That workflow only wakes for a push
+# carrying a migration; this one has to see every push and every pull request,
+# which is the whole point of it.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - run: bun install --frozen-lockfile
+
+      # `vitest` alone would sit in watch mode if the CI variable ever went
+      # missing; `run` says once and means it.
+      - name: Run tests
+        run: bunx vitest run
+
+      - name: Typecheck
+        run: bunx astro check

--- a/ideas.md
+++ b/ideas.md
@@ -196,3 +196,73 @@ where growth is what makes neighbours collide.
 Markers need a `prefers-reduced-transparency` answer too — flat, opaque dots.
 The map already listens for colour-scheme changes, so listening for one more
 media query is symmetrical, not new machinery.
+
+## Flags without the stylesheet
+
+### Where they stand
+
+`/travel` asks for `flag-icons/css/flag-icons.min.css`: **501 KB** of CSS, two
+hundred and seventy-one `.fi-xx` rules, each with a whole country outline
+inlined as a `data:image/svg+xml` background. Gzipped it is 82 KB — five times
+the entire HTML document of the page it decorates, and until recently it sat in
+front of the first paint.
+
+It is now preloaded and promoted by a script once the document is parsed
+(`src/pages/travel/index.astro`), so it no longer blocks. Render-blocking CSS on
+that page went from ~102 KB gzipped to ~20 KB. What is left of it is the trade
+that buys: the flags land a frame or two after the text they sit in.
+
+The obvious next move — ship only the flags the site uses — does not work here,
+and the reason is worth writing down so nobody tries it twice:
+
+```
+distinct flag codes referenced on /travel: 245 of 271
+because the checklist lists 250 countries, each with its flag
+without the checklist, the page needs about 35
+```
+
+Trimming the library saves nothing while the checklist draws flags. The
+checklist is also the one view nobody opens by default.
+
+### Load them as images instead
+
+Replace `<span class="fi fi-ru">` with an `<img>` pointing at a single flag,
+served from `public/` (the SVGs are in `node_modules/flag-icons/flags/4x3/`, one
+file each, 1–3 KB), with `loading="lazy"`.
+
+What it buys, and why it is the real fix rather than a smaller version of the
+current one:
+
+- The 82 KB goes away entirely; nothing replaces it up front.
+- A hidden panel fetches **nothing**. The checklist's 245 flags cost zero until
+  someone opens it, which is what a `display: none` subtree should have cost all
+  along.
+- The timeline, which is what a visitor actually lands on, needs about twenty
+  files. Over HTTP/2 that is one round trip's worth of parallel requests, each
+  smaller than a favicon.
+- Flags become cacheable per country rather than as one monolith, so adding a
+  trip stops invalidating every flag on the site.
+
+### What it costs
+
+- Six call sites: `TravelTrip`, `TravelCountries`, `TravelContinents`,
+  `TravelChecklist`, `TravelStatsDashboard`, and the map's city labels in
+  `TravelMap`. The map one is the awkward one — its labels are built in an HTML
+  overlay from a script, not from an Astro template.
+- A build step to copy the SVGs into `public/flags/`, or an integration that
+  emits only the codes in `countries.ts`. Copying all 271 is 400 KB on disk and
+  nothing on the wire, which is probably the right trade for the simplicity.
+- Sizing has to be restated. `.fi` sizes itself from the font (`width:
+  1.33333em`), which is exactly why a flag stands correctly beside a city name
+  in the timeline and beside a 1.25rem answer in the stats; an `<img>` needs
+  `width`/`height` attributes for aspect-ratio and an em-based CSS width to keep
+  that behaviour.
+- Regional flags (`gb-eng`, `gb-sct`) and the five `xx` placeholders in the
+  checklist need the same treatment, not a special case.
+
+### The other half of that page
+
+While in there: `maplibre-gl`'s stylesheet is the remaining 91 KB / 14 KB
+gzipped of render-blocking CSS on `/travel`, and the map is the first thing on
+the page, so it has a better claim to blocking than the flags did. Worth
+measuring before assuming it needs the same treatment.

--- a/src/client/crumb-home-magnet.ts
+++ b/src/client/crumb-home-magnet.ts
@@ -1,90 +1,19 @@
-// Magnetic pull for the breadcrumb home button — the same cursor magnetism as
-// the magnetic glass dock (nav-dock.ts) and the language switcher. The home
-// glyph drifts toward the pointer while it's within range, easing back to
-// centre on leave. Smoothing mirrors the lerp + requestAnimationFrame approach
-// used elsewhere.
+// Cursor magnetism for the breadcrumb home button — see @client/magnet.ts for
+// the behaviour and the numbers. The pointer is tracked across the whole header
+// row so the glyph reacts as the cursor approaches it rather than only once the
+// cursor is on it.
 
-const MAGNET_STRENGTH = 0.35; // Fraction of cursor offset applied to the button
-const MAGNET_MAX = 6; // Max px the button can drift toward the cursor
-const MAGNET_RADIUS = 90; // Cursor distance (px) at which the pull starts
-const SMOOTH = 0.18; // lerp factor toward the target offset
-
-const prefersReducedMotion = window.matchMedia(
-  "(prefers-reduced-motion: reduce)",
-).matches;
-
-function lerp(start: number, end: number, factor: number): number {
-  return start + (end - start) * factor;
-}
-
-function initMagnet(home: HTMLElement) {
-  if (home.dataset.magnet === "ready") return;
-  home.dataset.magnet = "ready";
-
-  // Track the pointer across the whole header row so the button reacts as the
-  // cursor approaches; the radius check keeps the pull local.
-  const scope =
-    home.closest<HTMLElement>(".header-row") ??
-    home.closest<HTMLElement>(".crumbs") ??
-    home;
-
-  const current = { x: 0, y: 0 };
-  const target = { x: 0, y: 0 };
-  let running = false;
-
-  function animate() {
-    current.x = lerp(current.x, target.x, SMOOTH);
-    current.y = lerp(current.y, target.y, SMOOTH);
-    home.style.transform = `translate(${current.x}px, ${current.y}px)`;
-    if (
-      Math.abs(current.x - target.x) > 0.05 ||
-      Math.abs(current.y - target.y) > 0.05
-    ) {
-      requestAnimationFrame(animate);
-    } else {
-      running = false;
-    }
-  }
-
-  function kick() {
-    if (!running) {
-      running = true;
-      requestAnimationFrame(animate);
-    }
-  }
-
-  scope.addEventListener("pointermove", (e) => {
-    const rect = home.getBoundingClientRect();
-    const cx = rect.left + rect.width / 2;
-    const cy = rect.top + rect.height / 2;
-    const dx = e.clientX - cx;
-    const dy = e.clientY - cy;
-    if (Math.hypot(dx, dy) < MAGNET_RADIUS) {
-      target.x = Math.max(
-        -MAGNET_MAX,
-        Math.min(MAGNET_MAX, dx * MAGNET_STRENGTH),
-      );
-      target.y = Math.max(
-        -MAGNET_MAX,
-        Math.min(MAGNET_MAX, dy * MAGNET_STRENGTH),
-      );
-    } else {
-      target.x = 0;
-      target.y = 0;
-    }
-    kick();
-  });
-
-  scope.addEventListener("pointerleave", () => {
-    target.x = 0;
-    target.y = 0;
-    kick();
-  });
-}
+import { initMagnet } from "@client/magnet";
 
 function initAll() {
-  if (prefersReducedMotion) return;
-  document.querySelectorAll<HTMLElement>(".crumb-home").forEach(initMagnet);
+  document.querySelectorAll<HTMLElement>(".crumb-home").forEach((home) => {
+    initMagnet(home, {
+      scope:
+        home.closest<HTMLElement>(".header-row") ??
+        home.closest<HTMLElement>(".crumbs") ??
+        home,
+    });
+  });
 }
 
 initAll();

--- a/src/client/magnet.ts
+++ b/src/client/magnet.ts
@@ -1,0 +1,111 @@
+// Cursor magnetism: an element eases toward the pointer while the pointer is
+// near it, and eases back to rest when it leaves.
+//
+// The idiom is already the site's — the magnetic glass dock (nav-dock.ts) and
+// the language switcher move their indicators this way, and the breadcrumb
+// home glyph and the wishlist's Reserve button had each grown their own copy
+// of it. This is that copy, once, with the two differences between them turned
+// into options: where the pointer is tracked, and whether the element is
+// currently allowed to move at all.
+//
+// The pull is deliberately small. It says the thing is aware of where you are;
+// it is not a control that follows you around. Six pixels is far enough to
+// read as life and too little to move anything out from under a click.
+
+const STRENGTH = 0.35; // Fraction of the cursor's offset applied to the element
+const MAX = 6; // Furthest it may drift from rest, px
+const RADIUS = 90; // Cursor distance at which the pull starts, px
+const SMOOTH = 0.18; // lerp factor toward the target offset
+
+export interface MagnetOptions {
+  /** Where the pointer is tracked. Wider than the element itself, normally, so
+      it reacts as the cursor approaches rather than only once it has arrived —
+      the radius check below is what keeps the pull local. Defaults to the
+      element, which makes it a hover effect instead. */
+  scope?: HTMLElement | null;
+  /** Held at rest while this returns true. A disabled button should not twitch
+      under a cursor that cannot press it. */
+  inert?: () => boolean;
+  strength?: number;
+  max?: number;
+  radius?: number;
+  smooth?: number;
+}
+
+export const prefersReducedMotion = window.matchMedia(
+  "(prefers-reduced-motion: reduce)",
+).matches;
+
+function lerp(start: number, end: number, factor: number): number {
+  return start + (end - start) * factor;
+}
+
+/** Wire one element up to the cursor. Safe to call again on the same element —
+    a page-load handler re-running over a document that was never replaced must
+    not leave two loops fighting over one transform. */
+export function initMagnet(el: HTMLElement, options: MagnetOptions = {}): void {
+  if (prefersReducedMotion) return;
+  if (el.dataset.magnet === "ready") return;
+  el.dataset.magnet = "ready";
+
+  const {
+    scope = el,
+    inert,
+    strength = STRENGTH,
+    max = MAX,
+    radius = RADIUS,
+    smooth = SMOOTH,
+  } = options;
+
+  const tracked = scope ?? el;
+
+  const current = { x: 0, y: 0 };
+  const target = { x: 0, y: 0 };
+  let running = false;
+
+  function animate() {
+    current.x = lerp(current.x, target.x, smooth);
+    current.y = lerp(current.y, target.y, smooth);
+    el.style.transform = `translate(${current.x}px, ${current.y}px)`;
+    if (
+      Math.abs(current.x - target.x) > 0.05 ||
+      Math.abs(current.y - target.y) > 0.05
+    ) {
+      requestAnimationFrame(animate);
+    } else {
+      running = false;
+    }
+  }
+
+  function kick() {
+    if (!running) {
+      running = true;
+      requestAnimationFrame(animate);
+    }
+  }
+
+  function rest() {
+    target.x = 0;
+    target.y = 0;
+    kick();
+  }
+
+  tracked.addEventListener("pointermove", (e) => {
+    if (inert?.()) {
+      rest();
+      return;
+    }
+    const rect = el.getBoundingClientRect();
+    const dx = e.clientX - (rect.left + rect.width / 2);
+    const dy = e.clientY - (rect.top + rect.height / 2);
+    if (Math.hypot(dx, dy) < radius) {
+      target.x = Math.max(-max, Math.min(max, dx * strength));
+      target.y = Math.max(-max, Math.min(max, dy * strength));
+      kick();
+    } else {
+      rest();
+    }
+  });
+
+  tracked.addEventListener("pointerleave", rest);
+}

--- a/src/client/reserve-magnet.ts
+++ b/src/client/reserve-magnet.ts
@@ -1,97 +1,19 @@
-// Magnetic pull for the wishlist Reserve button — the same cursor magnetism as
-// the magnetic glass dock (nav-dock.ts), the language switcher and the
-// breadcrumb home glyph (crumb-home-magnet.ts). The button drifts toward the
-// pointer while it's within range, easing back to centre on leave. Smoothing
-// mirrors the lerp + requestAnimationFrame approach used elsewhere.
+// Cursor magnetism for the wishlist Reserve button — see @client/magnet.ts for
+// the behaviour and the numbers. The pointer is tracked across the whole card
+// so the button reacts as the cursor approaches it, and a received item or
+// somebody else's reservation renders it disabled, which holds it still.
 
-const MAGNET_STRENGTH = 0.35; // Fraction of cursor offset applied to the button
-const MAGNET_MAX = 6; // Max px the button can drift toward the cursor
-const MAGNET_RADIUS = 90; // Cursor distance (px) at which the pull starts
-const SMOOTH = 0.18; // lerp factor toward the target offset
-
-const prefersReducedMotion = window.matchMedia(
-  "(prefers-reduced-motion: reduce)",
-).matches;
-
-function lerp(start: number, end: number, factor: number): number {
-  return start + (end - start) * factor;
-}
-
-function initMagnet(button: HTMLButtonElement) {
-  if (button.dataset.magnet === "ready") return;
-  button.dataset.magnet = "ready";
-
-  // Track the pointer across the whole card so the button reacts as the cursor
-  // approaches; the radius check keeps the pull local.
-  const scope = button.closest<HTMLElement>("article") ?? button;
-
-  const current = { x: 0, y: 0 };
-  const target = { x: 0, y: 0 };
-  let running = false;
-
-  function animate() {
-    current.x = lerp(current.x, target.x, SMOOTH);
-    current.y = lerp(current.y, target.y, SMOOTH);
-    button.style.transform = `translate(${current.x}px, ${current.y}px)`;
-    if (
-      Math.abs(current.x - target.x) > 0.05 ||
-      Math.abs(current.y - target.y) > 0.05
-    ) {
-      requestAnimationFrame(animate);
-    } else {
-      running = false;
-    }
-  }
-
-  function kick() {
-    if (!running) {
-      running = true;
-      requestAnimationFrame(animate);
-    }
-  }
-
-  scope.addEventListener("pointermove", (e) => {
-    // Received items and other people's reservations render a disabled (or
-    // hidden) button — it shouldn't twitch under the cursor.
-    if (button.disabled) {
-      target.x = 0;
-      target.y = 0;
-      kick();
-      return;
-    }
-    const rect = button.getBoundingClientRect();
-    const cx = rect.left + rect.width / 2;
-    const cy = rect.top + rect.height / 2;
-    const dx = e.clientX - cx;
-    const dy = e.clientY - cy;
-    if (Math.hypot(dx, dy) < MAGNET_RADIUS) {
-      target.x = Math.max(
-        -MAGNET_MAX,
-        Math.min(MAGNET_MAX, dx * MAGNET_STRENGTH),
-      );
-      target.y = Math.max(
-        -MAGNET_MAX,
-        Math.min(MAGNET_MAX, dy * MAGNET_STRENGTH),
-      );
-    } else {
-      target.x = 0;
-      target.y = 0;
-    }
-    kick();
-  });
-
-  scope.addEventListener("pointerleave", () => {
-    target.x = 0;
-    target.y = 0;
-    kick();
-  });
-}
+import { initMagnet } from "@client/magnet";
 
 function initAll() {
-  if (prefersReducedMotion) return;
   document
     .querySelectorAll<HTMLButtonElement>(".reserve-btn")
-    .forEach(initMagnet);
+    .forEach((button) => {
+      initMagnet(button, {
+        scope: button.closest<HTMLElement>("article"),
+        inert: () => button.disabled,
+      });
+    });
 }
 
 initAll();

--- a/src/client/toggle-tabs.ts
+++ b/src/client/toggle-tabs.ts
@@ -1,0 +1,145 @@
+// Drives a ToggleGroup rendered with variant="tabs".
+//
+// Three jobs, none of which a stylesheet can do: keep the WAI-ARIA tab pattern
+// honest (roving tabindex, arrow keys, aria-selected), park the sliding marker
+// under the current label, and keep that label on screen when the rail is
+// narrower than its tabs.
+//
+// Activation is automatic — an arrow key both moves focus and switches the
+// panel. The manual pattern exists for panels that cost something to show;
+// these are already in the document with `hidden` toggled, so making someone
+// press Enter after arrowing would be ceremony over nothing.
+
+import { initScrollableCategories } from "@client/scrollable-categories";
+
+/** Why the current tab changed, so callers can treat a click differently from
+    the first paint — scrolling on one and not the other, typically. */
+export type ToggleTabsCause = "init" | "user";
+
+export interface ToggleTabsInstance {
+  /** Switch tabs from outside — a hashchange, a deep link. Counts as "init":
+      nothing the reader did, so nothing should move under them. */
+  select: (id: string) => void;
+  /** Re-measure the marker. Called on its own for changes no observer here
+      sees. */
+  refresh: () => void;
+}
+
+export function initToggleTabs(
+  group: HTMLElement,
+  onChange: (id: string, cause: ToggleTabsCause) => void,
+): ToggleTabsInstance {
+  const tabs = Array.from(group.querySelectorAll<HTMLElement>('[role="tab"]'));
+  const marker = group.querySelector<HTMLElement>(".kit-toggle-group__marker");
+
+  // The rail is the scroller in the narrow case, so it owns the edge fades.
+  // "minimal" rather than "center": on a wide screen nothing overflows and the
+  // row must not twitch, and on a narrow one only a tab that is actually cut
+  // off is worth scrolling to.
+  const scroller = initScrollableCategories({
+    scroller: group,
+    scrollMode: "minimal",
+  });
+
+  let current = "";
+
+  const tabFor = (id: string) => tabs.find((tab) => tab.dataset.id === id);
+
+  // The lens takes the whole capsule, so the four properties are simply the
+  // tab's own offset box — the same four nav-dock.ts writes as --dock-*. Height
+  // and vertical offset are set as well as width, so a rail that ever wraps to
+  // two lines still lands the glass on the right tab rather than on the one
+  // above it.
+  function moveMarker() {
+    if (!marker) return;
+    const tab = tabFor(current);
+    if (!tab) return;
+    marker.style.setProperty("--marker-x", `${tab.offsetLeft}px`);
+    marker.style.setProperty("--marker-y", `${tab.offsetTop}px`);
+    marker.style.setProperty("--marker-w", `${tab.offsetWidth}px`);
+    marker.style.setProperty("--marker-h", `${tab.offsetHeight}px`);
+  }
+
+  function select(id: string, cause: ToggleTabsCause) {
+    const tab = tabFor(id);
+    if (!tab) return;
+    current = id;
+
+    for (const item of tabs) {
+      const isActive = item === tab;
+      item.setAttribute("aria-selected", String(isActive));
+      item.classList.toggle("is-active", isActive);
+      // Roving tabindex: the rail is one stop in the page's tab order and the
+      // arrows move within it, rather than five stops in a row.
+      item.tabIndex = isActive ? 0 : -1;
+    }
+
+    moveMarker();
+    scroller.scrollToActive();
+    onChange(id, cause);
+  }
+
+  group.addEventListener("click", (event) => {
+    const tab = (event.target as HTMLElement | null)?.closest<HTMLElement>(
+      '[role="tab"]',
+    );
+    const id = tab?.dataset.id;
+    if (!id) return;
+    event.preventDefault();
+    select(id, "user");
+  });
+
+  group.addEventListener("keydown", (event) => {
+    const index = tabs.indexOf(document.activeElement as HTMLElement);
+    if (index === -1) return;
+
+    let next: number;
+    switch (event.key) {
+      case "ArrowRight":
+        next = (index + 1) % tabs.length;
+        break;
+      case "ArrowLeft":
+        next = (index - 1 + tabs.length) % tabs.length;
+        break;
+      case "Home":
+        next = 0;
+        break;
+      case "End":
+        next = tabs.length - 1;
+        break;
+      default:
+        return;
+    }
+
+    event.preventDefault();
+    const id = tabs[next].dataset.id;
+    if (!id) return;
+    select(id, "user");
+    tabs[next].focus();
+  });
+
+  // Anything that changes a label's width moves the line under it: the
+  // viewport, the web font arriving, and — the one that matters here — the
+  // language switch, which rewrites every label from data-en to data-ru and
+  // makes the row half again as wide.
+  const observer = new ResizeObserver(moveMarker);
+  observer.observe(group);
+  for (const tab of tabs) observer.observe(tab);
+  document.fonts?.ready.then(moveMarker);
+
+  // Open on whatever the server marked, so a rail with no caller-supplied
+  // starting tab still lands somewhere sane.
+  const initial =
+    tabs.find((tab) => tab.getAttribute("aria-selected") === "true") ?? tabs[0];
+  if (initial?.dataset.id) select(initial.dataset.id, "init");
+
+  // A frame later, so the marker is already sitting where it belongs when the
+  // rule that reveals *and* animates it applies — otherwise it sweeps in from
+  // the left edge of the rail on every page load.
+  requestAnimationFrame(() => group.classList.add("has-marker"));
+
+  return {
+    select: (id) => select(id, "init"),
+    refresh: moveMarker,
+  };
+}

--- a/src/components/PageHeader.astro
+++ b/src/components/PageHeader.astro
@@ -50,6 +50,7 @@ const hasActions = Astro.slots.has("actions");
   class:list={["page-header", { "page-header--condense": condenseOnScroll }]}
 >
   {condenseOnScroll && <div class="page-header__veil" aria-hidden="true" />}
+  {condenseOnScroll && <div class="page-header__cap" aria-hidden="true" />}
   <div class="header-row">
     <nav
       class:list={["crumbs", "liquid-glass", { "crumbs--solo": soloCrumb }]}
@@ -422,9 +423,20 @@ const hasActions = Astro.slots.has("actions");
        the blur runs unbroken from the top edge to the end of the year's bar;
        with no year docked the same fade is simply a soft bottom. One shape does
        both the tint and the blur — they used to fade on two different curves,
-       25% for the colour against 45%-96% for the mask. */
+       25% for the colour against 45%-96% for the mask.
+
+       A page that pins something else under the pills publishes its height as
+       --sticky-rail-offset (/travel's view rail does), and the strip grows to
+       carry it. That is the whole point of the variable here: the rail used to
+       bring a veil and a blur of its own, docking exactly where this one starts
+       to fade, so the two tints stacked in that band and the seam between them
+       was visible. One surface holds both now, and the fade happens below the
+       rail rather than through it. Unset elsewhere, where it costs nothing. */
     --veil-fade: 2.75rem;
-    height: calc(var(--sticky-header-offset, 5.5rem) + var(--veil-fade));
+    height: calc(
+      var(--sticky-header-offset, 5.5rem) + var(--sticky-rail-offset, 0px) +
+        var(--veil-fade)
+    );
     pointer-events: none;
     z-index: 5;
     background: var(--veil-bg);
@@ -439,6 +451,39 @@ const hasActions = Astro.slots.has("actions");
   }
 
   .page-header--condense.is-condensed .page-header__veil {
+    opacity: 1;
+  }
+
+  /* The lid over the pill row, and the one piece of this that is above the
+     sticky headings rather than below them.
+
+     A section heading sits at z-index 10 so it covers the rows passing under
+     it, which also puts it above the veil (5) — deliberately, so the veil can
+     dissolve behind a docked year instead of stopping dead at its top edge. The
+     cost only shows when a heading *leaves*: its own section pushes it up out
+     of its dock, and on the way up it crosses the pill row, where the veil is
+     the only thing between it and the page and cannot hide it. That is the
+     "Observer States" written across the Home button.
+
+     So the strip the pills float over gets a second, solid layer above the
+     headings. It stops exactly where --sticky-header-offset does, which is
+     where anything else pinned — /travel's view rail — begins, so the two never
+     overlap and nothing else needs to know it is there. Below the pills (30),
+     so they still read as capsules on it rather than under it. */
+  .page-header__cap {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: var(--sticky-header-offset, 5.5rem);
+    pointer-events: none;
+    z-index: 20;
+    background: var(--veil-bg);
+    opacity: 0;
+    transition: opacity 0.4s ease;
+  }
+
+  .page-header--condense.is-condensed .page-header__cap {
     opacity: 1;
   }
 
@@ -527,6 +572,7 @@ const hasActions = Astro.slots.has("actions");
 
   @media (prefers-reduced-motion: reduce) {
     .page-header__veil,
+    .page-header__cap,
     .condensed-title {
       transition: none;
     }

--- a/src/components/YearGroup.astro
+++ b/src/components/YearGroup.astro
@@ -28,8 +28,10 @@ const { year, class: className } = Astro.props;
     /* On pages with a pinned condensing header (/travel), the header's script
        publishes its stuck height as --sticky-header-offset on <main>, so the
        year docks just below the floating pills instead of colliding with
-       them. Elsewhere the variable is unset and the year sticks to the top. */
-    top: var(--sticky-header-offset, 0px);
+       them. /travel pins a second thing under those pills — the view rail —
+       which publishes --sticky-rail-offset the same way, so the year clears
+       both. Elsewhere neither is set and the year sticks to the top. */
+    top: calc(var(--sticky-header-offset, 0px) + var(--sticky-rail-offset, 0px));
     /* The same veil as the pinned header's strip: both are the page closing
        over what scrolls beneath them, and they used to say so with two sets of
        hand-written values. */
@@ -40,7 +42,12 @@ const { year, class: className } = Astro.props;
     /* Years are numbers first: tabular figures keep them aligned down the page
        as the eye scans the column. */
     font-variant-numeric: tabular-nums;
-    padding: 0.5rem 0;
+    /* Out to the edge a ListItem's hover wash reaches (0.75rem) and back in by
+       the same amount, so the year stays on the content edge while its rule and
+       its veil end where the rows' wash does. Every list on the site pairs this
+       heading with those rows, so the two share one edge everywhere. */
+    padding: 0.5rem 0.75rem;
+    margin-inline: -0.75rem;
     border-bottom: var(--glass-border);
     margin-bottom: 0.5rem;
     z-index: 10;

--- a/src/components/kit/ProgressBar.astro
+++ b/src/components/kit/ProgressBar.astro
@@ -6,13 +6,20 @@ interface Props {
   showPercent?: boolean;
   accent?: boolean;
   class?: string;
+  /** Anything else lands on the bar itself — see the note below. */
+  [key: string]: unknown;
 }
 
-const { value, max = 100, label, showPercent = true, accent = false, class: className } = Astro.props;
+const { value, max = 100, label, showPercent = true, accent = false, class: className, ...rest } = Astro.props;
 const percent = Math.floor((value / max) * 100);
 ---
 
 <div class:list={["progress-row", className]}>
+  {/* Leftover props go on the bar, not the row, because the only thing worth
+      addressing from outside is the element carrying role="progressbar" — a
+      bilingual page hands it data-aria-label-en/ru so LangInit can translate
+      the label it would otherwise be stuck with in one language. Spread last
+      so a caller can override aria-label outright. */}
   <div
     class="progress-bar"
     role="progressbar"
@@ -20,6 +27,7 @@ const percent = Math.floor((value / max) * 100);
     aria-valuemin="0"
     aria-valuemax="100"
     aria-label={label}
+    {...rest}
   >
     <div class:list={["progress-fill", { accent }]} style={`width: ${percent}%`}></div>
   </div>

--- a/src/components/kit/ProgressBar.astro
+++ b/src/components/kit/ProgressBar.astro
@@ -6,12 +6,37 @@ interface Props {
   showPercent?: boolean;
   accent?: boolean;
   class?: string;
-  /** Anything else lands on the bar itself — see the note below. */
-  [key: string]: unknown;
+  /** Overrides the aria-label `label` would have produced. */
+  "aria-label"?: string;
+  /** Data attributes land on the bar itself — see the note below. A blanket
+      `[key: string]: unknown` would have done the same job, at the cost of
+      every caller's spelling: with it, `showPercet` is a valid prop that goes
+      out as an HTML attribute while the real one keeps its default. */
+  [key: `data-${string}`]: string | undefined;
 }
 
-const { value, max = 100, label, showPercent = true, accent = false, class: className, ...rest } = Astro.props;
-const percent = Math.floor((value / max) * 100);
+const {
+  value,
+  max = 100,
+  label,
+  showPercent = true,
+  accent = false,
+  class: className,
+  ...rest
+} = Astro.props;
+
+// Astro hands a child the caller's style-scope marker as an ordinary prop, so
+// it arrives in `rest` and would be spread onto the bar — stamping the caller's
+// [data-astro-cid-…] onto an element they cannot see, which is exactly what
+// lets one of their rules restyle the insides of a kit component. Scoping the
+// wrapper is Astro's own job; what it adds is not ours to pass along.
+const passthrough = Object.fromEntries(
+  Object.entries(rest).filter(([key]) => !key.startsWith("data-astro-")),
+);
+
+// A max of zero has no fraction to read: (0 / 0) * 100 is NaN, and it would
+// reach the DOM as aria-valuenow="NaN" and width: NaN%.
+const percent = max > 0 ? Math.floor((value / max) * 100) : 0;
 ---
 
 <div class:list={["progress-row", className]}>
@@ -27,7 +52,7 @@ const percent = Math.floor((value / max) * 100);
     aria-valuemin="0"
     aria-valuemax="100"
     aria-label={label}
-    {...rest}
+    {...passthrough}
   >
     <div class:list={["progress-fill", { accent }]} style={`width: ${percent}%`}></div>
   </div>

--- a/src/components/kit/ToggleGroup.astro
+++ b/src/components/kit/ToggleGroup.astro
@@ -15,6 +15,14 @@ export interface ToggleItem {
   href?: string;
   /** Disabled state */
   disabled?: boolean;
+  /** How much is behind this item — a plain number, or a fraction like "2/7".
+      Language-neutral by design: a figure needs no translation, and one that
+      did would be a second label. */
+  count?: string | number;
+  /** `tabs` only: id of the element this tab shows. The tab takes the id
+      `${controls}-tab`, which is what the panel points back at with
+      aria-labelledby. */
+  controls?: string;
 }
 
 export interface Props {
@@ -24,8 +32,14 @@ export interface Props {
   value?: string;
   /** Size variant */
   size?: "sm" | "md";
-  /** Visual variant */
-  variant?: "pill" | "separated";
+  /** Visual variant. `tabs` is the only one that is not a set of toggles: it
+      renders a real tablist and needs initToggleTabs (@client/toggle-tabs) to
+      drive it. */
+  variant?: "pill" | "separated" | "tabs";
+  /** `separated` only. `quiet` marks the current item with ink and a wash
+      instead of the accent capsule — for a row that shares its space with
+      something already louder. */
+  tone?: "accent" | "quiet";
   /** Enable horizontal scrolling */
   scrollable?: boolean;
   /** ARIA label for the group */
@@ -44,6 +58,7 @@ const {
   value,
   size = "md",
   variant = "pill",
+  tone = "accent",
   scrollable = false,
   ariaLabel,
   ariaLabelEn,
@@ -52,18 +67,29 @@ const {
   name,
 } = Astro.props;
 
+const isTabs = variant === "tabs";
+const iconSize = size === "sm" ? 14 : 16;
+
 const classes = [
   "kit-toggle-group",
   `kit-toggle-group--${size}`,
   variant === "separated" && "kit-toggle-group--separated",
+  variant === "separated" && tone === "quiet" && "kit-toggle-group--quiet",
+  isTabs && "kit-toggle-group--tabs",
   scrollable && "kit-toggle-group--scrollable",
+  // Start with both edges declared clear. The scrollable variant's mask is a
+  // stylesheet rule and applies from the first paint, so a row that does not
+  // overflow — every one of them on a wide screen — used to spend the frames
+  // before its script ran with its first and last labels faded out. These come
+  // off again in the same tick if there really is something to scroll to.
+  scrollable && "at-start at-end",
   className,
 ].filter(Boolean).join(" ");
 ---
 
 <div
   class={classes}
-  role="group"
+  role={isTabs ? "tablist" : "group"}
   aria-label={ariaLabel}
   data-aria-label-en={ariaLabelEn}
   data-aria-label-ru={ariaLabelRu}
@@ -73,7 +99,41 @@ const classes = [
   {items.map((item) => {
     const isActive = item.id === value;
 
-    const iconSize = size === "sm" ? 14 : 16;
+    {/* The label and its count are the same in all three variants; only the
+        element and the role around them change. */}
+    const content = (
+      <Fragment>
+        {item.icon && <Icon name={item.icon} width={iconSize} height={iconSize} class="kit-toggle-group__icon" />}
+        <span data-en={item.label} data-ru={item.labelRu}>{item.label}</span>
+        {item.count !== undefined && (
+          <span class="kit-toggle-item__count">{item.count}</span>
+        )}
+      </Fragment>
+    );
+
+    {/* A tab, not a toggle: aria-selected rather than aria-pressed (the two
+        must never appear together), and a roving tabindex so the rail is one
+        stop in the tab order with the arrow keys moving inside it. The server
+        renders the roving state for the tab it opens on; initToggleTabs takes
+        it over from there. */}
+    if (isTabs) {
+      return (
+        <button
+          type="button"
+          id={item.controls ? `${item.controls}-tab` : undefined}
+          class="kit-toggle-item"
+          class:list={[{ "is-active": isActive }]}
+          data-id={item.id}
+          role="tab"
+          aria-selected={isActive}
+          aria-controls={item.controls}
+          tabindex={isActive ? 0 : -1}
+          disabled={item.disabled}
+        >
+          {content}
+        </button>
+      );
+    }
 
     if (item.href) {
       return (
@@ -85,8 +145,7 @@ const classes = [
           aria-current={isActive ? "page" : undefined}
           aria-disabled={item.disabled || undefined}
         >
-          {item.icon && <Icon name={item.icon} width={iconSize} height={iconSize} class="kit-toggle-group__icon" />}
-          <span data-en={item.label} data-ru={item.labelRu}>{item.label}</span>
+          {content}
         </a>
       );
     }
@@ -102,11 +161,12 @@ const classes = [
         name={name}
         value={item.id}
       >
-        {item.icon && <Icon name={item.icon} width={iconSize} height={iconSize} class="kit-toggle-group__icon" />}
-        <span data-en={item.label} data-ru={item.labelRu}>{item.label}</span>
+        {content}
       </button>
     );
   })}
+
+  {isTabs && <span class="kit-toggle-group__marker liquid-glass" aria-hidden="true" />}
 
   <slot name="after" />
 </div>

--- a/src/components/travel/TravelChecklist.astro
+++ b/src/components/travel/TravelChecklist.astro
@@ -65,21 +65,28 @@ const stats = getChecklistStats();
 </div>
 
 <style>
-  /* 193 countries, so three columns rather than the two a continent's dozen
-     needs. The count is the only thing this view changes about the shared
-     grid. */
+  /* Two columns, not the three this view used to take. Its rows are the
+     timeline's rows now, and at that size a third column left roughly 160px for
+     a name — enough to clip a dozen of them, "Saint Vincent and the
+     Grenadines" first. Two columns is the longest view on the page by some way,
+     which is what the sticky category heading is for. */
   .countries {
-    --travel-columns: 3;
+    --travel-columns: 2;
   }
 
   /* A country not yet visited is still worth reading — it is the list of what
      is left — so it fades rather than greys: the flag, the tick box and the
-     name recede together instead of the name alone changing colour. */
-  .travel-row {
+     name recede together instead of the name alone changing colour.
+
+     The fade is on the row's contents rather than the row, because an opacity
+     on the row takes its hover wash down with it — pointing at an unvisited
+     country would then answer at a third the strength of pointing at a visited
+     one, which is the row saying something about itself that isn't true. */
+  .travel-row > * {
     opacity: 0.35;
   }
 
-  .travel-row.visited {
+  .travel-row.visited > * {
     opacity: 1;
   }
 
@@ -90,6 +97,9 @@ const stats = getChecklistStats();
     width: 14px;
     height: 14px;
     min-width: 14px;
+    /* The row's gap is the 4px the timeline puts between a flag and a name;
+       between the box and the flag it wants a little more than that. */
+    margin-right: 0.25rem;
     border-radius: 3px;
     border: 1.5px solid light-dark(rgba(0, 0, 0, 0.15), rgba(255, 255, 255, 0.15));
     color: transparent;
@@ -103,11 +113,5 @@ const stats = getChecklistStats();
   .check svg {
     width: 12px;
     height: 12px;
-  }
-
-  @media (max-width: 768px) {
-    .countries {
-      --travel-columns: 2;
-    }
   }
 </style>

--- a/src/components/travel/TravelChecklist.astro
+++ b/src/components/travel/TravelChecklist.astro
@@ -1,18 +1,60 @@
 ---
+import ToggleGroup from "@components/kit/ToggleGroup.astro";
 import { getChecklist, getChecklistStats } from "@lib/travel/checklist";
+import "@styles/kit/checkbox.css";
 import "@styles/travel.css";
-import "flag-icons/css/flag-icons.min.css";
 
 const checklist = getChecklist();
 const stats = getChecklistStats();
+
+// Two hundred and fifty rows, of which thirty-two are ticked. Finding one
+// country among them is a job for the eyes and nothing else, so the view gets
+// the one control that turns it into a short list.
+//
+// It belongs to the whole view rather than to a category, which is why it can't
+// go where the sort went in the countries view: the right of a category heading
+// is taken by that category's score, and the filter is not about one category.
+// So the checklist gets a heading of its own above them — the first it has had
+// — and the category headings dock below it.
+const filters = [
+  { id: "all", label: "All", labelRu: "Все" },
+  { id: "visited", label: "Been", labelRu: "Был" },
+  { id: "remaining", label: "Not yet", labelRu: "Не был" },
+];
 ---
 
-<div class="travel-sections">
+<div class="checklist-view" data-filter="all">
+  {/* No title on this bar. It would be the third landmark in a row and the
+      second one saying the same word — the tab that opened this view is
+      labelled "Checklist" and is still on screen, pinned, forty pixels above.
+      What is left is the control, which is all the bar was for. */}
+  <header class="travel-section-head filter-bar">
+    <ToggleGroup
+      items={filters}
+      value="all"
+      variant="separated"
+      tone="quiet"
+      size="sm"
+      class="filter"
+      ariaLabelEn="Filter the checklist"
+      ariaLabelRu="Фильтр чеклиста"
+    />
+  </header>
+
+  <div class="travel-sections">
   {
     checklist.map((category) => {
       const categoryStats = stats.byCategory[category.id];
       return (
-        <section>
+        // A category with nothing ticked has nothing to show under "Been", and
+        // one where everything is ticked has nothing under "Not yet". Both
+        // counts are known here, so the whole filter is two attributes and a
+        // pair of CSS rules — no counting in the browser, and no heading left
+        // standing over an empty list.
+        <section
+          data-visited={categoryStats.visited}
+          data-remaining={categoryStats.total - categoryStats.visited}
+        >
           <header class="travel-section-head">
             <h2
               class="travel-section-title"
@@ -30,17 +72,27 @@ const stats = getChecklistStats();
               <li
                 class:list={["travel-row", { visited: country.visited }]}
                 data-country={country.a2}
+                data-name-en={country.nameShort}
+                data-name-ru={country.nameShortRu}
               >
-                <span class="check" aria-hidden="true">
+                {/* The kit's mark, not a copy of it — see the note on
+                    .kit-check in checkbox.css. This row used to draw its own:
+                    a 1.5px border that turned accent, with the tick in
+                    currentColor on a viewBox of a different size. */}
+                <span
+                  class:list={["kit-check", { "kit-check--on": country.visited }]}
+                  aria-hidden="true"
+                >
                   {country.visited && (
-                    <svg viewBox="0 0 16 16" fill="none">
-                      <path
-                        d="M12 5.5L7 11L4 8"
-                        stroke="currentColor"
-                        stroke-width="1.5"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                      />
+                    <svg
+                      viewBox="0 0 12 12"
+                      fill="none"
+                      stroke="white"
+                      stroke-width="2"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    >
+                      <polyline points="2.5 6 5 8.5 9.5 3.5" />
                     </svg>
                   )}
                 </span>
@@ -62,9 +114,131 @@ const stats = getChecklistStats();
       );
     })
   }
+  </div>
 </div>
 
+<script>
+  // The filter is two attributes and a handful of CSS rules; this only flips
+  // the one on the view, and publishes the bar's height so the category
+  // headings know how far down to dock.
+  let listening = false;
+  let resort: (() => void) | null = null;
+
+  // The list arrives in the order countries.md is written in, which is English
+  // alphabetical — and on the Russian page that is no order at all: Afghanistan,
+  // Albania, Algeria, Andorra, Angola reads as Афганистан, Албания, Алжир,
+  // Андорра, Ангола, with А, Ал, Ан and Аф interleaved by a spelling nobody on
+  // that page can see. Two hundred and fifty rows sorted by an invisible key.
+  //
+  // The right order is only knowable in the browser, because the language is:
+  // the server sends one document for both. So the rows are sorted here, and
+  // sorted again whenever the language changes.
+  function sortByLanguage(view: HTMLElement) {
+    const locale = document.documentElement.lang === "ru" ? "ru" : "en";
+    const key = locale === "ru" ? "nameRu" : "nameEn";
+    // A collator rather than localeCompare per pair: it is built once instead
+    // of per comparison, and `sensitivity: base` puts Е and Ё together, which
+    // is what a reader looking for Ёмен expects and what the raw code points
+    // refuse to do — Ё sits after я in Unicode.
+    const collator = new Intl.Collator(locale, { sensitivity: "base" });
+
+    for (const list of view.querySelectorAll<HTMLElement>(".countries")) {
+      const rows = Array.from(list.querySelectorAll<HTMLElement>(".travel-row"));
+      rows
+        .sort((a, b) =>
+          collator.compare(a.dataset[key] ?? "", b.dataset[key] ?? ""),
+        )
+        .forEach((row) => list.appendChild(row));
+    }
+  }
+
+  function initChecklistFilter() {
+    const view = document.querySelector<HTMLElement>(".checklist-view");
+    const group = view?.querySelector<HTMLElement>(".filter");
+    if (!view || !group) return;
+
+    const bar = view.querySelector<HTMLElement>(".filter-bar");
+    if (bar) {
+      const publish = () =>
+        view.style.setProperty(
+          "--checklist-filter-offset",
+          `${Math.round(bar.offsetHeight)}px`,
+        );
+      publish();
+      new ResizeObserver(publish).observe(bar);
+    }
+
+    sortByLanguage(view);
+    resort = () => sortByLanguage(view);
+
+    if (listening) return;
+    listening = true;
+
+    window.addEventListener("lang-change", () => resort?.());
+
+    // Delegated on the document, so it survives a page swap without needing to
+    // be taken off and put back on the new bar.
+    document.addEventListener("click", (event) => {
+      const button = (event.target as HTMLElement | null)?.closest<HTMLElement>(
+        ".checklist-view .filter .kit-toggle-item",
+      );
+      const id = button?.dataset.id;
+      if (!button || !id) return;
+
+      const current = button.closest<HTMLElement>(".checklist-view");
+      if (!current) return;
+
+      for (const item of current.querySelectorAll<HTMLElement>(
+        ".filter .kit-toggle-item",
+      )) {
+        const isActive = item === button;
+        item.classList.toggle("is-active", isActive);
+        item.setAttribute("aria-pressed", String(isActive));
+      }
+
+      current.dataset.filter = id;
+    });
+  }
+
+  initChecklistFilter();
+  document.addEventListener("astro:page-load", initChecklistFilter);
+</script>
+
 <style>
+  /* A control strip rather than a heading: pushed to the right, thin, and with
+     no rule of its own — the category heading docking under it has one, and two
+     hairlines forty pixels apart is exactly what the rail gave up its surface
+     to stop. */
+  .filter-bar {
+    justify-content: flex-end;
+    border-bottom: none;
+    padding: 0.15rem 0 0.35rem;
+    margin-bottom: 0;
+  }
+
+  /* Which puts a third pinned thing above the rows — pills, rail, filter — so
+     the category headings clear all three. */
+  .checklist-view .travel-section-head:not(.filter-bar) {
+    top: calc(
+      var(--sticky-header-offset, 0px) + var(--sticky-rail-offset, 0px) +
+        var(--checklist-filter-offset, 0px)
+    );
+    z-index: 9;
+  }
+
+  /* The filter itself. Nothing is removed from the page, only stopped from
+     being drawn, so the counts in the headings still read against the whole
+     category and a screen reader is handed the same list it always was. */
+  .checklist-view[data-filter="visited"] .travel-row:not(.visited),
+  .checklist-view[data-filter="remaining"] .travel-row.visited {
+    display: none;
+  }
+
+  .checklist-view[data-filter="visited"] section[data-visited="0"],
+  .checklist-view[data-filter="remaining"] section[data-remaining="0"] {
+    display: none;
+  }
+
   /* Two columns, not the three this view used to take. Its rows are the
      timeline's rows now, and at that size a third column left roughly 160px for
      a name — enough to clip a dozen of them, "Saint Vincent and the
@@ -75,43 +249,46 @@ const stats = getChecklistStats();
   }
 
   /* A country not yet visited is still worth reading — it is the list of what
-     is left — so it fades rather than greys: the flag, the tick box and the
-     name recede together instead of the name alone changing colour.
+     is left — so the whole row used to fade to 0.35 together, marks and name
+     alike. That is 2.27:1 against this page in the light scheme and 3.16:1 in
+     the dark: not "receded", illegible, and for two hundred and eighteen of the
+     two hundred and fifty rows here. There is no opacity that fixes it either —
+     the name only clears 4.5:1 somewhere past 0.7, by which point it has
+     stopped fading at all.
 
-     The fade is on the row's contents rather than the row, because an opacity
-     on the row takes its hover wash down with it — pointing at an unvisited
-     country would then answer at a third the strength of pointing at a visited
-     one, which is the row saying something about itself that isn't true. */
-  .travel-row > * {
-    opacity: 0.35;
+     So the name takes a colour instead of a fraction of one, and only the two
+     marks beside it keep fading. Words are read and get a legible value; a flag
+     and an empty socket are glanced at, and can recede as far as they like.
+
+     Either way the fade is on the row's contents rather than the row, because
+     an opacity on the row takes its hover wash down with it — pointing at an
+     unvisited country would then answer at a third the strength of pointing at
+     a visited one, which is the row saying something about itself that isn't
+     true. */
+  .travel-row > .travel-name {
+    color: var(--travel-muted);
   }
 
-  .travel-row.visited > * {
+  .travel-row > .kit-check,
+  .travel-row > .travel-flag {
+    opacity: 0.45;
+  }
+
+  .travel-row.visited > .travel-name {
+    color: inherit;
+  }
+
+  .travel-row.visited > .kit-check,
+  .travel-row.visited > .travel-flag {
     opacity: 1;
   }
 
-  .check {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 14px;
-    height: 14px;
-    min-width: 14px;
+  /* Only the size and the spacing are this view's business; the socket, the
+     fill and the tick all come from the kit. */
+  .kit-check {
+    --kit-check-size: 14px;
     /* The row's gap is the 4px the timeline puts between a flag and a name;
-       between the box and the flag it wants a little more than that. */
+       between the mark and the flag it wants a little more than that. */
     margin-right: 0.25rem;
-    border-radius: 3px;
-    border: 1.5px solid light-dark(rgba(0, 0, 0, 0.15), rgba(255, 255, 255, 0.15));
-    color: transparent;
-  }
-
-  .travel-row.visited .check {
-    border-color: light-dark(var(--accent-start), var(--accent-end));
-    color: light-dark(var(--accent-start), var(--accent-end));
-  }
-
-  .check svg {
-    width: 12px;
-    height: 12px;
   }
 </style>

--- a/src/components/travel/TravelChecklist.astro
+++ b/src/components/travel/TravelChecklist.astro
@@ -1,29 +1,34 @@
 ---
 import { getChecklist, getChecklistStats } from "@lib/travel/checklist";
+import "@styles/travel.css";
 import "flag-icons/css/flag-icons.min.css";
 
 const checklist = getChecklist();
 const stats = getChecklistStats();
 ---
 
-<div class="checklist">
+<div class="travel-sections">
   {
     checklist.map((category) => {
       const categoryStats = stats.byCategory[category.id];
       return (
-        <section class="category">
-          <header class="category-header">
-            <h2 data-en={category.name} data-ru={category.nameRu}>
+        <section>
+          <header class="travel-section-head">
+            <h2
+              class="travel-section-title"
+              data-en={category.name}
+              data-ru={category.nameRu}
+            >
               {category.name}
             </h2>
-            <span class="category-count">
-              {categoryStats.visited}/{categoryStats.total}
+            <span class="travel-metric">
+              {categoryStats.visited} / {categoryStats.total}
             </span>
           </header>
-          <ul class="country-grid" role="list">
+          <ul class="travel-grid countries" role="list">
             {category.countries.map((country) => (
               <li
-                class:list={["country-item", { visited: country.visited }]}
+                class:list={["travel-row", { visited: country.visited }]}
                 data-country={country.a2}
               >
                 <span class="check" aria-hidden="true">
@@ -41,12 +46,15 @@ const stats = getChecklistStats();
                 </span>
                 {country.a2 && !country.a2.startsWith("xx") && (
                   <span
-                    class={`fi fi-${country.a2}`}
-                    role="img"
-                    aria-label={`${country.nameShort} flag`}
+                    class={`travel-flag fi fi-${country.a2}`}
+                    aria-hidden="true"
                   />
                 )}
-                <span class="country-name" data-en={country.nameShort} data-ru={country.nameShortRu}>{country.nameShort}</span>
+                <span
+                  class="travel-name"
+                  data-en={country.nameShort}
+                  data-ru={country.nameShortRu}
+                >{country.nameShort}</span>
               </li>
             ))}
           </ul>
@@ -57,57 +65,21 @@ const stats = getChecklistStats();
 </div>
 
 <style>
-  .checklist {
-    display: flex;
-    flex-direction: column;
-    gap: 2rem;
+  /* 193 countries, so three columns rather than the two a continent's dozen
+     needs. The count is the only thing this view changes about the shared
+     grid. */
+  .countries {
+    --travel-columns: 3;
   }
 
-  .category-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 1rem;
-    padding-bottom: 0.5rem;
-    margin-bottom: 0.5rem;
-    border-bottom: 1px solid light-dark(rgba(0, 0, 0, 0.1), rgba(255, 255, 255, 0.1));
-  }
-
-  .category-header h2 {
-    margin: 0;
-    font-size: 0.8rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    color: light-dark(#666, #888);
-  }
-
-  .category-count {
-    font-size: 0.8rem;
-    font-weight: 500;
-    color: light-dark(#888, #666);
-    font-variant-numeric: tabular-nums;
-    white-space: nowrap;
-  }
-
-  .country-grid {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: 0;
-    margin: 0;
-    padding: 0;
-    list-style: none;
-  }
-
-  .country-item {
-    display: flex;
-    align-items: center;
-    gap: 0.4rem;
-    padding: 0.25rem 0;
+  /* A country not yet visited is still worth reading — it is the list of what
+     is left — so it fades rather than greys: the flag, the tick box and the
+     name recede together instead of the name alone changing colour. */
+  .travel-row {
     opacity: 0.35;
   }
 
-  .country-item.visited {
+  .travel-row.visited {
     opacity: 1;
   }
 
@@ -123,7 +95,7 @@ const stats = getChecklistStats();
     color: transparent;
   }
 
-  .country-item.visited .check {
+  .travel-row.visited .check {
     border-color: light-dark(var(--accent-start), var(--accent-end));
     color: light-dark(var(--accent-start), var(--accent-end));
   }
@@ -133,41 +105,9 @@ const stats = getChecklistStats();
     height: 12px;
   }
 
-  .fi {
-    font-size: 0.85rem;
-    border-radius: 2px;
-  }
-
-  .country-name {
-    font-size: 0.85rem;
-    color: light-dark(#555, #999);
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    line-height: 1.3;
-  }
-
-  .country-item.visited .country-name {
-    color: light-dark(#111, #eee);
-  }
-
-  /* Tablet */
   @media (max-width: 768px) {
-    .country-grid {
-      grid-template-columns: repeat(2, 1fr);
-    }
-
-    .category-header {
-      flex-direction: column;
-      align-items: flex-start;
-      gap: 0.5rem;
-    }
-  }
-
-  /* Mobile */
-  @media (max-width: 480px) {
-    .country-grid {
-      grid-template-columns: 1fr;
+    .countries {
+      --travel-columns: 2;
     }
   }
 </style>

--- a/src/components/travel/TravelContinents.astro
+++ b/src/components/travel/TravelContinents.astro
@@ -36,15 +36,19 @@ const remaining = continents.filter(
             {continent.visited} / {continent.total}
           </span>
         </header>
-        <ProgressBar
-          value={continent.visited}
-          max={continent.total}
-          showPercent={false}
-          accent
-          label={`${continent.name.en}: ${continent.visited} of ${continent.total} countries visited`}
-          data-aria-label-en={`${continent.name.en}: ${continent.visited} of ${continent.total} countries visited`}
-          data-aria-label-ru={`${continent.name.ru}: посещено ${continent.visited} из ${continent.total} стран`}
-        />
+        {/* Same reason the fraction below is withheld for Antarctica: a
+            continent with no countries to count has no progress to draw. */}
+        {continent.total > 0 && (
+          <ProgressBar
+            value={continent.visited}
+            max={continent.total}
+            showPercent={false}
+            accent
+            label={`${continent.name.en}: ${continent.visited} of ${continent.total} countries visited`}
+            data-aria-label-en={`${continent.name.en}: ${continent.visited} of ${continent.total} countries visited`}
+            data-aria-label-ru={`${continent.name.ru}: посещено ${continent.visited} из ${continent.total} стран`}
+          />
+        )}
         <ul class="travel-grid countries" role="list">
           {continent.countries.map((country) => (
             <li class="travel-row">
@@ -103,6 +107,28 @@ const remaining = continents.filter(
       </section>
     )
   }
+
+  {/* The counters above this view read "32 / 250" and the fractions here add up
+      to "32 / 195" — the same numerator against two different ideas of how many
+      countries there are. Both are honest on their own: 250 is the site's own
+      list, which goes on past the UN membership, while a per-continent total
+      only exists for the 195 everyone splits the same way. Together on one page
+      they read as an arithmetic error unless the page says which is which. */}
+  <p class="note">
+    <span
+      data-en="Totals here count the 195 UN member and observer states. The counters above measure against a longer list."
+      data-ru="Итоги здесь считаются от 195 государств — членов и наблюдателей ООН. Счётчики выше — по более длинному списку."
+    >
+      Totals here count the 195 UN member and observer states. The counters
+      above measure against a longer list.
+    </span>
+    <a
+      href="/travel/countries"
+      target="_blank"
+      data-en="See the list"
+      data-ru="Посмотреть список">See the list</a
+    >
+  </p>
 </div>
 
 <style>
@@ -111,5 +137,26 @@ const remaining = continents.filter(
      summary. */
   .countries {
     margin-top: 0.85rem;
+  }
+
+  /* An aside about the arithmetic, not a section of its own — set below the
+     body size and in the muted colour the metrics use, so it settles under the
+     last section instead of competing with it. */
+  .note {
+    margin: 0;
+    font-size: 0.8rem;
+    line-height: 1.5;
+    color: light-dark(#666, #8a8a90);
+    text-wrap: pretty;
+  }
+
+  .note a {
+    color: inherit;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+  }
+
+  .note a:hover {
+    color: light-dark(#1a1a1a, #fff);
   }
 </style>

--- a/src/components/travel/TravelContinents.astro
+++ b/src/components/travel/TravelContinents.astro
@@ -6,15 +6,30 @@ import {
   getCountriesByContinent,
 } from "@lib/travel";
 import "@styles/travel.css";
-import "flag-icons/css/flag-icons.min.css";
 
 const continents = getCountriesByContinent(datedTrips);
 
-// Five sections that say nothing would drown the two that do, so the untouched
-// continents collapse into one closing section. They are still named — half
-// the point of a continents view is what is left to go, and a missing Africa
-// would read as a rendering bug rather than as zero.
+// The untouched continents close the view in a single line, and that line is
+// names only. They used to be five rows of the same shape the countries above
+// them use — and a row here means "a place I have been, and how much of it"
+// thirty-two times before you reach them. Five more meaning the opposite, each
+// with a nought over a total, read as data that had failed to load rather than
+// as a nought; there was nothing to compare down that column, and Antarctica
+// fell out of it anyway with a dash, because 0 / 0 is not a target.
+//
+// No sizes either, and no total. Every figure this line could carry is a figure
+// about places nobody has been, and the page already has four counters saying
+// how much there is and how much of it is done. What is left for this line to
+// say is which parts of the world they are, and that is a list of names.
+//
+// Named, though, and all of them: half the point of a continents view is what
+// is still to go, and a missing Africa would read as a rendering bug rather
+// than as zero.
 const visited = continents.filter((continent) => continent.countries.length > 0);
+
+// In the order the continents come in, which is the order they are in
+// everywhere else on the site. With no numbers on the line there is nothing for
+// a sort by size to express, and Antarctica lands at the end here anyway.
 const remaining = continents.filter(
   (continent) => continent.countries.length === 0,
 );
@@ -76,59 +91,21 @@ const remaining = continents.filter(
 
   {
     remaining.length > 0 && (
-      <section>
-        <header class="travel-section-head">
-          <h2
-            class="travel-section-title"
-            data-en="Still to go"
-            data-ru="Ещё предстоит"
-          >
-            Still to go
-          </h2>
-        </header>
-        <ul class="travel-grid" role="list">
-          {remaining.map((continent) => (
-            <li class="travel-row">
-              <span
-                class="travel-name travel-name--muted"
-                data-en={continent.name.en}
-                data-ru={continent.name.ru}
-              >
-                {continent.name.en}
-              </span>
-              {/* Antarctica has no countries to count, so a fraction there
-                  would be a hollow "0 / 0" rather than a target. */}
-              <span class="travel-metric travel-metric--trailing">
-                {continent.total > 0 ? `0 / ${continent.total}` : "—"}
-              </span>
-            </li>
-          ))}
-        </ul>
-      </section>
+      <p class="remaining">
+        <span class="lead" data-en="Still to go:" data-ru="Ещё предстоит:">
+          Still to go:
+        </span>{" "}
+        {remaining.map((continent, i) => (
+          <>
+            <span data-en={continent.name.en} data-ru={continent.name.ru}>
+              {continent.name.en}
+            </span>
+            {i < remaining.length - 1 && ", "}
+          </>
+        ))}
+      </p>
     )
   }
-
-  {/* The counters above this view read "32 / 250" and the fractions here add up
-      to "32 / 195" — the same numerator against two different ideas of how many
-      countries there are. Both are honest on their own: 250 is the site's own
-      list, which goes on past the UN membership, while a per-continent total
-      only exists for the 195 everyone splits the same way. Together on one page
-      they read as an arithmetic error unless the page says which is which. */}
-  <p class="note">
-    <span
-      data-en="Totals here count the 195 UN member and observer states. The counters above measure against a longer list."
-      data-ru="Итоги здесь считаются от 195 государств — членов и наблюдателей ООН. Счётчики выше — по более длинному списку."
-    >
-      Totals here count the 195 UN member and observer states. The counters
-      above measure against a longer list.
-    </span>
-    <a
-      href="/travel/countries"
-      target="_blank"
-      data-en="See the list"
-      data-ru="Посмотреть список">See the list</a
-    >
-  </p>
 </div>
 
 <style>
@@ -140,24 +117,22 @@ const remaining = continents.filter(
     margin-top: 0.5rem;
   }
 
-  /* An aside about the arithmetic, not a section of its own — set below the
-     body size and in the colour the views give secondary text, so it settles
-     under the last section instead of competing with it. */
-  .note {
+  /* A closing line, not a footnote: it is the last thing the view has to say
+     rather than an aside about it, so it stays at the body size the rows above
+     it are set in. Only its colour steps back. */
+  .remaining {
     margin: 0;
-    font-size: 0.85rem;
-    line-height: 1.5;
-    color: var(--travel-quiet);
+    font-size: 1rem;
+    line-height: 1.6;
+    color: var(--travel-muted);
     text-wrap: pretty;
   }
 
-  .note a {
-    color: inherit;
-    text-decoration: underline;
-    text-underline-offset: 2px;
-  }
-
-  .note a:hover {
-    color: light-dark(#1a1a1a, #fff);
+  /* The words that were a section heading, now opening a sentence — in the
+     colour of a heading and nothing else, since a 1.25rem landmark over a
+     single line was the weight this change was written to shed. */
+  .lead {
+    color: light-dark(#333, #fafafa);
+    font-weight: 600;
   }
 </style>

--- a/src/components/travel/TravelContinents.astro
+++ b/src/components/travel/TravelContinents.astro
@@ -1,0 +1,203 @@
+---
+import Badge from "@components/kit/Badge.astro";
+import ProgressBar from "@components/kit/ProgressBar.astro";
+import {
+  datedTrips,
+  formatCityCount,
+  getCountriesByContinent,
+} from "@lib/travel";
+import "flag-icons/css/flag-icons.min.css";
+
+const continents = getCountriesByContinent(datedTrips);
+
+// Seven glass cards where five of them say nothing would drown the two that do,
+// so the untouched continents collapse into one closing card. They are still
+// named — half the point of a continents view is what is left to go, and a
+// missing Africa would read as a rendering bug rather than as zero.
+const visited = continents.filter((continent) => continent.countries.length > 0);
+const remaining = continents.filter(
+  (continent) => continent.countries.length === 0,
+);
+---
+
+<div class="continents">
+  {
+    visited.map((continent) => (
+      <section class="card">
+        <header class="head">
+          <h2 data-en={continent.name.en} data-ru={continent.name.ru}>
+            {continent.name.en}
+          </h2>
+          <Badge size="sm">{continent.visited} / {continent.total}</Badge>
+        </header>
+        <ProgressBar
+          value={continent.visited}
+          max={continent.total}
+          showPercent={false}
+          accent
+          label={`${continent.name.en}: ${continent.visited} of ${continent.total} countries visited`}
+        />
+        <ul class="countries" role="list">
+          {continent.countries.map((country) => (
+            <li class="country">
+              <span class={`fi fi-${country.a2}`} aria-hidden="true" />
+              <span
+                class="name"
+                data-en={country.name.en}
+                data-ru={country.name.ru}
+              >
+                {country.name.en}
+              </span>
+              <span
+                class="cities"
+                data-en={formatCityCount(country.cities.length, "en")}
+                data-ru={formatCityCount(country.cities.length, "ru")}
+              >
+                {formatCityCount(country.cities.length, "en")}
+              </span>
+            </li>
+          ))}
+        </ul>
+      </section>
+    ))
+  }
+
+  {
+    remaining.length > 0 && (
+      <section class="card">
+        <header class="head">
+          <h2 data-en="Still to go" data-ru="Ещё предстоит">
+            Still to go
+          </h2>
+        </header>
+        <ul class="countries" role="list">
+          {remaining.map((continent) => (
+            <li class="country">
+              <span
+                class="name muted"
+                data-en={continent.name.en}
+                data-ru={continent.name.ru}
+              >
+                {continent.name.en}
+              </span>
+              {/* Antarctica has no countries to count, so a fraction there
+                  would be a hollow "0 / 0" rather than a target. */}
+              <span class="cities">
+                {continent.total > 0 ? `0 / ${continent.total}` : "—"}
+              </span>
+            </li>
+          ))}
+        </ul>
+      </section>
+    )
+  }
+</div>
+
+<style>
+  .continents {
+    display: flex;
+    flex-direction: column;
+    /* The page's own grid gap, so the cards sit on the same rhythm as the stat
+       strip and the map rather than a tighter one of their own. */
+    gap: 1.25rem;
+  }
+
+  /* The same material as the stat strip and a wishlist card: tint, border,
+     shadow and rim all from the shared tokens, and the same 20px radius so the
+     three read as one family of surfaces. */
+  .card {
+    position: relative;
+    background: var(--card-bg);
+    border: var(--glass-border);
+    border-radius: 20px;
+    box-shadow: var(--glass-shadow);
+    padding: 1rem 1.1rem;
+  }
+
+  /* The refractive rim — a lens edge lit from the top left. */
+  .card::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    pointer-events: none;
+    box-shadow: var(--glass-rim);
+  }
+
+  .head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 0.7rem;
+  }
+
+  .head h2 {
+    margin: 0;
+    font-size: 0.85rem;
+    font-weight: 500;
+    color: light-dark(#666, #9a9aa0);
+  }
+
+  /* Two columns on a card this wide: 23 European countries in a single stack
+     is a scroll, and each row is a flag, a short name and a small number. */
+  .countries {
+    columns: 2;
+    column-gap: 1.5rem;
+    margin: 0.85rem 0 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  /* break-inside keeps a row from being split across the column boundary,
+     which multi-column layout will otherwise do mid-line. */
+  .country {
+    display: flex;
+    align-items: baseline;
+    gap: 0.45rem;
+    padding: 0.2rem 0;
+    break-inside: avoid;
+    font-size: 0.85rem;
+  }
+
+  .country .fi {
+    flex-shrink: 0;
+    font-size: 0.8rem;
+    border-radius: 2px;
+    /* The flag is a box on the text baseline, so it needs nudging back down to
+       sit with the letters rather than on top of them. */
+    transform: translateY(0.1em);
+  }
+
+  .name {
+    color: light-dark(#111, #eee);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .name.muted {
+    color: light-dark(#666, #9a9aa0);
+  }
+
+  /* Pushed to the right edge of its column so the counts line up down the list
+     instead of trailing each name at a different offset. */
+  .cities {
+    margin-left: auto;
+    padding-left: 0.5rem;
+    font-size: 0.8rem;
+    color: light-dark(#888, #8a8a90);
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+  }
+
+  @media (max-width: 520px) {
+    .countries {
+      columns: 1;
+    }
+
+    .card {
+      padding: 0.85rem 0.9rem;
+    }
+  }
+</style>

--- a/src/components/travel/TravelContinents.astro
+++ b/src/components/travel/TravelContinents.astro
@@ -1,34 +1,40 @@
 ---
-import Badge from "@components/kit/Badge.astro";
 import ProgressBar from "@components/kit/ProgressBar.astro";
 import {
   datedTrips,
   formatCityCount,
   getCountriesByContinent,
 } from "@lib/travel";
+import "@styles/travel.css";
 import "flag-icons/css/flag-icons.min.css";
 
 const continents = getCountriesByContinent(datedTrips);
 
-// Seven glass cards where five of them say nothing would drown the two that do,
-// so the untouched continents collapse into one closing card. They are still
-// named — half the point of a continents view is what is left to go, and a
-// missing Africa would read as a rendering bug rather than as zero.
+// Five sections that say nothing would drown the two that do, so the untouched
+// continents collapse into one closing section. They are still named — half
+// the point of a continents view is what is left to go, and a missing Africa
+// would read as a rendering bug rather than as zero.
 const visited = continents.filter((continent) => continent.countries.length > 0);
 const remaining = continents.filter(
   (continent) => continent.countries.length === 0,
 );
 ---
 
-<div class="continents">
+<div class="travel-sections">
   {
     visited.map((continent) => (
-      <section class="card">
-        <header class="head">
-          <h2 data-en={continent.name.en} data-ru={continent.name.ru}>
+      <section>
+        <header class="travel-section-head">
+          <h2
+            class="travel-section-title"
+            data-en={continent.name.en}
+            data-ru={continent.name.ru}
+          >
             {continent.name.en}
           </h2>
-          <Badge size="sm">{continent.visited} / {continent.total}</Badge>
+          <span class="travel-metric">
+            {continent.visited} / {continent.total}
+          </span>
         </header>
         <ProgressBar
           value={continent.visited}
@@ -39,19 +45,19 @@ const remaining = continents.filter(
           data-aria-label-en={`${continent.name.en}: ${continent.visited} of ${continent.total} countries visited`}
           data-aria-label-ru={`${continent.name.ru}: посещено ${continent.visited} из ${continent.total} стран`}
         />
-        <ul class="countries" role="list">
+        <ul class="travel-grid countries" role="list">
           {continent.countries.map((country) => (
-            <li class="country">
-              <span class={`fi fi-${country.a2}`} aria-hidden="true" />
+            <li class="travel-row">
+              <span class={`travel-flag fi fi-${country.a2}`} aria-hidden="true" />
               <span
-                class="name"
+                class="travel-name"
                 data-en={country.name.en}
                 data-ru={country.name.ru}
               >
                 {country.name.en}
               </span>
               <span
-                class="cities"
+                class="travel-metric travel-metric--trailing"
                 data-en={formatCityCount(country.cities.length, "en")}
                 data-ru={formatCityCount(country.cities.length, "ru")}
               >
@@ -66,17 +72,21 @@ const remaining = continents.filter(
 
   {
     remaining.length > 0 && (
-      <section class="card">
-        <header class="head">
-          <h2 data-en="Still to go" data-ru="Ещё предстоит">
+      <section>
+        <header class="travel-section-head">
+          <h2
+            class="travel-section-title"
+            data-en="Still to go"
+            data-ru="Ещё предстоит"
+          >
             Still to go
           </h2>
         </header>
-        <ul class="countries" role="list">
+        <ul class="travel-grid" role="list">
           {remaining.map((continent) => (
-            <li class="country">
+            <li class="travel-row">
               <span
-                class="name muted"
+                class="travel-name travel-name--muted"
                 data-en={continent.name.en}
                 data-ru={continent.name.ru}
               >
@@ -84,7 +94,7 @@ const remaining = continents.filter(
               </span>
               {/* Antarctica has no countries to count, so a fraction there
                   would be a hollow "0 / 0" rather than a target. */}
-              <span class="cities">
+              <span class="travel-metric travel-metric--trailing">
                 {continent.total > 0 ? `0 / ${continent.total}` : "—"}
               </span>
             </li>
@@ -96,110 +106,10 @@ const remaining = continents.filter(
 </div>
 
 <style>
-  .continents {
-    display: flex;
-    flex-direction: column;
-    /* The page's own grid gap, so the cards sit on the same rhythm as the stat
-       strip and the map rather than a tighter one of their own. */
-    gap: 1.25rem;
-  }
-
-  /* The same material as the stat strip and a wishlist card: tint, border,
-     shadow and rim all from the shared tokens, and the same 20px radius so the
-     three read as one family of surfaces. */
-  .card {
-    position: relative;
-    background: var(--card-bg);
-    border: var(--glass-border);
-    border-radius: 20px;
-    box-shadow: var(--glass-shadow);
-    padding: 1rem 1.1rem;
-  }
-
-  /* The refractive rim — a lens edge lit from the top left. */
-  .card::after {
-    content: "";
-    position: absolute;
-    inset: 0;
-    border-radius: inherit;
-    pointer-events: none;
-    box-shadow: var(--glass-rim);
-  }
-
-  .head {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 1rem;
-    margin-bottom: 0.7rem;
-  }
-
-  .head h2 {
-    margin: 0;
-    font-size: 0.85rem;
-    font-weight: 500;
-    color: light-dark(#666, #9a9aa0);
-  }
-
-  /* Two columns on a card this wide: 23 European countries in a single stack
-     is a scroll, and each row is a flag, a short name and a small number. */
+  /* Air under the progress bar. Without it the bar touches the first row of
+     countries and reads as that row's underline rather than as the section's
+     summary. */
   .countries {
-    columns: 2;
-    column-gap: 1.5rem;
-    margin: 0.85rem 0 0;
-    padding: 0;
-    list-style: none;
-  }
-
-  /* break-inside keeps a row from being split across the column boundary,
-     which multi-column layout will otherwise do mid-line. */
-  .country {
-    display: flex;
-    align-items: baseline;
-    gap: 0.45rem;
-    padding: 0.2rem 0;
-    break-inside: avoid;
-    font-size: 0.85rem;
-  }
-
-  .country .fi {
-    flex-shrink: 0;
-    font-size: 0.8rem;
-    border-radius: 2px;
-    /* The flag is a box on the text baseline, so it needs nudging back down to
-       sit with the letters rather than on top of them. */
-    transform: translateY(0.1em);
-  }
-
-  .name {
-    color: light-dark(#111, #eee);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .name.muted {
-    color: light-dark(#666, #9a9aa0);
-  }
-
-  /* Pushed to the right edge of its column so the counts line up down the list
-     instead of trailing each name at a different offset. */
-  .cities {
-    margin-left: auto;
-    padding-left: 0.5rem;
-    font-size: 0.8rem;
-    color: light-dark(#888, #8a8a90);
-    font-variant-numeric: tabular-nums;
-    white-space: nowrap;
-  }
-
-  @media (max-width: 520px) {
-    .countries {
-      columns: 1;
-    }
-
-    .card {
-      padding: 0.85rem 0.9rem;
-    }
+    margin-top: 0.85rem;
   }
 </style>

--- a/src/components/travel/TravelContinents.astro
+++ b/src/components/travel/TravelContinents.astro
@@ -36,6 +36,8 @@ const remaining = continents.filter(
           showPercent={false}
           accent
           label={`${continent.name.en}: ${continent.visited} of ${continent.total} countries visited`}
+          data-aria-label-en={`${continent.name.en}: ${continent.visited} of ${continent.total} countries visited`}
+          data-aria-label-ru={`${continent.name.ru}: посещено ${continent.visited} из ${continent.total} стран`}
         />
         <ul class="countries" role="list">
           {continent.countries.map((country) => (

--- a/src/components/travel/TravelContinents.astro
+++ b/src/components/travel/TravelContinents.astro
@@ -134,19 +134,20 @@ const remaining = continents.filter(
 <style>
   /* Air under the progress bar. Without it the bar touches the first row of
      countries and reads as that row's underline rather than as the section's
-     summary. */
+     summary. 0.5rem is the gap the heading above it keeps, and the rows now
+     carry 0.5rem of padding of their own on top of it. */
   .countries {
-    margin-top: 0.85rem;
+    margin-top: 0.5rem;
   }
 
   /* An aside about the arithmetic, not a section of its own — set below the
-     body size and in the muted colour the metrics use, so it settles under the
-     last section instead of competing with it. */
+     body size and in the colour the views give secondary text, so it settles
+     under the last section instead of competing with it. */
   .note {
     margin: 0;
-    font-size: 0.8rem;
+    font-size: 0.85rem;
     line-height: 1.5;
-    color: light-dark(#666, #8a8a90);
+    color: var(--travel-quiet);
     text-wrap: pretty;
   }
 

--- a/src/components/travel/TravelCountries.astro
+++ b/src/components/travel/TravelCountries.astro
@@ -7,10 +7,13 @@ import "flag-icons/css/flag-icons.min.css";
 const countriesWithCities = getCountriesWithCities(datedTrips);
 ---
 
-<div class="countries-view">
+{/* One column, so the shared grid is here only for the row shell it brings —
+    a country's cities run to the end of the line and would be cut in half by a
+    second column. */}
+<ul class="travel-grid countries" role="list">
   {
     countriesWithCities.map((country) => (
-      <div class="country-row">
+      <li class="travel-row travel-row--flow">
         <span
           class={`travel-flag flag fi fi-${country.a2}`}
           aria-hidden="true"
@@ -30,55 +33,40 @@ const countriesWithCities = getCountriesWithCities(datedTrips);
             >{city}{i < country.cities.length - 1 ? "," : ""}</span>{" "}
           </>
         ))}
-      </div>
+      </li>
     ))
   }
-</div>
+</ul>
 
 <style>
-  .countries-view {
-    display: flex;
-    flex-direction: column;
+  .countries {
+    --travel-columns: 1;
   }
 
-  .country-row {
-    padding: 0.4rem 0.5rem;
-    border-radius: 6px;
-    line-height: 1.7;
-    color: light-dark(#666, #888);
-    font-size: 0.85rem;
-    transition: background-color 0.15s ease;
-  }
-
-  .country-row:hover {
-    background: light-dark(rgba(0, 0, 0, 0.03), rgba(255, 255, 255, 0.04));
-  }
-
-  /* The shared flag is written for a flex row, where the browser puts it on
-     the centre line for you. Here it sits in running text and has to be told. */
+  /* The shared flag is written for a flex row, where the browser puts it on the
+     centre line for you. Here it sits in running text and takes the timeline's
+     own offset and gap instead. */
   .flag {
-    margin-right: 0.4rem;
-    vertical-align: middle;
+    margin-right: 4px;
+    vertical-align: -0.12em;
   }
 
-  /* How many cities the row is about to list. Sits inline after the name
-     rather than at the end of the row, because the row keeps going. */
+  /* How many cities the row is about to list. Sits inline after the name rather
+     than at the end of the row, because the row keeps going. */
   .city-count {
     margin-left: 0.2rem;
   }
 
+  /* The same colour the timeline gives the arrows between its cities. */
   .separator {
-    color: light-dark(#ccc, #444);
+    color: light-dark(#999, #666);
     margin: 0 0.3rem;
   }
 
+  /* The cities are what the row goes on to say, so they stay readable rather
+     than dropping to the colour of a count. */
   .city {
+    color: var(--travel-quiet);
     white-space: nowrap;
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    .country-row {
-      transition: none;
-    }
   }
 </style>

--- a/src/components/travel/TravelCountries.astro
+++ b/src/components/travel/TravelCountries.astro
@@ -1,46 +1,251 @@
 ---
-import { datedTrips, getCountriesWithCities } from "@lib/travel";
+import ToggleGroup from "@components/kit/ToggleGroup.astro";
+import {
+  datedTrips,
+  formatVisitCount,
+  getCountriesWithCities,
+} from "@lib/travel";
 import { getCityName } from "@lib/travel/cities-i18n";
 import "@styles/travel.css";
-import "flag-icons/css/flag-icons.min.css";
 
 const countriesWithCities = getCountriesWithCities(datedTrips);
+
+// Three ways through the same 32 rows. The lib hands them over in the first
+// order, which is why it is the default here — the other two are applied in the
+// browser, on the rows already on the page.
+const sorts = [
+  { id: "cities", label: "By cities", labelRu: "По городам" },
+  { id: "name", label: "A–Z", labelRu: "А–Я" },
+  { id: "first", label: "By first visit", labelRu: "По первому визиту" },
+];
 ---
 
-{/* One column, so the shared grid is here only for the row shell it brings —
-    a country's cities run to the end of the line and would be cut in half by a
-    second column. */}
-<ul class="travel-grid countries" role="list">
-  {
-    countriesWithCities.map((country) => (
-      <li class="travel-row travel-row--flow">
-        <span
-          class={`travel-flag flag fi fi-${country.a2}`}
-          aria-hidden="true"
-        /><span
-          class="travel-name country-name"
-          data-en={country.name.en}
-          data-ru={country.name.ru}
-        >{country.name.en}</span>
-        <span class="travel-metric city-count">({country.cities.length})</span>
-        <span class="separator" aria-hidden="true">—</span>
-        {country.cities.map((city, i) => (
-          <>
-            <span
-              class="city"
-              data-en={`${city}${i < country.cities.length - 1 ? "," : ""}`}
-              data-ru={`${getCityName(city, "ru")}${i < country.cities.length - 1 ? "," : ""}`}
-            >{city}{i < country.cities.length - 1 ? "," : ""}</span>{" "}
-          </>
-        ))}
-      </li>
-    ))
+<div class="countries-view">
+  <header class="travel-section-head">
+    <h2 class="travel-section-title" data-en="Countries" data-ru="Страны">
+      Countries
+    </h2>
+    <ToggleGroup
+      items={sorts}
+      value="cities"
+      variant="separated"
+      tone="quiet"
+      size="sm"
+      class="sort"
+      ariaLabelEn="Sort countries"
+      ariaLabelRu="Сортировка стран"
+    />
+  </header>
+
+  {/* One column, so the shared grid is here only for the row shell it brings —
+      a country's cities run to the end of the line and would be cut in half by
+      a second column. */}
+  <ul class="travel-grid countries" role="list">
+    {
+      countriesWithCities.map((country) => (
+        <li
+          class="travel-row travel-row--flow"
+          data-name-en={country.name.en}
+          data-name-ru={country.name.ru}
+          data-cities={country.cities.length}
+          data-first-seen={country.firstSeen ?? ""}
+        >
+          <span
+            class={`travel-flag flag fi fi-${country.a2}`}
+            aria-hidden="true"
+          /><span
+            class="travel-name country-name"
+            data-en={country.name.en}
+            data-ru={country.name.ru}
+          >{country.name.en}</span>
+          <span class="separator" aria-hidden="true">—</span>
+          {country.cities.map((city, i) => (
+            <>
+              <span class="city">
+                <span
+                  data-en={getCityName(city.name, "en")}
+                  data-ru={getCityName(city.name, "ru")}
+                >{city.name}</span>
+                {/* Only where it says something. Eight of eighty-six cities
+                    have been seen more than once, so a number here is rare
+                    enough to mean "I went back" — one beside every city would
+                    be seventy-eight ways of writing "once". */}
+                {city.visits > 1 && (
+                  <span
+                    class="travel-metric visits"
+                    data-tooltip={formatVisitCount(city.visits, "en")}
+                    data-tooltip-en={formatVisitCount(city.visits, "en")}
+                    data-tooltip-ru={formatVisitCount(city.visits, "ru")}
+                  >
+                    ({city.visits})
+                  </span>
+                )}
+                {i < country.cities.length - 1 && ","}
+              </span>{" "}
+            </>
+          ))}
+          {/* The year the country entered the list. It is the one thing this
+              view could not say before: four lists of the same 32 countries,
+              and not one of them had time in it. In its own column rather than
+              inline, because a column of years is read down the page and a year
+              buried in running text is not. */}
+          {country.firstYear !== null && (
+            <span class="travel-metric first">{country.firstYear}</span>
+          )}
+        </li>
+      ))
+    }
+  </ul>
+</div>
+
+<script>
+  import { initTooltips } from "@client/tooltip";
+
+  // The repeat counts explain themselves with the site's own bead.
+  initTooltips();
+
+  type SortId = "cities" | "name" | "first";
+
+  // Kept outside the function: with view transitions the module is evaluated
+  // once and the document is replaced under it, so the language listener at the
+  // bottom is attached once and always re-sorts whichever list is on the page
+  // now, rather than one stale handler per visit.
+  let resort: (() => void) | null = null;
+  let listening = false;
+
+  function initCountrySort() {
+    const view = document.querySelector<HTMLElement>(".countries-view");
+    if (!view) {
+      resort = null;
+      return;
+    }
+
+    const list = view.querySelector<HTMLElement>(".countries");
+    const group = view.querySelector<HTMLElement>(".sort");
+    if (!list || !group) {
+      resort = null;
+      return;
+    }
+    const rowList = list;
+
+    const rows = Array.from(list.querySelectorAll<HTMLElement>(".travel-row"));
+    // The order the server sent, which is the "by cities" order — kept so that
+    // sort can return to it exactly rather than re-deriving it from a count
+    // that ties for two thirds of the list.
+    const asRendered = rows.slice();
+
+    // From the document's own lang, which LangInit sets before anything paints
+    // — the same source the checklist sorts by, rather than a second reading of
+    // a class that happens to travel with it.
+    const lang = () => (document.documentElement.lang === "ru" ? "ru" : "en");
+
+    function order(sort: SortId): HTMLElement[] {
+      if (sort === "cities") return asRendered;
+
+      if (sort === "name") {
+        // Sorted in the language on screen: "Австрия" and "Austria" fall in
+        // different places, and a Russian page sorted by English names is a
+        // list in no order at all.
+        const locale = lang();
+        const key = locale === "ru" ? "nameRu" : "nameEn";
+        // `sensitivity: base` files Ё with Е, which is where a reader looks for
+        // it and where the raw code points refuse to put it — Ё sits after я.
+        const collator = new Intl.Collator(locale, { sensitivity: "base" });
+        return rows
+          .slice()
+          .sort((a, b) =>
+            collator.compare(a.dataset[key] ?? "", b.dataset[key] ?? ""),
+          );
+      }
+
+      // Earliest first — this one is a chronology, the order the world arrived
+      // in, so it reads forwards. It sorts on the rank the lib worked out by
+      // walking the trips in order, not on the year: four countries share 2019,
+      // and two of them were first stood in on the same journey, so nothing on
+      // the row could have separated them here. A country with no rank has no
+      // date to be placed by and goes last.
+      return rows.slice().sort((a, b) => {
+        const rank = (row: HTMLElement) =>
+          row.dataset.firstSeen === "" || row.dataset.firstSeen === undefined
+            ? Infinity
+            : Number(row.dataset.firstSeen);
+        return rank(a) - rank(b);
+      });
+    }
+
+    let current: SortId = "cities";
+
+    function apply(sort: SortId) {
+      current = sort;
+      // Moving the rows themselves rather than setting `order` on them: flex
+      // order changes what is drawn and not what is read, so a screen reader
+      // would be handed the same sequence whichever button was lit.
+      for (const row of order(sort)) rowList.appendChild(row);
+    }
+
+    group.addEventListener("click", (event) => {
+      const button = (event.target as HTMLElement | null)?.closest<HTMLElement>(
+        ".kit-toggle-item",
+      );
+      const id = button?.dataset.id as SortId | undefined;
+      if (!id) return;
+
+      for (const item of group.querySelectorAll<HTMLElement>(
+        ".kit-toggle-item",
+      )) {
+        const isActive = item === button;
+        item.classList.toggle("is-active", isActive);
+        item.setAttribute("aria-pressed", String(isActive));
+      }
+
+      apply(id);
+    });
+
+    // A–Z is a different order in each language, so switching language has to
+    // re-sort — the labels change under the rows otherwise and the list stops
+    // being alphabetical without anything having moved.
+    resort = () => {
+      if (current === "name") apply("name");
+    };
+
+    if (!listening) {
+      listening = true;
+      window.addEventListener("lang-change", () => resort?.());
+    }
   }
-</ul>
+
+  // A module script runs with the document already parsed. The second line is
+  // for view transitions: they swap the body without a navigation, so
+  // DOMContentLoaded never fires again and a sort wired only on that event
+  // would be dead on every page reached from inside the site. astro:page-load
+  // covers both, and does not fire at all until a ClientRouter exists — so this
+  // changes nothing today.
+  initCountrySort();
+  document.addEventListener("astro:page-load", initCountrySort);
+</script>
 
 <style>
   .countries {
     --travel-columns: 1;
+  }
+
+  .countries .travel-row {
+    /* The absolutely placed year needs a positioned host, and .travel-row--flow
+       is a plain block. */
+    position: relative;
+    /* Room at the end of every row for it, so a long line of cities wraps
+       before it reaches the years rather than running under them. The wash is
+       unaffected: padding moves the text, not the row's box, so a row still
+       bleeds the same 0.75rem into the gutter on both sides. */
+    padding-right: 3.4rem;
+  }
+
+  /* The head is why this view has one at all: the sort belongs in a control
+     slot, and every other view already docks a heading here. It also means the
+     sort stays reachable from anywhere in the list, the way the view rail
+     above it does. */
+  .travel-section-head :global(.sort) {
+    flex-wrap: nowrap;
   }
 
   /* The shared flag is written for a flex row, where the browser puts it on the
@@ -51,12 +256,6 @@ const countriesWithCities = getCountriesWithCities(datedTrips);
     vertical-align: -0.12em;
   }
 
-  /* How many cities the row is about to list. Sits inline after the name rather
-     than at the end of the row, because the row keeps going. */
-  .city-count {
-    margin-left: 0.2rem;
-  }
-
   /* The same colour the timeline gives the arrows between its cities. */
   .separator {
     color: light-dark(#999, #666);
@@ -64,9 +263,46 @@ const countriesWithCities = getCountriesWithCities(datedTrips);
   }
 
   /* The cities are what the row goes on to say, so they stay readable rather
-     than dropping to the colour of a count. */
+     than dropping to the colour of a count. Kept whole with their own count and
+     comma, so "(10)," never wraps away from the city it belongs to. */
   .city {
-    color: var(--travel-quiet);
+    color: var(--travel-muted);
     white-space: nowrap;
+  }
+
+  /* A city seen more than once. Both this and the year below wear
+     .travel-metric, the page's one spec for a figure beside content, and add
+     only where they sit — a second set of sizes and colours here is exactly the
+     drift travel.css was written to end. */
+  .visits {
+    margin-left: 0.2rem;
+    cursor: help;
+  }
+
+  /* Pinned to the row's right edge and to its first line, so the years line up
+     down the page whether a country's cities take one line or four. The line
+     height is the row's own — set as a length, since the row's 1.9 is against a
+     1rem body and this is 0.9rem — so the year centres on the first line
+     instead of riding a few pixels above it. */
+  .first {
+    position: absolute;
+    top: 0.5rem;
+    right: var(--travel-row-inset);
+    line-height: 1.9rem;
+  }
+
+  @media (max-width: 560px) {
+    /* Three labels, the longest of which is "По первому визиту", do not share a
+       line with a heading on a phone. The head stacks and the sort keeps its
+       full words rather than being cut down to initials nobody can read. */
+    .travel-section-head {
+      flex-direction: column;
+      align-items: flex-start;
+      gap: 0.4rem;
+    }
+
+    .travel-section-head :global(.sort) {
+      flex-wrap: wrap;
+    }
   }
 </style>

--- a/src/components/travel/TravelCountries.astro
+++ b/src/components/travel/TravelCountries.astro
@@ -1,6 +1,7 @@
 ---
 import { datedTrips, getCountriesWithCities } from "@lib/travel";
 import { getCityName } from "@lib/travel/cities-i18n";
+import "@styles/travel.css";
 import "flag-icons/css/flag-icons.min.css";
 
 const countriesWithCities = getCountriesWithCities(datedTrips);
@@ -11,15 +12,14 @@ const countriesWithCities = getCountriesWithCities(datedTrips);
     countriesWithCities.map((country) => (
       <div class="country-row">
         <span
-          class={`flag fi fi-${country.a2}`}
-          role="img"
-          aria-label={`${country.name.en} flag`}
+          class={`travel-flag flag fi fi-${country.a2}`}
+          aria-hidden="true"
         /><span
-          class="country-name"
+          class="travel-name country-name"
           data-en={country.name.en}
           data-ru={country.name.ru}
         >{country.name.en}</span>
-        <span class="city-count">({country.cities.length})</span>
+        <span class="travel-metric city-count">({country.cities.length})</span>
         <span class="separator" aria-hidden="true">—</span>
         {country.cities.map((city, i) => (
           <>
@@ -54,27 +54,17 @@ const countriesWithCities = getCountriesWithCities(datedTrips);
     background: light-dark(rgba(0, 0, 0, 0.03), rgba(255, 255, 255, 0.04));
   }
 
+  /* The shared flag is written for a flex row, where the browser puts it on
+     the centre line for you. Here it sits in running text and has to be told. */
   .flag {
-    font-size: 0.9rem;
-    border-radius: 2px;
     margin-right: 0.4rem;
     vertical-align: middle;
   }
 
-  .country-name {
-    font-size: 0.9rem;
-    font-weight: 600;
-    color: light-dark(#111, #fff);
-    white-space: nowrap;
-  }
-
-  /* How many cities the row is about to list. Tabular figures so the counts
-     line up down the column instead of wandering with the digit widths. */
+  /* How many cities the row is about to list. Sits inline after the name
+     rather than at the end of the row, because the row keeps going. */
   .city-count {
-    font-size: 0.8rem;
-    color: light-dark(#999, #666);
     margin-left: 0.2rem;
-    font-variant-numeric: tabular-nums;
   }
 
   .separator {

--- a/src/components/travel/TravelCountries.astro
+++ b/src/components/travel/TravelCountries.astro
@@ -19,6 +19,7 @@ const countriesWithCities = getCountriesWithCities(datedTrips);
           data-en={country.name.en}
           data-ru={country.name.ru}
         >{country.name.en}</span>
+        <span class="city-count">({country.cities.length})</span>
         <span class="separator" aria-hidden="true">—</span>
         {country.cities.map((city, i) => (
           <>
@@ -65,6 +66,15 @@ const countriesWithCities = getCountriesWithCities(datedTrips);
     font-weight: 600;
     color: light-dark(#111, #fff);
     white-space: nowrap;
+  }
+
+  /* How many cities the row is about to list. Tabular figures so the counts
+     line up down the column instead of wandering with the digit widths. */
+  .city-count {
+    font-size: 0.8rem;
+    color: light-dark(#999, #666);
+    margin-left: 0.2rem;
+    font-variant-numeric: tabular-nums;
   }
 
   .separator {

--- a/src/components/travel/TravelMap.astro
+++ b/src/components/travel/TravelMap.astro
@@ -1,5 +1,4 @@
 ---
-import "flag-icons/css/flag-icons.min.css";
 import "maplibre-gl/dist/maplibre-gl.css";
 
 interface Props {

--- a/src/components/travel/TravelStats.astro
+++ b/src/components/travel/TravelStats.astro
@@ -92,6 +92,12 @@ import {
     /* The page's own grid gap, so the stats sit on the same rhythm as the map
        and the trip list rather than a tighter one of their own. */
     gap: 1.25rem;
+    /* And out to the page's shared edge. A row's hover wash bleeds 0.75rem past
+       the content edge by design — the text stays put and the wash reaches into
+       the gutter — which used to leave these cards ending 12px short of it, so
+       the page had two different left edges and the wash looked like it was
+       escaping. Now everything that draws a surface ends on the same line. */
+    margin-inline: -0.75rem;
   }
 
   /* The same material as a wishlist card: tint, border, shadow and rim all from

--- a/src/components/travel/TravelStats.astro
+++ b/src/components/travel/TravelStats.astro
@@ -34,7 +34,14 @@ import {
         <Icon name="question" class="info-icon" aria-hidden="true" />
       </a>
     </div>
-    <ProgressBar value={countries.size} max={countryListSize} label="Countries visited progress" accent />
+    <ProgressBar
+      value={countries.size}
+      max={countryListSize}
+      label="Countries visited progress"
+      data-aria-label-en="Countries visited progress"
+      data-aria-label-ru="Прогресс по странам"
+      accent
+    />
   </div>
   <div class="card">
     <h3 data-en="Cities" data-ru="Города">Cities</h3>
@@ -59,7 +66,14 @@ import {
         <Icon name="question" class="info-icon" aria-hidden="true" />
       </a>
     </div>
-    <ProgressBar value={continentsVisited} max={continentsTotal} label="Continents visited progress" accent />
+    <ProgressBar
+      value={continentsVisited}
+      max={continentsTotal}
+      label="Continents visited progress"
+      data-aria-label-en="Continents visited progress"
+      data-aria-label-ru="Прогресс по континентам"
+      accent
+    />
   </div>
 </div>
 

--- a/src/components/travel/TravelStatsDashboard.astro
+++ b/src/components/travel/TravelStatsDashboard.astro
@@ -32,15 +32,13 @@ const busiestYear = facts.tripsByYear.reduce(
     {
       facts.mostVisitedCity && (
         <section>
-          <header class="travel-section-head">
-            <h2
-              class="travel-section-title"
-              data-en="Most visited city"
-              data-ru="Самый посещаемый город"
-            >
-              Most visited city
-            </h2>
-          </header>
+          <h2
+            class="travel-caption"
+            data-en="Most visited city"
+            data-ru="Самый посещаемый город"
+          >
+            Most visited city
+          </h2>
           <div class="value">
             <span class={`fi fi-${facts.mostVisitedCity.a2}`} aria-hidden="true" />
             <span
@@ -64,15 +62,13 @@ const busiestYear = facts.tripsByYear.reduce(
     {
       facts.mostVisitedCountry && (
         <section>
-          <header class="travel-section-head">
-            <h2
-              class="travel-section-title"
-              data-en="Most visited country"
-              data-ru="Самая посещаемая страна"
-            >
-              Most visited country
-            </h2>
-          </header>
+          <h2
+            class="travel-caption"
+            data-en="Most visited country"
+            data-ru="Самая посещаемая страна"
+          >
+            Most visited country
+          </h2>
           <div class="value">
             <span
               class={`fi fi-${facts.mostVisitedCountry.a2}`}
@@ -99,15 +95,13 @@ const busiestYear = facts.tripsByYear.reduce(
     {
       facts.mostActiveYear && (
         <section>
-          <header class="travel-section-head">
-            <h2
-              class="travel-section-title"
-              data-en="Busiest year"
-              data-ru="Самый активный год"
-            >
-              Busiest year
-            </h2>
-          </header>
+          <h2
+            class="travel-caption"
+            data-en="Busiest year"
+            data-ru="Самый активный год"
+          >
+            Busiest year
+          </h2>
           <div class="value">{facts.mostActiveYear.year}</div>
           <span
             class="travel-metric"
@@ -123,15 +117,13 @@ const busiestYear = facts.tripsByYear.reduce(
     {
       facts.latestNewCountry && (
         <section>
-          <header class="travel-section-head">
-            <h2
-              class="travel-section-title"
-              data-en="Latest new country"
-              data-ru="Последняя новая страна"
-            >
-              Latest new country
-            </h2>
-          </header>
+          <h2
+            class="travel-caption"
+            data-en="Latest new country"
+            data-ru="Последняя новая страна"
+          >
+            Latest new country
+          </h2>
           <div class="value">
             <span
               class={`fi fi-${facts.latestNewCountry.a2}`}
@@ -185,7 +177,7 @@ const busiestYear = facts.tripsByYear.reduce(
             .slice()
             .reverse()
             .map((entry) => (
-              <li class="year">
+              <li class="travel-row year">
                 <span class="travel-metric">{entry.year}</span>
                 <ProgressBar
                   value={entry.trips}
@@ -214,8 +206,9 @@ const busiestYear = facts.tripsByYear.reduce(
     gap: 1.5rem;
   }
 
-  /* The one place a number is the answer rather than the annotation, so it is
-     the one place these views set type larger than the body. */
+  /* A fact's answer, at the size and weight of a group heading — the same
+     1.25rem/600 a year is set at, which is what the counters above the switcher
+     give their own numbers. */
   .value {
     display: flex;
     align-items: center;
@@ -223,16 +216,17 @@ const busiestYear = facts.tripsByYear.reduce(
     font-weight: 600;
     font-size: 1.25rem;
     font-variant-numeric: tabular-nums;
-    color: light-dark(#111, #fff);
+    color: light-dark(#111, #fafafa);
     /* A grid item without this widens its column past the page rather than
        letting a long country name ellipsize inside it. */
     min-width: 0;
-    margin-bottom: 0.2em;
+    margin-bottom: 0.1em;
   }
 
+  /* No size of its own, so a flag stands to its name here in the same
+     proportion it does in the timeline. */
   .value .fi {
     flex-shrink: 0;
-    font-size: 0.9rem;
     border-radius: 3px;
   }
 
@@ -245,19 +239,22 @@ const busiestYear = facts.tripsByYear.reduce(
   .years {
     display: flex;
     flex-direction: column;
-    gap: 0.35rem;
-    margin: 0.85rem 0 0;
+    /* The rows bring their own 0.5rem of padding, so the list needs no gap of
+       its own and sits the same 0.5rem below its heading that a year's trips
+       sit below theirs. */
+    margin: 0;
     padding: 0;
     list-style: none;
   }
 
-  /* Three fixed tracks rather than a flex row: the year and the count are
-     tabular numerals of known width, so pinning their columns keeps every
-     groove starting and ending on the same two lines down the whole list. */
+  /* Three fixed tracks rather than the shared row's flex: the year and the count
+     are tabular numerals of known width, so pinning their columns keeps every
+     groove starting and ending on the same two lines down the whole list. The
+     rest of the row — its padding, radius and hover — comes from .travel-row,
+     so pointing at a year here answers exactly as pointing at a trip does. */
   .year {
     display: grid;
     grid-template-columns: 2.5rem minmax(0, 1fr) 1.25rem;
-    align-items: center;
     gap: 0.6rem;
   }
 

--- a/src/components/travel/TravelStatsDashboard.astro
+++ b/src/components/travel/TravelStatsDashboard.astro
@@ -1,0 +1,292 @@
+---
+import ProgressBar from "@components/kit/ProgressBar.astro";
+import {
+  datedTrips,
+  formatMonthYear,
+  formatTripCount,
+  formatVisitCount,
+  getTravelFacts,
+} from "@lib/travel";
+import "flag-icons/css/flag-icons.min.css";
+
+const facts = getTravelFacts(datedTrips);
+
+// The bars are read against the busiest year rather than against a round
+// number, so the tallest one always reaches the end of its groove and the
+// shape of the decade is legible instead of a row of stubs.
+const busiestYear = facts.tripsByYear.reduce(
+  (max, entry) => Math.max(max, entry.trips),
+  0,
+);
+---
+
+<div class="facts">
+  <div class="cards">
+    {
+      facts.mostVisitedCity && (
+        <div class="card">
+          <h3 data-en="Most visited city" data-ru="Самый посещаемый город">
+            Most visited city
+          </h3>
+          <div class="value">
+            <span class={`fi fi-${facts.mostVisitedCity.a2}`} aria-hidden="true" />
+            <span
+              data-en={facts.mostVisitedCity.name.en}
+              data-ru={facts.mostVisitedCity.name.ru}
+            >
+              {facts.mostVisitedCity.name.en}
+            </span>
+          </div>
+          <span
+            class="detail"
+            data-en={formatVisitCount(facts.mostVisitedCity.visits, "en")}
+            data-ru={formatVisitCount(facts.mostVisitedCity.visits, "ru")}
+          >
+            {formatVisitCount(facts.mostVisitedCity.visits, "en")}
+          </span>
+        </div>
+      )
+    }
+
+    {
+      facts.mostVisitedCountry && (
+        <div class="card">
+          <h3 data-en="Most visited country" data-ru="Самая посещаемая страна">
+            Most visited country
+          </h3>
+          <div class="value">
+            <span
+              class={`fi fi-${facts.mostVisitedCountry.a2}`}
+              aria-hidden="true"
+            />
+            <span
+              data-en={facts.mostVisitedCountry.name.en}
+              data-ru={facts.mostVisitedCountry.name.ru}
+            >
+              {facts.mostVisitedCountry.name.en}
+            </span>
+          </div>
+          <span
+            class="detail"
+            data-en={formatTripCount(facts.mostVisitedCountry.visits, "en")}
+            data-ru={formatTripCount(facts.mostVisitedCountry.visits, "ru")}
+          >
+            {formatTripCount(facts.mostVisitedCountry.visits, "en")}
+          </span>
+        </div>
+      )
+    }
+
+    {
+      facts.mostActiveYear && (
+        <div class="card">
+          <h3 data-en="Busiest year" data-ru="Самый активный год">
+            Busiest year
+          </h3>
+          <div class="value">{facts.mostActiveYear.year}</div>
+          <span
+            class="detail"
+            data-en={formatTripCount(facts.mostActiveYear.trips, "en")}
+            data-ru={formatTripCount(facts.mostActiveYear.trips, "ru")}
+          >
+            {formatTripCount(facts.mostActiveYear.trips, "en")}
+          </span>
+        </div>
+      )
+    }
+
+    {
+      facts.latestNewCountry && (
+        <div class="card">
+          <h3 data-en="Latest new country" data-ru="Последняя новая страна">
+            Latest new country
+          </h3>
+          <div class="value">
+            <span
+              class={`fi fi-${facts.latestNewCountry.a2}`}
+              aria-hidden="true"
+            />
+            <span
+              data-en={facts.latestNewCountry.name.en}
+              data-ru={facts.latestNewCountry.name.ru}
+            >
+              {facts.latestNewCountry.name.en}
+            </span>
+          </div>
+          <span
+            class="detail"
+            data-en={formatMonthYear(
+              facts.latestNewCountry.year,
+              facts.latestNewCountry.month,
+              "en",
+            )}
+            data-ru={formatMonthYear(
+              facts.latestNewCountry.year,
+              facts.latestNewCountry.month,
+              "ru",
+            )}
+          >
+            {formatMonthYear(
+              facts.latestNewCountry.year,
+              facts.latestNewCountry.month,
+              "en",
+            )}
+          </span>
+        </div>
+      )
+    }
+  </div>
+
+  {
+    facts.tripsByYear.length > 0 && (
+      <section class="card chart">
+        <h3 data-en="Trips by year" data-ru="Поездки по годам">
+          Trips by year
+        </h3>
+        <ol class="years" role="list">
+          {facts.tripsByYear
+            .slice()
+            .reverse()
+            .map((entry) => (
+              <li class="year">
+                <span class="year-label">{entry.year}</span>
+                <ProgressBar
+                  value={entry.trips}
+                  max={busiestYear}
+                  showPercent={false}
+                  accent={entry.trips === busiestYear}
+                  label={`${entry.year}: ${formatTripCount(entry.trips, "en")}`}
+                />
+                <span class="year-count">{entry.trips}</span>
+              </li>
+            ))}
+        </ol>
+      </section>
+    )
+  }
+</div>
+
+<style>
+  .facts {
+    display: flex;
+    flex-direction: column;
+    /* The page's own grid gap, so the dashboard sits on the same rhythm as the
+       stat strip above it rather than a tighter one of its own. */
+    gap: 1.25rem;
+  }
+
+  .cards {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 1.25rem;
+  }
+
+  /* The same material as the stat strip and a wishlist card: tint, border,
+     shadow and rim all from the shared tokens, and the same 20px radius so the
+     three read as one family of surfaces. */
+  .card {
+    position: relative;
+    background: var(--card-bg);
+    border: var(--glass-border);
+    border-radius: 20px;
+    box-shadow: var(--glass-shadow);
+    padding: 1rem 1.1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.4em;
+    /* The card is a grid item; without this a long country name would widen the
+       column past the page instead of wrapping inside it. */
+    min-width: 0;
+  }
+
+  /* The refractive rim — a lens edge lit from the top left. */
+  .card::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    pointer-events: none;
+    box-shadow: var(--glass-rim);
+  }
+
+  .card h3 {
+    margin: 0;
+    font-size: 0.85rem;
+    font-weight: 500;
+    color: light-dark(#666, #9a9aa0);
+  }
+
+  .value {
+    display: flex;
+    align-items: center;
+    gap: 0.45rem;
+    font-weight: 600;
+    font-size: 1.25rem;
+    font-variant-numeric: tabular-nums;
+    color: light-dark(#111, #fff);
+    min-width: 0;
+  }
+
+  .value .fi {
+    flex-shrink: 0;
+    font-size: 0.9rem;
+    border-radius: 3px;
+  }
+
+  .value > span:last-child {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .detail {
+    font-size: 0.8rem;
+    color: light-dark(#888, #8a8a90);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .years {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    margin: 0.85rem 0 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  /* Three fixed tracks rather than a flex row: the year and the count are
+     tabular numerals of known width, so pinning their columns keeps every
+     groove starting and ending on the same two lines down the whole list. */
+  .year {
+    display: grid;
+    grid-template-columns: 2.5rem minmax(0, 1fr) 1.25rem;
+    align-items: center;
+    gap: 0.6rem;
+  }
+
+  .year-label,
+  .year-count {
+    font-size: 0.75rem;
+    color: light-dark(#888, #8a8a90);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .year-count {
+    text-align: right;
+  }
+
+  @media (max-width: 480px) {
+    .cards {
+      grid-template-columns: 1fr;
+      gap: 16px;
+    }
+
+    .card {
+      padding: 0.85rem 0.9rem;
+    }
+
+    .value {
+      font-size: 1.1rem;
+    }
+  }
+</style>

--- a/src/components/travel/TravelStatsDashboard.astro
+++ b/src/components/travel/TravelStatsDashboard.astro
@@ -7,6 +7,7 @@ import {
   formatVisitCount,
   getTravelFacts,
 } from "@lib/travel";
+import "@styles/travel.css";
 import "flag-icons/css/flag-icons.min.css";
 
 const facts = getTravelFacts(datedTrips);
@@ -26,14 +27,20 @@ const busiestYear = facts.tripsByYear.reduce(
 );
 ---
 
-<div class="facts">
-  <div class="cards">
+<div class="travel-sections">
+  <div class="facts">
     {
       facts.mostVisitedCity && (
-        <div class="card">
-          <h3 data-en="Most visited city" data-ru="Самый посещаемый город">
-            Most visited city
-          </h3>
+        <section>
+          <header class="travel-section-head">
+            <h3
+              class="travel-section-title"
+              data-en="Most visited city"
+              data-ru="Самый посещаемый город"
+            >
+              Most visited city
+            </h3>
+          </header>
           <div class="value">
             <span class={`fi fi-${facts.mostVisitedCity.a2}`} aria-hidden="true" />
             <span
@@ -44,22 +51,28 @@ const busiestYear = facts.tripsByYear.reduce(
             </span>
           </div>
           <span
-            class="detail"
+            class="travel-metric"
             data-en={formatVisitCount(facts.mostVisitedCity.visits, "en")}
             data-ru={formatVisitCount(facts.mostVisitedCity.visits, "ru")}
           >
             {formatVisitCount(facts.mostVisitedCity.visits, "en")}
           </span>
-        </div>
+        </section>
       )
     }
 
     {
       facts.mostVisitedCountry && (
-        <div class="card">
-          <h3 data-en="Most visited country" data-ru="Самая посещаемая страна">
-            Most visited country
-          </h3>
+        <section>
+          <header class="travel-section-head">
+            <h3
+              class="travel-section-title"
+              data-en="Most visited country"
+              data-ru="Самая посещаемая страна"
+            >
+              Most visited country
+            </h3>
+          </header>
           <div class="value">
             <span
               class={`fi fi-${facts.mostVisitedCountry.a2}`}
@@ -73,40 +86,52 @@ const busiestYear = facts.tripsByYear.reduce(
             </span>
           </div>
           <span
-            class="detail"
+            class="travel-metric"
             data-en={formatVisitCount(facts.mostVisitedCountry.visits, "en")}
             data-ru={formatVisitCount(facts.mostVisitedCountry.visits, "ru")}
           >
             {formatVisitCount(facts.mostVisitedCountry.visits, "en")}
           </span>
-        </div>
+        </section>
       )
     }
 
     {
       facts.mostActiveYear && (
-        <div class="card">
-          <h3 data-en="Busiest year" data-ru="Самый активный год">
-            Busiest year
-          </h3>
+        <section>
+          <header class="travel-section-head">
+            <h3
+              class="travel-section-title"
+              data-en="Busiest year"
+              data-ru="Самый активный год"
+            >
+              Busiest year
+            </h3>
+          </header>
           <div class="value">{facts.mostActiveYear.year}</div>
           <span
-            class="detail"
+            class="travel-metric"
             data-en={formatTripCount(facts.mostActiveYear.trips, "en")}
             data-ru={formatTripCount(facts.mostActiveYear.trips, "ru")}
           >
             {formatTripCount(facts.mostActiveYear.trips, "en")}
           </span>
-        </div>
+        </section>
       )
     }
 
     {
       facts.latestNewCountry && (
-        <div class="card">
-          <h3 data-en="Latest new country" data-ru="Последняя новая страна">
-            Latest new country
-          </h3>
+        <section>
+          <header class="travel-section-head">
+            <h3
+              class="travel-section-title"
+              data-en="Latest new country"
+              data-ru="Последняя новая страна"
+            >
+              Latest new country
+            </h3>
+          </header>
           <div class="value">
             <span
               class={`fi fi-${facts.latestNewCountry.a2}`}
@@ -120,7 +145,7 @@ const busiestYear = facts.tripsByYear.reduce(
             </span>
           </div>
           <span
-            class="detail"
+            class="travel-metric"
             data-en={formatMonthYear(
               facts.latestNewCountry.year,
               facts.latestNewCountry.month,
@@ -138,24 +163,30 @@ const busiestYear = facts.tripsByYear.reduce(
               "en",
             )}
           </span>
-        </div>
+        </section>
       )
     }
   </div>
 
   {
     facts.tripsByYear.length > 0 && (
-      <section class="card chart">
-        <h3 data-en="Trips by year" data-ru="Поездки по годам">
-          Trips by year
-        </h3>
+      <section>
+        <header class="travel-section-head">
+          <h3
+            class="travel-section-title"
+            data-en="Trips by year"
+            data-ru="Поездки по годам"
+          >
+            Trips by year
+          </h3>
+        </header>
         <ol class="years" role="list">
           {facts.tripsByYear
             .slice()
             .reverse()
             .map((entry) => (
               <li class="year">
-                <span class="year-label">{entry.year}</span>
+                <span class="travel-metric">{entry.year}</span>
                 <ProgressBar
                   value={entry.trips}
                   max={busiestYear}
@@ -165,7 +196,7 @@ const busiestYear = facts.tripsByYear.reduce(
                   data-aria-label-en={`${entry.year}: ${formatTripCount(entry.trips, "en")}`}
                   data-aria-label-ru={`${entry.year}: ${formatTripCount(entry.trips, "ru")}`}
                 />
-                <span class="year-count">{entry.trips}</span>
+                <span class="travel-metric year-count">{entry.trips}</span>
               </li>
             ))}
         </ol>
@@ -175,55 +206,16 @@ const busiestYear = facts.tripsByYear.reduce(
 </div>
 
 <style>
+  /* Two facts across, on the same rhythm the sections stack at, so the gap
+     between the columns matches the gap above and below them. */
   .facts {
-    display: flex;
-    flex-direction: column;
-    /* The page's own grid gap, so the dashboard sits on the same rhythm as the
-       stat strip above it rather than a tighter one of its own. */
-    gap: 1.25rem;
-  }
-
-  .cards {
     display: grid;
     grid-template-columns: repeat(2, 1fr);
-    gap: 1.25rem;
+    gap: 1.5rem;
   }
 
-  /* The same material as the stat strip and a wishlist card: tint, border,
-     shadow and rim all from the shared tokens, and the same 20px radius so the
-     three read as one family of surfaces. */
-  .card {
-    position: relative;
-    background: var(--card-bg);
-    border: var(--glass-border);
-    border-radius: 20px;
-    box-shadow: var(--glass-shadow);
-    padding: 1rem 1.1rem;
-    display: flex;
-    flex-direction: column;
-    gap: 0.4em;
-    /* The card is a grid item; without this a long country name would widen the
-       column past the page instead of wrapping inside it. */
-    min-width: 0;
-  }
-
-  /* The refractive rim — a lens edge lit from the top left. */
-  .card::after {
-    content: "";
-    position: absolute;
-    inset: 0;
-    border-radius: inherit;
-    pointer-events: none;
-    box-shadow: var(--glass-rim);
-  }
-
-  .card h3 {
-    margin: 0;
-    font-size: 0.85rem;
-    font-weight: 500;
-    color: light-dark(#666, #9a9aa0);
-  }
-
+  /* The one place a number is the answer rather than the annotation, so it is
+     the one place these views set type larger than the body. */
   .value {
     display: flex;
     align-items: center;
@@ -232,7 +224,10 @@ const busiestYear = facts.tripsByYear.reduce(
     font-size: 1.25rem;
     font-variant-numeric: tabular-nums;
     color: light-dark(#111, #fff);
+    /* A grid item without this widens its column past the page rather than
+       letting a long country name ellipsize inside it. */
     min-width: 0;
+    margin-bottom: 0.2em;
   }
 
   .value .fi {
@@ -245,12 +240,6 @@ const busiestYear = facts.tripsByYear.reduce(
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-  }
-
-  .detail {
-    font-size: 0.8rem;
-    color: light-dark(#888, #8a8a90);
-    font-variant-numeric: tabular-nums;
   }
 
   .years {
@@ -272,25 +261,13 @@ const busiestYear = facts.tripsByYear.reduce(
     gap: 0.6rem;
   }
 
-  .year-label,
-  .year-count {
-    font-size: 0.75rem;
-    color: light-dark(#888, #8a8a90);
-    font-variant-numeric: tabular-nums;
-  }
-
   .year-count {
     text-align: right;
   }
 
-  @media (max-width: 480px) {
-    .cards {
+  @media (max-width: 520px) {
+    .facts {
       grid-template-columns: 1fr;
-      gap: 16px;
-    }
-
-    .card {
-      padding: 0.85rem 0.9rem;
     }
 
     .value {

--- a/src/components/travel/TravelStatsDashboard.astro
+++ b/src/components/travel/TravelStatsDashboard.astro
@@ -11,6 +11,12 @@ import "flag-icons/css/flag-icons.min.css";
 
 const facts = getTravelFacts(datedTrips);
 
+// Both "most visited" cards are counted in visits rather than trips. The number
+// is the same either way — a journey that touches a place counts once, however
+// many stops it makes there — but a card headed "Most visited country" that
+// answers "17 trips" reads as if it were answering some other question. The
+// busiest-year card below really is about trips and keeps the word.
+
 // The bars are read against the busiest year rather than against a round
 // number, so the tallest one always reaches the end of its groove and the
 // shape of the decade is legible instead of a row of stubs.
@@ -68,10 +74,10 @@ const busiestYear = facts.tripsByYear.reduce(
           </div>
           <span
             class="detail"
-            data-en={formatTripCount(facts.mostVisitedCountry.visits, "en")}
-            data-ru={formatTripCount(facts.mostVisitedCountry.visits, "ru")}
+            data-en={formatVisitCount(facts.mostVisitedCountry.visits, "en")}
+            data-ru={formatVisitCount(facts.mostVisitedCountry.visits, "ru")}
           >
-            {formatTripCount(facts.mostVisitedCountry.visits, "en")}
+            {formatVisitCount(facts.mostVisitedCountry.visits, "en")}
           </span>
         </div>
       )
@@ -156,6 +162,8 @@ const busiestYear = facts.tripsByYear.reduce(
                   showPercent={false}
                   accent={entry.trips === busiestYear}
                   label={`${entry.year}: ${formatTripCount(entry.trips, "en")}`}
+                  data-aria-label-en={`${entry.year}: ${formatTripCount(entry.trips, "en")}`}
+                  data-aria-label-ru={`${entry.year}: ${formatTripCount(entry.trips, "ru")}`}
                 />
                 <span class="year-count">{entry.trips}</span>
               </li>

--- a/src/components/travel/TravelStatsDashboard.astro
+++ b/src/components/travel/TravelStatsDashboard.astro
@@ -33,13 +33,13 @@ const busiestYear = facts.tripsByYear.reduce(
       facts.mostVisitedCity && (
         <section>
           <header class="travel-section-head">
-            <h3
+            <h2
               class="travel-section-title"
               data-en="Most visited city"
               data-ru="Самый посещаемый город"
             >
               Most visited city
-            </h3>
+            </h2>
           </header>
           <div class="value">
             <span class={`fi fi-${facts.mostVisitedCity.a2}`} aria-hidden="true" />
@@ -65,13 +65,13 @@ const busiestYear = facts.tripsByYear.reduce(
       facts.mostVisitedCountry && (
         <section>
           <header class="travel-section-head">
-            <h3
+            <h2
               class="travel-section-title"
               data-en="Most visited country"
               data-ru="Самая посещаемая страна"
             >
               Most visited country
-            </h3>
+            </h2>
           </header>
           <div class="value">
             <span
@@ -100,13 +100,13 @@ const busiestYear = facts.tripsByYear.reduce(
       facts.mostActiveYear && (
         <section>
           <header class="travel-section-head">
-            <h3
+            <h2
               class="travel-section-title"
               data-en="Busiest year"
               data-ru="Самый активный год"
             >
               Busiest year
-            </h3>
+            </h2>
           </header>
           <div class="value">{facts.mostActiveYear.year}</div>
           <span
@@ -124,13 +124,13 @@ const busiestYear = facts.tripsByYear.reduce(
       facts.latestNewCountry && (
         <section>
           <header class="travel-section-head">
-            <h3
+            <h2
               class="travel-section-title"
               data-en="Latest new country"
               data-ru="Последняя новая страна"
             >
               Latest new country
-            </h3>
+            </h2>
           </header>
           <div class="value">
             <span
@@ -172,13 +172,13 @@ const busiestYear = facts.tripsByYear.reduce(
     facts.tripsByYear.length > 0 && (
       <section>
         <header class="travel-section-head">
-          <h3
+          <h2
             class="travel-section-title"
             data-en="Trips by year"
             data-ru="Поездки по годам"
           >
             Trips by year
-          </h3>
+          </h2>
         </header>
         <ol class="years" role="list">
           {facts.tripsByYear

--- a/src/components/travel/TravelStatsDashboard.astro
+++ b/src/components/travel/TravelStatsDashboard.astro
@@ -1,5 +1,5 @@
 ---
-import ProgressBar from "@components/kit/ProgressBar.astro";
+import TravelYearChart from "./TravelYearChart.astro";
 import {
   datedTrips,
   formatMonthYear,
@@ -8,7 +8,6 @@ import {
   getTravelFacts,
 } from "@lib/travel";
 import "@styles/travel.css";
-import "flag-icons/css/flag-icons.min.css";
 
 const facts = getTravelFacts(datedTrips);
 
@@ -17,14 +16,14 @@ const facts = getTravelFacts(datedTrips);
 // many stops it makes there — but a card headed "Most visited country" that
 // answers "17 trips" reads as if it were answering some other question. The
 // busiest-year card below really is about trips and keeps the word.
-
-// The bars are read against the busiest year rather than against a round
-// number, so the tallest one always reaches the end of its groove and the
-// shape of the decade is legible instead of a row of stubs.
-const busiestYear = facts.tripsByYear.reduce(
-  (max, entry) => Math.max(max, entry.trips),
-  0,
-);
+//
+// The line above the answer and the line below it are the same spec, and both
+// are .travel-caption. They used to be a caption over the answer and a metric
+// under it — 0.85rem at 500 against 0.9rem at 400, in colours that are the same
+// value in the dark scheme. Nobody can read a twentieth of a rem and a hundred
+// units of weight as a decision; it reads as a wobble. Three type sizes per
+// fact, four facts, twelve typographic events in a block where only the middle
+// line is the point. Two now: quiet, loud, quiet.
 ---
 
 <div class="travel-sections">
@@ -39,22 +38,24 @@ const busiestYear = facts.tripsByYear.reduce(
           >
             Most visited city
           </h2>
-          <div class="value">
-            <span class={`fi fi-${facts.mostVisitedCity.a2}`} aria-hidden="true" />
+          <div class="answer">
+            <div class="value">
+              <span class={`fi fi-${facts.mostVisitedCity.a2}`} aria-hidden="true" />
+              <span
+                data-en={facts.mostVisitedCity.name.en}
+                data-ru={facts.mostVisitedCity.name.ru}
+              >
+                {facts.mostVisitedCity.name.en}
+              </span>
+            </div>
             <span
-              data-en={facts.mostVisitedCity.name.en}
-              data-ru={facts.mostVisitedCity.name.ru}
+              class="travel-caption amount"
+              data-en={formatVisitCount(facts.mostVisitedCity.visits, "en")}
+              data-ru={formatVisitCount(facts.mostVisitedCity.visits, "ru")}
             >
-              {facts.mostVisitedCity.name.en}
+              {formatVisitCount(facts.mostVisitedCity.visits, "en")}
             </span>
           </div>
-          <span
-            class="travel-metric"
-            data-en={formatVisitCount(facts.mostVisitedCity.visits, "en")}
-            data-ru={formatVisitCount(facts.mostVisitedCity.visits, "ru")}
-          >
-            {formatVisitCount(facts.mostVisitedCity.visits, "en")}
-          </span>
         </section>
       )
     }
@@ -69,25 +70,27 @@ const busiestYear = facts.tripsByYear.reduce(
           >
             Most visited country
           </h2>
-          <div class="value">
+          <div class="answer">
+            <div class="value">
+              <span
+                class={`fi fi-${facts.mostVisitedCountry.a2}`}
+                aria-hidden="true"
+              />
+              <span
+                data-en={facts.mostVisitedCountry.name.en}
+                data-ru={facts.mostVisitedCountry.name.ru}
+              >
+                {facts.mostVisitedCountry.name.en}
+              </span>
+            </div>
             <span
-              class={`fi fi-${facts.mostVisitedCountry.a2}`}
-              aria-hidden="true"
-            />
-            <span
-              data-en={facts.mostVisitedCountry.name.en}
-              data-ru={facts.mostVisitedCountry.name.ru}
+              class="travel-caption amount"
+              data-en={formatVisitCount(facts.mostVisitedCountry.visits, "en")}
+              data-ru={formatVisitCount(facts.mostVisitedCountry.visits, "ru")}
             >
-              {facts.mostVisitedCountry.name.en}
+              {formatVisitCount(facts.mostVisitedCountry.visits, "en")}
             </span>
           </div>
-          <span
-            class="travel-metric"
-            data-en={formatVisitCount(facts.mostVisitedCountry.visits, "en")}
-            data-ru={formatVisitCount(facts.mostVisitedCountry.visits, "ru")}
-          >
-            {formatVisitCount(facts.mostVisitedCountry.visits, "en")}
-          </span>
         </section>
       )
     }
@@ -102,14 +105,16 @@ const busiestYear = facts.tripsByYear.reduce(
           >
             Busiest year
           </h2>
-          <div class="value">{facts.mostActiveYear.year}</div>
-          <span
-            class="travel-metric"
-            data-en={formatTripCount(facts.mostActiveYear.trips, "en")}
-            data-ru={formatTripCount(facts.mostActiveYear.trips, "ru")}
-          >
-            {formatTripCount(facts.mostActiveYear.trips, "en")}
-          </span>
+          <div class="answer">
+            <div class="value">{facts.mostActiveYear.year}</div>
+            <span
+              class="travel-caption amount"
+              data-en={formatTripCount(facts.mostActiveYear.trips, "en")}
+              data-ru={formatTripCount(facts.mostActiveYear.trips, "ru")}
+            >
+              {formatTripCount(facts.mostActiveYear.trips, "en")}
+            </span>
+          </div>
         </section>
       )
     }
@@ -124,86 +129,90 @@ const busiestYear = facts.tripsByYear.reduce(
           >
             Latest new country
           </h2>
-          <div class="value">
+          <div class="answer">
+            <div class="value">
+              <span
+                class={`fi fi-${facts.latestNewCountry.a2}`}
+                aria-hidden="true"
+              />
+              <span
+                data-en={facts.latestNewCountry.name.en}
+                data-ru={facts.latestNewCountry.name.ru}
+              >
+                {facts.latestNewCountry.name.en}
+              </span>
+            </div>
             <span
-              class={`fi fi-${facts.latestNewCountry.a2}`}
-              aria-hidden="true"
-            />
-            <span
-              data-en={facts.latestNewCountry.name.en}
-              data-ru={facts.latestNewCountry.name.ru}
+              class="travel-caption amount"
+              data-en={formatMonthYear(
+                facts.latestNewCountry.year,
+                facts.latestNewCountry.month,
+                "en",
+              )}
+              data-ru={formatMonthYear(
+                facts.latestNewCountry.year,
+                facts.latestNewCountry.month,
+                "ru",
+              )}
             >
-              {facts.latestNewCountry.name.en}
+              {formatMonthYear(
+                facts.latestNewCountry.year,
+                facts.latestNewCountry.month,
+                "en",
+              )}
             </span>
           </div>
-          <span
-            class="travel-metric"
-            data-en={formatMonthYear(
-              facts.latestNewCountry.year,
-              facts.latestNewCountry.month,
-              "en",
-            )}
-            data-ru={formatMonthYear(
-              facts.latestNewCountry.year,
-              facts.latestNewCountry.month,
-              "ru",
-            )}
-          >
-            {formatMonthYear(
-              facts.latestNewCountry.year,
-              facts.latestNewCountry.month,
-              "en",
-            )}
-          </span>
         </section>
       )
     }
   </div>
 
-  {
-    facts.tripsByYear.length > 0 && (
-      <section>
-        <header class="travel-section-head">
-          <h2
-            class="travel-section-title"
-            data-en="Trips by year"
-            data-ru="Поездки по годам"
-          >
-            Trips by year
-          </h2>
-        </header>
-        <ol class="years" role="list">
-          {facts.tripsByYear
-            .slice()
-            .reverse()
-            .map((entry) => (
-              <li class="travel-row year">
-                <span class="travel-metric">{entry.year}</span>
-                <ProgressBar
-                  value={entry.trips}
-                  max={busiestYear}
-                  showPercent={false}
-                  accent={entry.trips === busiestYear}
-                  label={`${entry.year}: ${formatTripCount(entry.trips, "en")}`}
-                  data-aria-label-en={`${entry.year}: ${formatTripCount(entry.trips, "en")}`}
-                  data-aria-label-ru={`${entry.year}: ${formatTripCount(entry.trips, "ru")}`}
-                />
-                <span class="travel-metric year-count">{entry.trips}</span>
-              </li>
-            ))}
-        </ol>
-      </section>
-    )
-  }
+  {facts.tripsByYear.length > 0 && <TravelYearChart />}
 </div>
 
 <style>
-  /* Two facts across, on the same rhythm the sections stack at, so the gap
-     between the columns matches the gap above and below them. */
+  /* Two facts across. The rows sit further apart than the columns, which breaks
+     the page's even 1.5rem on purpose: the two lines of a fact are a few pixels
+     apart, so the space that groups them has to be unmistakably larger than the
+     space inside them. At an even gap the facts read as one slab of lines,
+     which is what they looked like. */
   .facts {
     display: grid;
     grid-template-columns: repeat(2, 1fr);
-    gap: 1.5rem;
+    gap: 2.25rem 1.5rem;
+  }
+
+  /* And inside a fact, the opposite: the two lines are pulled in tight and
+     given their own leading, so the grouping is done by space rather than by
+     the reader working out which caption belongs to which number. */
+  .facts section {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  /* The answer and its amount on one line, built the way a section head builds
+     its title and its count: baseline, pushed to opposite ends. A fact is two
+     lines now rather than three, and the four amounts fall into a column down
+     the right of each grid cell instead of hanging under four names of four
+     different lengths. */
+  .answer {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 0.75rem;
+    min-width: 0;
+  }
+
+  /* The name is what gives way when the pair will not fit; the amount is four
+     characters and would be nonsense clipped. */
+  .amount {
+    flex-shrink: 0;
+    white-space: nowrap;
+  }
+
+  .facts .travel-caption {
+    line-height: 1.35;
   }
 
   /* A fact's answer, at the size and weight of a group heading — the same
@@ -215,12 +224,14 @@ const busiestYear = facts.tripsByYear.reduce(
     gap: 0.45rem;
     font-weight: 600;
     font-size: 1.25rem;
+    /* Tighter than the document's, because the caption above it sits close now
+       and a loose line box would leave the answer floating off its label. */
+    line-height: 1.3;
     font-variant-numeric: tabular-nums;
     color: light-dark(#111, #fafafa);
-    /* A grid item without this widens its column past the page rather than
-       letting a long country name ellipsize inside it. */
+    /* Without this a flex item refuses to go below its content's width, so a
+       long country name widens the cell instead of ellipsizing inside it. */
     min-width: 0;
-    margin-bottom: 0.1em;
   }
 
   /* No size of its own, so a flag stands to its name here in the same
@@ -236,33 +247,12 @@ const busiestYear = facts.tripsByYear.reduce(
     white-space: nowrap;
   }
 
-  .years {
-    display: flex;
-    flex-direction: column;
-    /* The rows bring their own 0.5rem of padding, so the list needs no gap of
-       its own and sits the same 0.5rem below its heading that a year's trips
-       sit below theirs. */
-    margin: 0;
-    padding: 0;
-    list-style: none;
-  }
-
-  /* Three fixed tracks rather than the shared row's flex: the year and the count
-     are tabular numerals of known width, so pinning their columns keeps every
-     groove starting and ending on the same two lines down the whole list. The
-     rest of the row — its padding, radius and hover — comes from .travel-row,
-     so pointing at a year here answers exactly as pointing at a trip does. */
-  .year {
-    display: grid;
-    grid-template-columns: 2.5rem minmax(0, 1fr) 1.25rem;
-    gap: 0.6rem;
-  }
-
-  .year-count {
-    text-align: right;
-  }
-
-  @media (max-width: 520px) {
+  /* One column earlier than before. A name and its amount now share a line, so
+     "Saint Petersburg" and "10 visits" want about 280px between them; two
+     columns below this and the cell is narrower than that, and the name starts
+     ellipsizing to make room for four characters. Given the whole width it
+     never has to. */
+  @media (max-width: 640px) {
     .facts {
       grid-template-columns: 1fr;
     }

--- a/src/components/travel/TravelTrip.astro
+++ b/src/components/travel/TravelTrip.astro
@@ -1,5 +1,4 @@
 ---
-import "flag-icons/css/flag-icons.min.css";
 import type { Trip } from "@lib/travel";
 import { formatTripDate, getCountryName, getLandmarkName } from "@lib/travel";
 import { getCityName } from "@lib/travel/cities-i18n";

--- a/src/components/travel/TravelViewSwitcher.astro
+++ b/src/components/travel/TravelViewSwitcher.astro
@@ -1,5 +1,6 @@
 ---
 import ToggleGroup from "@components/kit/ToggleGroup.astro";
+import { Icon } from "astro-icon/components";
 import {
   countries,
   continentsVisited,
@@ -75,6 +76,17 @@ const viewIds = items.map((item) => item.id).join(" ");
 ---
 
 <nav class="view-switcher" data-current={currentView} data-views={viewIds}>
+  {/* The rail's own glyph, and the one place an icon earns its keep here. The
+      tabs dropped theirs because each one restated a word already under it;
+      this one states the thing none of them do — that the five words are five
+      ways of looking, not five links. It is pinned outside the scroller, so on
+      a phone the row scrolls under it and it stays where the row begins.
+
+      Decorative, and marked so: the tablist beside it already carries the
+      accessible name, and a second announcement of "view" would be noise. */}
+  <span class="view-eye" aria-hidden="true">
+    <Icon name="eye" width={18} height={18} />
+  </span>
   <ToggleGroup
     items={items}
     value={currentView}
@@ -88,6 +100,7 @@ const viewIds = items.map((item) => item.id).join(" ");
 
 <script>
   import { initToggleTabs, type ToggleTabsInstance } from "@client/toggle-tabs";
+  import { initMagnet } from "@client/magnet";
 
   // Kept outside the function on purpose. With view transitions this module is
   // evaluated once and the document is replaced underneath it, so the window
@@ -107,6 +120,12 @@ const viewIds = items.map((item) => item.id).join(" ");
       tabs = null;
       return;
     }
+
+    // The glyph leans toward the cursor while it is anywhere on the strip.
+    // initMagnet is idempotent and sits out a reduced-motion preference, so
+    // this can be called on every page load without guarding either.
+    const eye = switcher.querySelector<HTMLElement>(".view-eye");
+    if (eye) initMagnet(eye, { scope: switcher });
 
     const scope = switcher.closest<HTMLElement>("main");
     const views = document.querySelectorAll<HTMLElement>(".travel-view");
@@ -278,6 +297,54 @@ const viewIds = items.map((item) => item.id).join(" ");
        edge, so the strip ends where the counters above and the rows below do. */
     padding: 0.4rem 0.75rem;
     margin-inline: -0.75rem;
+
+    /* A row, so the glyph holds the first place and the rail takes what is
+       left. The gap is written as a sum because half of it is not a gap: the
+       rail bleeds fourteen pixels outward on every side — padding for the
+       lens's shadow with a matching negative margin, see kit/toggle-group.css
+       — so that much of whatever is set here is spent inside the rail's own
+       empty margin. The 0.75rem is the part you can actually see, and it is
+       that rather than the half of it the row would otherwise want because the
+       glyph drifts: six pixels of magnetic pull toward a cursor sitting on the
+       tabs, which out of a narrower gap would land it against the first tab's
+       glass. Twelve leaves it half a gap of clearance at full throw. */
+    display: flex;
+    align-items: center;
+    gap: calc(0.75rem + 14px);
+  }
+
+  /* Without this the rail is as wide as its five tabs and pushes the row off
+     the screen instead of scrolling inside it. `min-width: 0` is the half that
+     matters: a flex item refuses to shrink below its content otherwise, and
+     overflow-x on a box that is never narrower than its contents scrolls
+     nothing. */
+  .view-switcher :global(.kit-toggle-group--tabs) {
+    flex: 1;
+    min-width: 0;
+  }
+
+  /* Not a control. No capsule, no glass, no press — the glyph sits on the strip
+     the way the label of a thing sits on it, and `pointer-events: none` settles
+     the question before a cursor can ask it: no pointer, no hover, nothing to
+     click at.
+
+     It does move, though, and that is the point. The same magnetic drift the
+     home glyph in the header directly above answers the cursor with — see
+     @client/magnet.ts — which is what keeps "not clickable" from reading as
+     "not alive". The pull is driven from the whole strip, so the eye leans
+     toward you while you are choosing along the row. */
+  .view-eye {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex: none;
+    /* The row's resting ink, the same value the unselected tab labels are set
+       in (see .kit-toggle-group--tabs .kit-toggle-item). The glyph belongs to
+       the row rather than sitting behind it, so it reads at the same weight as
+       the words it introduces. */
+    color: light-dark(#666, #9a9aa0);
+    pointer-events: none;
+    will-change: transform;
   }
 
   /* And the tint only while it is actually docked.
@@ -300,6 +367,15 @@ const viewIds = items.map((item) => item.id).join(" ");
   @media (prefers-reduced-motion: reduce) {
     .view-switcher {
       transition: none;
+    }
+  }
+
+  /* The tab labels resolve under this query (kit/toggle-group.css), and the
+     glyph is set to match them — so it has to move when they do, or it is left
+     as the one dim thing in a row asked to be legible. */
+  @media (prefers-contrast: more) {
+    .view-eye {
+      color: light-dark(#333, #ddd);
     }
   }
 </style>

--- a/src/components/travel/TravelViewSwitcher.astro
+++ b/src/components/travel/TravelViewSwitcher.astro
@@ -1,5 +1,12 @@
 ---
 import ToggleGroup from "@components/kit/ToggleGroup.astro";
+import {
+  countries,
+  continentsVisited,
+  continentsTotal,
+  tripsCount,
+} from "@lib/travel";
+import { getChecklistStats } from "@lib/travel/checklist";
 
 interface Props {
   currentView: string;
@@ -7,17 +14,57 @@ interface Props {
 
 const { currentView } = Astro.props;
 
+const checklist = getChecklistStats();
+
 // No icons. ToggleGroup draws one before the label when an item asks for it,
 // and five of them across a row this wide were five more things to read than
 // the five words already there — a flag, a globe, a bar chart and a tick that
 // each restated their own label. The words are short and unambiguous in both
 // languages, so the icons were decoration on a control, not a way into it.
+//
+// The counts are the opposite case: they say something the label cannot, which
+// is how much is behind it. The five views run from 32 rows to 250, and the row
+// used to give no sign of that — you found out by opening one. The two written
+// as fractions are the two where "of how many" is the whole point of the view.
+// Stats has none because it is not a list of anything; the gap where its number
+// would be is the row saying so.
+//
+// The order is the scale each view reads at. Four lists, each a coarser grain
+// than the last — a trip, a country, a continent, and then the whole world with
+// what is still left on it — and the dashboard closing the row, because it is
+// not a list and has no place in that run. Stats used to sit fourth, between
+// two of the lists, which made the row read as five unrelated views side by
+// side rather than as one thing zooming out.
 const items = [
-  { id: "timeline", label: "Timeline", labelRu: "Хронология" },
-  { id: "countries", label: "Countries", labelRu: "Страны" },
-  { id: "continents", label: "Continents", labelRu: "Континенты" },
-  { id: "stats", label: "Stats", labelRu: "Статистика" },
-  { id: "checklist", label: "Checklist", labelRu: "Чеклист" },
+  {
+    id: "timeline",
+    label: "Timeline",
+    labelRu: "Хронология",
+    count: tripsCount,
+    controls: "view-timeline",
+  },
+  {
+    id: "countries",
+    label: "Countries",
+    labelRu: "Страны",
+    count: countries.size,
+    controls: "view-countries",
+  },
+  {
+    id: "continents",
+    label: "Continents",
+    labelRu: "Континенты",
+    count: `${continentsVisited}/${continentsTotal}`,
+    controls: "view-continents",
+  },
+  {
+    id: "checklist",
+    label: "Checklist",
+    labelRu: "Чеклист",
+    count: `${checklist.visited}/${checklist.total}`,
+    controls: "view-checklist",
+  },
+  { id: "stats", label: "Stats", labelRu: "Статистика", controls: "view-stats" },
 ];
 
 // The script below used to carry its own copy of this list to validate the
@@ -31,84 +78,228 @@ const viewIds = items.map((item) => item.id).join(" ");
   <ToggleGroup
     items={items}
     value={currentView}
-    variant="separated"
+    variant="tabs"
     size="sm"
-    ariaLabelEn="Travel view mode"
-    ariaLabelRu="Режим просмотра"
+    scrollable
+    ariaLabelEn="Travel view"
+    ariaLabelRu="Вид"
   />
 </nav>
 
 <script>
+  import { initToggleTabs, type ToggleTabsInstance } from "@client/toggle-tabs";
+
+  // Kept outside the function on purpose. With view transitions this module is
+  // evaluated once and the document is replaced underneath it, so the window
+  // listeners at the bottom are attached once and always address whichever rail
+  // is on the page now — re-attaching them per page would leave one handler per
+  // visit, each holding a rail that no longer exists.
+  let tabs: ToggleTabsInstance | null = null;
+  let validViews: string[] = [];
+  let defaultView = "";
+  let listening = false;
+
   function initViewSwitcher() {
-    const switcher = document.querySelector(".view-switcher");
-    if (!switcher) return;
-
-    const buttons = switcher.querySelectorAll(".kit-toggle-item");
-    const views = document.querySelectorAll(".travel-view");
-
-    // Get initial view from URL hash or default
-    const hash = window.location.hash.slice(1);
-    const validViews = (switcher.getAttribute("data-views") ?? "").split(" ");
-    const defaultView = validViews[0];
-    const initialView = validViews.includes(hash) ? hash : defaultView;
-
-    function setView(viewId: string) {
-      // Update buttons
-      buttons.forEach((btn) => {
-        const id = btn.getAttribute("data-id");
-        const isActive = id === viewId;
-        btn.classList.toggle("is-active", isActive);
-        btn.setAttribute("aria-pressed", String(isActive));
-      });
-
-      // Update views
-      views.forEach((view) => {
-        const id = view.getAttribute("data-view");
-        if (id === viewId) {
-          view.removeAttribute("hidden");
-        } else {
-          view.setAttribute("hidden", "");
-        }
-      });
-
-      // Update URL hash without scrolling
-      history.replaceState(
-        null,
-        "",
-        viewId === defaultView ? "/travel" : `/travel#${viewId}`,
-      );
+    const switcher = document.querySelector<HTMLElement>(".view-switcher");
+    const group = switcher?.querySelector<HTMLElement>('[role="tablist"]');
+    // A page without a rail leaves nothing for the window listeners to talk to.
+    if (!switcher || !group) {
+      tabs = null;
+      return;
     }
 
-    // Set initial view
-    setView(initialView);
+    const scope = switcher.closest<HTMLElement>("main");
+    const views = document.querySelectorAll<HTMLElement>(".travel-view");
+    validViews = (switcher.getAttribute("data-views") ?? "").split(" ");
+    defaultView = validViews[0];
 
-    // Handle clicks
-    buttons.forEach((btn) => {
-      btn.addEventListener("click", (e) => {
-        e.preventDefault();
-        const viewId = btn.getAttribute("data-id");
-        if (viewId) setView(viewId);
+    // The rail pins under the page header, and the sticky section headings
+    // inside the views have to dock below *it* rather than under it. It
+    // publishes its own height the way the header publishes its own — see
+    // page-header-condense.ts, which is where --sticky-header-offset comes
+    // from, and travel.css / YearGroup.astro, which add the two together.
+    if (scope) {
+      const publish = () =>
+        scope.style.setProperty(
+          "--sticky-rail-offset",
+          `${Math.round(switcher.offsetHeight)}px`,
+        );
+      publish();
+      new ResizeObserver(publish).observe(switcher);
+    }
+
+    // The dock line, from the header's published height. Read fresh each time
+    // rather than captured: the pills wrap on a narrow viewport and the offset
+    // moves with them.
+    function dockLine() {
+      return scope
+        ? parseFloat(
+            getComputedStyle(scope).getPropertyValue("--sticky-header-offset"),
+          ) || 0
+        : 0;
+    }
+
+    // Docked or not. A sticky element never leaves the viewport, so there is
+    // nothing to observe directly — the trick is to shrink the observation area
+    // to start one pixel below the dock line, which the rail can only cross by
+    // being stuck to it.
+    let dockWatcher: IntersectionObserver | null = null;
+    function watchDock() {
+      dockWatcher?.disconnect();
+      dockWatcher = new IntersectionObserver(
+        ([entry]) =>
+          switcher.classList.toggle("is-docked", entry.intersectionRatio < 1),
+        {
+          rootMargin: `-${Math.round(dockLine()) + 1}px 0px 0px 0px`,
+          threshold: [1],
+        },
+      );
+      dockWatcher.observe(switcher);
+    }
+    watchDock();
+    window.addEventListener("resize", watchDock);
+
+    // Where the rail sits in the document, which is not where it is drawn once
+    // it is stuck: a sticky element keeps its layout position in offsetTop and
+    // reports the shifted one in getBoundingClientRect.
+    function railTop() {
+      let top = 0;
+      let node: HTMLElement | null = switcher;
+      while (node) {
+        top += node.offsetTop;
+        node = node.offsetParent as HTMLElement | null;
+      }
+      return top;
+    }
+
+    // Switching views changes the page's height by thousands of pixels — the
+    // checklist is a hundred rows longer than the stats — so a reader deep in
+    // one view lands somewhere arbitrary in the next. Coming back to the rail
+    // puts them at the top of what they just asked for, with the control they
+    // used still under the cursor. Only when the rail has already gone past:
+    // switching from the top of the page shouldn't move the page at all.
+    function keepRailInView() {
+      const dock = railTop() - dockLine();
+      if (window.scrollY <= dock) return;
+      const reduced = window.matchMedia(
+        "(prefers-reduced-motion: reduce)",
+      ).matches;
+      window.scrollTo({ top: dock, behavior: reduced ? "auto" : "smooth" });
+    }
+
+    // Read before the rail is wired up. initToggleTabs selects the tab the
+    // server rendered on the way in, and the callback below rewrites the URL —
+    // so by the time it returns, the hash it was about to be asked for is gone.
+    const hash = window.location.hash.slice(1);
+    const initialView = validViews.includes(hash) ? hash : defaultView;
+
+    // What is on screen, which is not always what was just asked for: clicking
+    // the tab you are already on is a real thing to do — it is how you get back
+    // to the top of a long view — and it must not leave a history entry behind
+    // every time.
+    let shownView = "";
+
+    tabs = initToggleTabs(group, (viewId, cause) => {
+      const changed = viewId !== shownView;
+      shownView = viewId;
+
+      views.forEach((view) => {
+        view.toggleAttribute("hidden", view.dataset.view !== viewId);
       });
+
+      // A view is a place, so choosing one goes in the history and Back returns
+      // to the one before it. Everything else — the first paint, a deep link,
+      // the popstate that Back itself causes — only rewrites the address, since
+      // pushing there would either bury the page someone arrived from or fight
+      // the navigation that is already happening.
+      const url = viewId === defaultView ? "/travel" : `/travel#${viewId}`;
+      if (cause === "user" && changed) history.pushState(null, "", url);
+      else history.replaceState(null, "", url);
+
+      if (cause === "user") keepRailInView();
     });
 
-    // Handle hash changes
-    window.addEventListener("hashchange", () => {
-      const hash = window.location.hash.slice(1);
-      const viewId = validViews.includes(hash) ? hash : defaultView;
-      setView(viewId);
-    });
+    // A view asked for by its own link opens on it. Not a user action as far as
+    // the page is concerned — nothing should scroll out from under someone who
+    // has only just arrived.
+    if (initialView !== defaultView) tabs.select(initialView);
+
+    // Back and Forward land here: a push that only changed the fragment fires
+    // hashchange, so this one listener covers both the history buttons and any
+    // link into a view from elsewhere on the page. Attached once, for the life
+    // of the module — see the note at the top.
+    if (!listening) {
+      listening = true;
+      window.addEventListener("hashchange", () => {
+        const next = window.location.hash.slice(1);
+        tabs?.select(validViews.includes(next) ? next : defaultView);
+      });
+    }
   }
 
-  // Initialize on DOM ready
-  if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", initViewSwitcher);
-  } else {
-    initViewSwitcher();
-  }
+  // This script is a module, so it runs with the document already parsed. The
+  // second line is for view transitions: they swap the body without a
+  // navigation, so DOMContentLoaded never fires again and a rail wired only on
+  // that event would be dead on every page reached from inside the site.
+  // astro:page-load covers both, and never fires at all until a ClientRouter
+  // exists — so this changes nothing until one is added.
+  initViewSwitcher();
+  document.addEventListener("astro:page-load", initViewSwitcher);
 </script>
 
 <style>
+  /* The rail pins under the header pills, on the same veil the header and the
+     sticky year headings use — three things closing over the page as it
+     scrolls, saying so the same way. It earns the pin honestly: the checklist
+     is a hundred and twenty-five rows tall, and until now switching away from
+     the bottom of it meant scrolling all the way back up to reach the control.
+
+     z-index 11 rather than the headings' 10, and below the header row's 30: the
+     stack from the top of the page down is pills, rail, heading, content. */
+  /* A tint, but no blur and no rule. The rule is gone because the heading that
+     docks under it already draws one and two hairlines forty pixels apart was
+     the complaint. The blur is gone because the header's veil is directly
+     behind this and has already done it.
+
+     The tint had to come back. A sticky section heading sits above the veil by
+     design — it is chrome, not content — so when its own section scrolls out
+     and the heading is pushed up out of its dock, it travels straight through
+     the pinned strip. What used to hide it was this background; without it the
+     outgoing heading was drawn across the tabs and the pills. Two veils of the
+     same colour stacking here is what the seam used to be, and at a tint this
+     opaque 0.97 over 0.97 is indistinguishable from 0.97. */
   .view-switcher {
-    display: flex;
+    position: sticky;
+    top: var(--sticky-header-offset, 0px);
+    z-index: 11;
+    transition: background-color 0.2s ease;
+    /* Even, because the tabs are capsules floating on the strip rather than
+       something anchored to its bottom edge — and out to the page's shared
+       edge, so the strip ends where the counters above and the rows below do. */
+    padding: 0.4rem 0.75rem;
+    margin-inline: -0.75rem;
+  }
+
+  /* And the tint only while it is actually docked.
+
+     Carried all the time, it cut the counters' shadow in half. Those cards drop
+     0 10px 30px and the rail sits twenty pixels under them, so an opaque strip
+     at z-index 11 sliced the soft part off in a dead straight line across the
+     page — a shadow that ends on a ruler, which reads as a rendering fault
+     rather than as depth.
+
+     In flow it does not need one: nothing is passing behind a row of tabs
+     sitting on the page. Docked it does, and for a reason easy to miss — a
+     sticky section heading is above the veil so it can cover the rows going
+     under it, which means when its own section pushes it out of its dock it
+     travels up through here with nothing to hide it. */
+  .view-switcher.is-docked {
+    background-color: var(--veil-bg);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .view-switcher {
+      transition: none;
+    }
   }
 </style>

--- a/src/components/travel/TravelViewSwitcher.astro
+++ b/src/components/travel/TravelViewSwitcher.astro
@@ -162,8 +162,16 @@ const viewIds = items.map((item) => item.id).join(" ");
     // nothing to observe directly — the trick is to shrink the observation area
     // to start one pixel below the dock line, which the rail can only cross by
     // being stuck to it.
+    //
+    // An arrow rather than a declaration, and not as a matter of taste: a
+    // function declaration is hoisted, so TypeScript has to assume it could run
+    // before the guard above and reads `switcher` at its declared type — null
+    // included — however plainly the guard returns. An arrow is created here,
+    // after the narrowing, and keeps it. `publish` above is an arrow for the
+    // same reason; this one was the exception and it was the one that failed
+    // the typecheck.
     let dockWatcher: IntersectionObserver | null = null;
-    function watchDock() {
+    const watchDock = () => {
       dockWatcher?.disconnect();
       dockWatcher = new IntersectionObserver(
         ([entry]) =>
@@ -174,7 +182,7 @@ const viewIds = items.map((item) => item.id).join(" ");
         },
       );
       dockWatcher.observe(switcher);
-    }
+    };
     watchDock();
     window.addEventListener("resize", watchDock);
 

--- a/src/components/travel/TravelViewSwitcher.astro
+++ b/src/components/travel/TravelViewSwitcher.astro
@@ -7,37 +7,17 @@ interface Props {
 
 const { currentView } = Astro.props;
 
+// No icons. ToggleGroup draws one before the label when an item asks for it,
+// and five of them across a row this wide were five more things to read than
+// the five words already there — a flag, a globe, a bar chart and a tick that
+// each restated their own label. The words are short and unambiguous in both
+// languages, so the icons were decoration on a control, not a way into it.
 const items = [
-  {
-    id: "timeline",
-    label: "Timeline",
-    labelRu: "Хронология",
-    icon: "timeline",
-  },
-  {
-    id: "countries",
-    label: "Countries",
-    labelRu: "Страны",
-    icon: "flag",
-  },
-  {
-    id: "continents",
-    label: "Continents",
-    labelRu: "Континенты",
-    icon: "continent",
-  },
-  {
-    id: "stats",
-    label: "Stats",
-    labelRu: "Статистика",
-    icon: "stats",
-  },
-  {
-    id: "checklist",
-    label: "Checklist",
-    labelRu: "Чеклист",
-    icon: "checklist",
-  },
+  { id: "timeline", label: "Timeline", labelRu: "Хронология" },
+  { id: "countries", label: "Countries", labelRu: "Страны" },
+  { id: "continents", label: "Continents", labelRu: "Континенты" },
+  { id: "stats", label: "Stats", labelRu: "Статистика" },
+  { id: "checklist", label: "Checklist", labelRu: "Чеклист" },
 ];
 
 // The script below used to carry its own copy of this list to validate the

--- a/src/components/travel/TravelViewSwitcher.astro
+++ b/src/components/travel/TravelViewSwitcher.astro
@@ -21,15 +21,33 @@ const items = [
     icon: "flag",
   },
   {
+    id: "continents",
+    label: "Continents",
+    labelRu: "Континенты",
+    icon: "continent",
+  },
+  {
+    id: "stats",
+    label: "Stats",
+    labelRu: "Статистика",
+    icon: "stats",
+  },
+  {
     id: "checklist",
     label: "Checklist",
     labelRu: "Чеклист",
     icon: "checklist",
   },
 ];
+
+// The script below used to carry its own copy of this list to validate the
+// URL hash against. Adding a view meant editing both, and forgetting the copy
+// left the new view reachable by its button but not by its own link — the hash
+// fell through to the default and the page opened on the timeline instead.
+const viewIds = items.map((item) => item.id).join(" ");
 ---
 
-<nav class="view-switcher" data-current={currentView}>
+<nav class="view-switcher" data-current={currentView} data-views={viewIds}>
   <ToggleGroup
     items={items}
     value={currentView}
@@ -50,8 +68,9 @@ const items = [
 
     // Get initial view from URL hash or default
     const hash = window.location.hash.slice(1);
-    const validViews = ["timeline", "countries", "checklist"];
-    const initialView = validViews.includes(hash) ? hash : "timeline";
+    const validViews = (switcher.getAttribute("data-views") ?? "").split(" ");
+    const defaultView = validViews[0];
+    const initialView = validViews.includes(hash) ? hash : defaultView;
 
     function setView(viewId: string) {
       // Update buttons
@@ -73,7 +92,11 @@ const items = [
       });
 
       // Update URL hash without scrolling
-      history.replaceState(null, "", viewId === "timeline" ? "/travel" : `/travel#${viewId}`);
+      history.replaceState(
+        null,
+        "",
+        viewId === defaultView ? "/travel" : `/travel#${viewId}`,
+      );
     }
 
     // Set initial view
@@ -91,7 +114,7 @@ const items = [
     // Handle hash changes
     window.addEventListener("hashchange", () => {
       const hash = window.location.hash.slice(1);
-      const viewId = validViews.includes(hash) ? hash : "timeline";
+      const viewId = validViews.includes(hash) ? hash : defaultView;
       setView(viewId);
     });
   }

--- a/src/components/travel/TravelYearChart.astro
+++ b/src/components/travel/TravelYearChart.astro
@@ -1,0 +1,366 @@
+---
+import {
+  datedTrips,
+  fillYearGaps,
+  formatTripCount,
+  getTravelFacts,
+} from "@lib/travel";
+import "@styles/travel.css";
+
+const series = fillYearGaps(getTravelFacts(datedTrips).tripsByYear);
+const peak = series.reduce((max, entry) => Math.max(max, entry.trips), 0);
+
+// Three intervals, so the grid reads 0 / n / 2n / 3n and the top of the plot is
+// a round number at or above the busiest year. The headroom the peak's own
+// label needs is a margin above the plot rather than a fourth interval of empty
+// grid: raising the ceiling to make room for one number would flatten every
+// column on the chart to pay for it.
+const step = Math.max(1, Math.ceil(peak / 3));
+const top = step * 3;
+const ticks = [0, step, step * 2, top];
+
+// The year still being lived in — the one label on the axis set in ink, so the
+// eye finds it. Its column is short because the year is not over yet, not
+// because the travelling stopped. Resolved at build time: this page is
+// prerendered, so a build left standing across New Year keeps calling the old
+// year the current one until the next deploy.
+const currentYear = new Date().getFullYear();
+
+// Fifteen four-digit labels don't fit a phone, so on a narrow screen only the
+// round years and the two ends stay. Marked here rather than by :nth-child, so
+// which ones survive doesn't depend on what year the series happens to start
+// on.
+//
+// A four-digit label is wider than a band is at that width, so two kept labels
+// in neighbouring bands would overlap — which is exactly what 2025 and 2026
+// would do. The ends win that argument: the axis is a range, and the years it
+// runs between are the two worth reading.
+const lastIndex = series.length - 1;
+const keepsLabelWhenNarrow = (index: number) => {
+  if (index === 0 || index === lastIndex) return true;
+  if (series[index].year % 5 !== 0) return false;
+  return index > 1 && index < lastIndex - 1;
+};
+---
+
+{/* A figure, because this is a picture with a caption rather than a section
+    with a heading — but the caption is dressed as the group heading every other
+    view on this page uses, since to a reader scrolling past it is the same kind
+    of landmark a year or a continent is. */}
+<figure class="chart">
+  <figcaption class="travel-section-head">
+    <h2
+      class="travel-section-title"
+      data-en="Trips by year"
+      data-ru="Поездки по годам"
+    >
+      Trips by year
+    </h2>
+    <span class="travel-metric">
+      {series[0]?.year}&ndash;{series[series.length - 1]?.year}
+    </span>
+  </figcaption>
+
+  {/* The caption stays outside this grid on purpose. It is one of the page's
+      sticky headings, and a sticky box travels only as far as its containing
+      block — as a grid item that would be a row holding nothing but itself, so
+      it would come unstuck the moment it was asked to move. As a block child of
+      the figure it has the whole chart to stay pinned over, exactly like the
+      section heads in every other view. */}
+  <div class="body" style={`--n: ${series.length}`}>
+  <div class="plot">
+    {/* Recessive by construction: solid hairlines one step off the page, with
+        the baseline a shade firmer because it is the axis the columns stand
+        on. */}
+    <div class="grid" aria-hidden="true">
+      {
+        ticks.map((tick) => (
+          <span
+            class:list={["gridline", { "gridline--base": tick === 0 }]}
+            style={`--at: ${tick / top}`}
+          >
+            <i class="tick">{tick}</i>
+          </span>
+        ))
+      }
+    </div>
+
+    <ol class="cols" role="list">
+      {
+        series.map((entry) => {
+          const label = {
+            en: `${entry.year}: ${formatTripCount(entry.trips, "en")}`,
+            ru: `${entry.year}: ${formatTripCount(entry.trips, "ru")}`,
+          };
+          return (
+            // The whole band answers the pointer, not the column: a year with
+            // no trips has no column to aim at, and the ones that do are twenty
+            // pixels wide.
+            <li
+              class="col"
+              style={`--v: ${entry.trips / top}`}
+              data-tooltip={label.en}
+              data-tooltip-en={label.en}
+              data-tooltip-ru={label.ru}
+            >
+              <span class="sr-only" data-en={label.en} data-ru={label.ru}>
+                {label.en}
+              </span>
+              {entry.trips > 0 && (
+                <span
+                  class:list={["bar", { "bar--peak": entry.trips === peak }]}
+                  aria-hidden="true"
+                />
+              )}
+              {/* One number on the chart, on the tallest column. A value over
+                  every one of fifteen columns is chaos that goes unread; the
+                  grid carries the rest and the pointer carries the exact
+                  figure. */}
+              {entry.trips === peak && (
+                <span class="cap" aria-hidden="true">
+                  {entry.trips}
+                </span>
+              )}
+            </li>
+          );
+        })
+      }
+    </ol>
+  </div>
+
+  {/* Hidden from the reading order because the list above already carries every
+      year and its count — this row is the same labels drawn where the eye needs
+      them. */}
+  <ol class="years" role="list" aria-hidden="true">
+    {
+      series.map((entry, index) => (
+        <li
+          class:list={[
+            "year",
+            {
+              "year--current": entry.year === currentYear,
+              "year--landmark": keepsLabelWhenNarrow(index),
+            },
+          ]}
+        >
+          {entry.year}
+        </li>
+      ))
+    }
+  </ol>
+  </div>
+</figure>
+
+<script>
+  // The columns explain themselves on hover with the site's own bead rather
+  // than the browser's title box.
+  import { initTooltips } from "@client/tooltip";
+  initTooltips();
+</script>
+
+<style>
+  .chart {
+    margin: 0;
+  }
+
+  /* Plot and axis share one grid, so a year label can never drift off the
+     column it belongs to: both rows run on the same `--n` tracks, and the tick
+     gutter is a column of that grid rather than a padding the two have to agree
+     on by hand. */
+  .body {
+    display: grid;
+    grid-template-columns: 1.6rem minmax(0, 1fr);
+  }
+
+  .plot {
+    position: relative;
+    grid-column: 2;
+    /* Tall enough that one trip is a visible difference in height at this
+       width, short enough that the whole decade is one glance. */
+    height: 148px;
+    /* Headroom for the label on the tallest column, which is drawn above the
+       cap it names and so reaches out of the plot box. Nothing clips it — the
+       margin is simply where it lands. */
+    margin-top: 1.3rem;
+  }
+
+  .grid {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+  }
+
+  /* Nudged down by half its own hairline so the line straddles the value it
+     names — without it the top rule sits a pixel above the tallest column's cap
+     and the baseline covers the bottom pixel of every bar. */
+  .gridline {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: calc(var(--at) * 100%);
+    transform: translateY(50%);
+    border-top: 1px solid
+      light-dark(rgba(0, 0, 0, 0.08), rgba(255, 255, 255, 0.08));
+  }
+
+  .gridline--base {
+    border-top-color: light-dark(rgba(0, 0, 0, 0.16), rgba(255, 255, 255, 0.16));
+  }
+
+  /* Hung off the gridline itself and pulled into the gutter, so the number and
+     the line it names line up by construction rather than by a matching pair of
+     offsets kept in step by hand. */
+  .tick {
+    position: absolute;
+    right: 100%;
+    top: 50%;
+    transform: translateY(-50%);
+    padding-right: 0.5rem;
+    font-style: normal;
+    font-size: 0.7rem;
+    font-variant-numeric: tabular-nums;
+    color: var(--travel-muted);
+  }
+
+  .cols,
+  .years {
+    display: grid;
+    grid-template-columns: repeat(var(--n), minmax(0, 1fr));
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .cols {
+    position: relative;
+    height: 100%;
+    align-items: end;
+  }
+
+  .col {
+    position: relative;
+    height: 100%;
+    display: flex;
+    align-items: flex-end;
+    justify-content: center;
+    /* No margin of its own: the document's list typography would otherwise put
+       8px under every column and lift the whole row off its baseline. */
+    margin: 0;
+  }
+
+  /* Capped rather than filling its band — the leftover is the air that keeps a
+     row of columns from reading as one solid block. */
+  .bar {
+    width: 100%;
+    max-width: 20px;
+    height: calc(var(--v) * 100%);
+    /* Rounded at the data end, square where it meets the axis. */
+    border-radius: 4px 4px 0 0;
+    background-color: light-dark(rgba(0, 0, 0, 0.38), rgba(255, 255, 255, 0.55));
+    /* The light the progress bar's fill catches along its leading edge, turned
+       to stand up. */
+    background-image: linear-gradient(
+      to bottom,
+      rgba(255, 255, 255, 0.35),
+      rgba(255, 255, 255, 0) 55%
+    );
+    /* A single-trip year is 16px tall here and still has to read as a column. */
+    min-height: 3px;
+  }
+
+  /* One column is the story — the busiest year — and it wears the accent the
+     progress bars wear. The rest are the context it is read against. */
+  .bar--peak {
+    background-color: transparent;
+    background-image:
+      linear-gradient(
+        to bottom,
+        rgba(255, 255, 255, 0.3),
+        rgba(255, 255, 255, 0) 55%
+      ),
+      linear-gradient(135deg, var(--accent-start), var(--accent-end));
+    box-shadow: 0 0 8px rgba(237, 87, 96, 0.45);
+  }
+
+  /* Sits on the cap it names, a hair clear of it. --v is the column's, so this
+     follows the bar's height without being told it twice. */
+  .cap {
+    position: absolute;
+    bottom: calc(var(--v) * 100%);
+    margin-bottom: 0.3rem;
+    font-size: 0.7rem;
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+    color: light-dark(#111, #fafafa);
+    pointer-events: none;
+  }
+
+  .years {
+    grid-column: 2;
+    padding-top: 0.45rem;
+  }
+
+  .year {
+    margin: 0;
+    text-align: center;
+    font-size: 0.7rem;
+    line-height: 1.4;
+    font-variant-numeric: tabular-nums;
+    color: var(--travel-muted);
+  }
+
+  /* A year with no travel in it keeps its label at full strength. Fading it was
+     the obvious move and the wrong one twice over: the empty slot is the point,
+     and a label at the contrast that fade needs would have been the one thing
+     on the chart nobody could read. The missing column already says it.
+
+     The year in progress is the one worth finding on the axis, so it is the
+     only label that steps forward. */
+  .year--current {
+    color: light-dark(#111, #fafafa);
+    font-weight: 600;
+  }
+
+  /* Reachable by a screen reader, invisible to everything else: the columns are
+     aria-hidden decoration, and this is the data they draw. */
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    overflow: hidden;
+    clip-path: inset(50%);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  @media (max-width: 640px) {
+    .body {
+      grid-template-columns: 1.4rem minmax(0, 1fr);
+    }
+
+    /* The axis thins out, not the data — every column keeps its place. */
+    .year:not(.year--landmark) {
+      visibility: hidden;
+    }
+
+    .bar {
+      max-width: 14px;
+    }
+  }
+
+  @media (prefers-reduced-transparency: reduce) {
+    .bar {
+      background-image: none;
+    }
+
+    .bar--peak {
+      background-image: linear-gradient(
+        135deg,
+        var(--accent-start),
+        var(--accent-end)
+      );
+    }
+  }
+</style>

--- a/src/icons/eye.svg
+++ b/src/icons/eye.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7z"></path>
+  <circle cx="12" cy="12" r="3"></circle>
+</svg>

--- a/src/lib/travel/index.test.ts
+++ b/src/lib/travel/index.test.ts
@@ -10,7 +10,9 @@ import {
   formatMonthYear,
   formatTripCount,
   formatVisitCount,
+  fillYearGaps,
   getCountriesByContinent,
+  getCountriesWithCities,
   getJourneys,
   getTravelFacts,
   getUnmappedCountries,
@@ -312,7 +314,10 @@ test("finds the most active year", () => {
 test("finds the latest country seen for the first time", () => {
   expect(getTravelFacts(factsTripsData).latestNewCountry).toEqual({
     name: { en: "United Kingdom", ru: "Великобритания" },
-    a2: "gb-eng",
+    // "gb", not the "gb-eng" this used to assert: the card names the country,
+    // so it flies the country's flag. The nation the journey actually landed in
+    // is the timeline's business, and the timeline still draws both.
+    a2: "gb",
     year: 2024,
     month: 10,
   });
@@ -387,6 +392,118 @@ test("a country first seen on an outing keeps that date", () => {
   });
 });
 
+test("a country flies its own flag, not one of its nations'", () => {
+  const gb = getCountriesWithCities(factsTripsData).find(
+    (country) => country.code === "GBR",
+  )!;
+
+  // The journey reaches England and Scotland; the country is neither.
+  expect(gb.a2).toBe("gb");
+  expect(getTravelFacts(factsTripsData).mostVisitedCountry!.a2).toBe("ru");
+});
+
+test("a city keeps the outings out of its count but the country keeps the date", () => {
+  const [kazakhstan] = getCountriesWithCities(outingTripsData);
+
+  // Almaty appears in all three trips, two of which are outings.
+  expect(kazakhstan.cities).toEqual([{ name: "Almaty", visits: 1 }]);
+  // And 2024 is still the year I first stood there, outing or not.
+  expect(kazakhstan.firstYear).toBe(2024);
+});
+
+test("a city is counted once per trip and dated from the first", () => {
+  const byCode = new Map(
+    getCountriesWithCities(factsTripsData).map((country) => [
+      country.code,
+      country,
+    ]),
+  );
+
+  expect(byCode.get("RUS")!.cities).toEqual([
+    { name: "Saint Petersburg", visits: 2 },
+  ]);
+  expect(byCode.get("RUS")!.firstYear).toBe(2021);
+
+  // England and Scotland are one journey through one country, so neither city
+  // scores twice and the country is dated once.
+  expect(byCode.get("GBR")!.cities).toEqual([
+    { name: "Edinburgh", visits: 1 },
+    { name: "London", visits: 1 },
+  ]);
+  expect(byCode.get("GBR")!.firstYear).toBe(2024);
+
+  // Reached only by a trip with no date, so there is no year to show.
+  expect(byCode.get("JPN")!.firstYear).toBeNull();
+});
+
+// The order the world arrived in, which a year alone cannot give: these three
+// journeys put two countries in one year and two more in one journey.
+const chronologyTripsData: Trip[] = [
+  {
+    // Later in the year than Latvia below, but with two cities — so a sort by
+    // city count would lift it above the trip that actually happened first.
+    year: 2019,
+    month: 9,
+    endMonth: null,
+    destinations: [{ cities: ["Prague", "Brno"], country: ["cz", "cze"] }],
+  },
+  {
+    year: 2019,
+    month: 3,
+    endMonth: null,
+    destinations: [{ cities: ["Riga"], country: ["lv", "lva"] }],
+  },
+  {
+    // One journey, two countries new on the same day: the route's own order is
+    // the order they were stood in, and no date on the row could say it.
+    year: 2020,
+    month: 1,
+    endMonth: null,
+    destinations: [
+      { cities: ["Vienna"], country: ["at", "aut"] },
+      { cities: ["Bratislava"], country: ["sk", "svk"] },
+    ],
+  },
+];
+
+test("first sightings are ranked by when they happened, not by the year", () => {
+  const ranked = getCountriesWithCities(chronologyTripsData)
+    .slice()
+    .sort((a, b) => a.firstSeen! - b.firstSeen!);
+
+  expect(ranked.map((country) => country.code)).toEqual([
+    "LVA",
+    "CZE",
+    "AUT",
+    "SVK",
+  ]);
+  expect(ranked.map((country) => country.firstSeen)).toEqual([0, 1, 2, 3]);
+  // Both 2019 countries still show the same year — the rank is what separates
+  // them, and it is not on display.
+  expect(ranked.map((country) => country.firstYear)).toEqual([
+    2019, 2019, 2020, 2020,
+  ]);
+});
+
+test("a country with no dated trip has no place in the chronology", () => {
+  const japan = getCountriesWithCities(factsTripsData).find(
+    (country) => country.code === "JPN",
+  )!;
+
+  expect(japan.firstSeen).toBeNull();
+  expect(japan.firstYear).toBeNull();
+});
+
+test("the countries view and the stats view agree on the most visited city", () => {
+  const busiest = Math.max(
+    ...getCountriesWithCities(datedTrips).flatMap((country) =>
+      country.cities.map((city) => city.visits),
+    ),
+  );
+
+  expect(busiest).toBe(getTravelFacts(datedTrips).mostVisitedCity!.visits);
+});
+
 test("the trips counter and the by-year bars count the same thing", () => {
   const total = getTravelFacts(trips).tripsByYear.reduce(
     (sum, entry) => sum + entry.trips,
@@ -426,4 +543,45 @@ test("agrees Russian nouns with the number in front of them", () => {
 test("formats a month and year in both languages", () => {
   expect(formatMonthYear(2026, 7, "en")).toBe("Jul 2026");
   expect(formatMonthYear(2026, 7, "ru")).toBe("Июл 2026");
+});
+
+test("puts the years with no trips back on the axis", () => {
+  expect(
+    fillYearGaps([
+      { year: 2013, trips: 1 },
+      { year: 2016, trips: 2 },
+      { year: 2017, trips: 1 },
+    ]),
+  ).toEqual([
+    { year: 2013, trips: 1 },
+    { year: 2014, trips: 0 },
+    { year: 2015, trips: 0 },
+    { year: 2016, trips: 2 },
+    { year: 2017, trips: 1 },
+  ]);
+});
+
+test("leaves a gapless run and an empty one alone", () => {
+  const gapless = [
+    { year: 2020, trips: 4 },
+    { year: 2021, trips: 9 },
+  ];
+  expect(fillYearGaps(gapless)).toEqual(gapless);
+  expect(fillYearGaps([])).toEqual([]);
+  expect(fillYearGaps([{ year: 2012, trips: 1 }])).toEqual([
+    { year: 2012, trips: 1 },
+  ]);
+});
+
+test("fills the real series without dropping a trip", () => {
+  const series = fillYearGaps(getTravelFacts(datedTrips).tripsByYear);
+  const years = series.map((entry) => entry.year);
+
+  // Consecutive by construction — the property the chart's axis depends on.
+  expect(years).toEqual(
+    Array.from({ length: years.length }, (_, i) => years[0] + i),
+  );
+  // And the columns add up to the counter above the chart. Outings are not
+  // journeys, so this is tripsCount rather than the number of dated trips.
+  expect(series.reduce((sum, entry) => sum + entry.trips, 0)).toBe(tripsCount);
 });

--- a/src/lib/travel/index.test.ts
+++ b/src/lib/travel/index.test.ts
@@ -6,6 +6,18 @@ import {
   groupTripsByYear,
   getSortedYears,
   formatTripDate,
+  formatCityCount,
+  formatMonthYear,
+  formatTripCount,
+  formatVisitCount,
+  getCountriesByContinent,
+  getTravelFacts,
+  getUnmappedCountries,
+  continentsTotal,
+  continentsVisited,
+  countries,
+  datedTrips,
+  trips,
   type Trip,
 } from "./index";
 
@@ -130,4 +142,217 @@ test("formats trip date - same month in endMonth", () => {
     destinations: [],
   };
   expect(formatTripDate(trip)).toBe("Jul");
+});
+
+// -----------------------------------------------------------------------------
+// Continents
+// -----------------------------------------------------------------------------
+
+const continentTripsData: Trip[] = [
+  {
+    year: 2019,
+    month: 5,
+    endMonth: null,
+    destinations: [
+      { cities: ["Paris"], country: ["fr", "fra"] },
+      { cities: ["Barcelona", "Madrid"], country: ["es", "esp"] },
+    ],
+  },
+  {
+    year: 2024,
+    month: 4,
+    endMonth: null,
+    destinations: [{ cities: ["Dubai"], country: ["ae", "are"] }],
+  },
+];
+
+test("groups visited countries under their continent", () => {
+  const groups = getCountriesByContinent(continentTripsData);
+  const europe = groups.find((group) => group.id === "europe")!;
+  const asia = groups.find((group) => group.id === "asia")!;
+
+  expect(europe.countries.map((c) => c.code)).toEqual(["ESP", "FRA"]);
+  expect(europe.visited).toBe(2);
+  expect(europe.total).toBe(44);
+  expect(asia.countries.map((c) => c.code)).toEqual(["ARE"]);
+  expect(asia.visited).toBe(1);
+});
+
+test("returns all seven continents, visited ones first", () => {
+  const groups = getCountriesByContinent(continentTripsData);
+  expect(groups.length).toBe(7);
+  expect(groups.map((group) => group.id)).toEqual([
+    "europe",
+    "asia",
+    "africa",
+    "north-america",
+    "south-america",
+    "oceania",
+    "antarctica",
+  ]);
+});
+
+test("the stat card counts the continents the view draws", () => {
+  expect(continentsTotal).toBe(7);
+  expect(continentsVisited).toBe(
+    getCountriesByContinent(datedTrips).filter(
+      (group) => group.countries.length > 0,
+    ).length,
+  );
+});
+
+test("continent totals cover the 195 countries the site counts", () => {
+  const total = getCountriesByContinent([]).reduce(
+    (sum, group) => sum + group.total,
+    0,
+  );
+  expect(total).toBe(195);
+});
+
+// The continents view silently drops a country with no continent, and the
+// per-continent fractions still add up, so nothing on the page looks wrong.
+test("every visited country has a continent", () => {
+  expect(getUnmappedCountries(trips)).toEqual([]);
+});
+
+test("every visited country appears under exactly one continent", () => {
+  const listed = getCountriesByContinent(datedTrips).flatMap(
+    (group) => group.countries,
+  );
+  expect(new Set(listed.map((c) => c.code)).size).toBe(listed.length);
+  expect(listed.length).toBe(countries.size);
+});
+
+test("no continent counts more countries than it has", () => {
+  for (const group of getCountriesByContinent(datedTrips)) {
+    expect(group.visited).toBeLessThanOrEqual(group.total);
+  }
+});
+
+// -----------------------------------------------------------------------------
+// Stats & facts
+// -----------------------------------------------------------------------------
+
+const factsTripsData: Trip[] = [
+  {
+    year: 2021,
+    month: 6,
+    endMonth: null,
+    destinations: [{ cities: ["Saint Petersburg"], country: ["ru", "rus"] }],
+  },
+  {
+    year: 2021,
+    month: 9,
+    endMonth: null,
+    destinations: [{ cities: ["Saint Petersburg"], country: ["ru", "rus"] }],
+  },
+  {
+    // England and Scotland reach the same country twice in one journey.
+    year: 2024,
+    month: 10,
+    endMonth: null,
+    destinations: [
+      { cities: ["London"], country: ["gb-eng", "gbr"] },
+      { cities: ["Edinburgh"], country: ["gb-sct", "gbr"] },
+    ],
+  },
+  {
+    year: null,
+    month: null,
+    endMonth: null,
+    destinations: [{ cities: ["Tokyo"], country: ["jp", "jpn"] }],
+  },
+];
+
+test("counts a country once per trip, not once per destination", () => {
+  const facts = getTravelFacts(factsTripsData);
+  const uk = facts.tripsByYear.find((entry) => entry.year === 2024)!;
+  expect(uk.trips).toBe(1);
+  expect(facts.mostVisitedCountry).toEqual({
+    name: { en: "Russia", ru: "Россия" },
+    a2: "ru",
+    visits: 2,
+  });
+});
+
+test("finds the most visited city", () => {
+  expect(getTravelFacts(factsTripsData).mostVisitedCity).toEqual({
+    name: { en: "Saint Petersburg", ru: "Санкт-Петербург" },
+    a2: "ru",
+    visits: 2,
+  });
+});
+
+test("finds the most active year", () => {
+  expect(getTravelFacts(factsTripsData).mostActiveYear).toEqual({
+    year: 2021,
+    trips: 2,
+  });
+});
+
+test("finds the latest country seen for the first time", () => {
+  expect(getTravelFacts(factsTripsData).latestNewCountry).toEqual({
+    name: { en: "United Kingdom", ru: "Великобритания" },
+    a2: "gb-eng",
+    year: 2024,
+    month: 10,
+  });
+});
+
+// A trip with no date is a plan, not a visit; letting one through would put a
+// country I have never been to at the top of "latest new country".
+test("ignores TBA trips", () => {
+  const facts = getTravelFacts(factsTripsData);
+  expect(facts.tripsByYear).toEqual([
+    { year: 2021, trips: 2 },
+    { year: 2024, trips: 1 },
+  ]);
+});
+
+test("has no facts to report for an empty history", () => {
+  expect(getTravelFacts([])).toEqual({
+    mostVisitedCity: null,
+    mostVisitedCountry: null,
+    mostActiveYear: null,
+    latestNewCountry: null,
+    tripsByYear: [],
+  });
+});
+
+test("counts every dated trip exactly once across the years", () => {
+  const total = getTravelFacts(trips).tripsByYear.reduce(
+    (sum, entry) => sum + entry.trips,
+    0,
+  );
+  expect(total).toBe(datedTrips.length);
+});
+
+// -----------------------------------------------------------------------------
+// Counted nouns
+// -----------------------------------------------------------------------------
+
+test("counts trips in English", () => {
+  expect(formatTripCount(1, "en")).toBe("1 trip");
+  expect(formatTripCount(17, "en")).toBe("17 trips");
+});
+
+test("agrees Russian nouns with the number in front of them", () => {
+  expect(formatTripCount(1, "ru")).toBe("1 поездка");
+  expect(formatTripCount(3, "ru")).toBe("3 поездки");
+  expect(formatTripCount(17, "ru")).toBe("17 поездок");
+  expect(formatTripCount(21, "ru")).toBe("21 поездка");
+  // The teens are the exception the mod-10 rule alone gets wrong.
+  expect(formatTripCount(11, "ru")).toBe("11 поездок");
+  expect(formatTripCount(12, "ru")).toBe("12 поездок");
+  expect(formatVisitCount(1, "ru")).toBe("1 визит");
+  expect(formatVisitCount(2, "ru")).toBe("2 визита");
+  expect(formatVisitCount(10, "ru")).toBe("10 визитов");
+  expect(formatCityCount(1, "ru")).toBe("1 город");
+  expect(formatCityCount(4, "ru")).toBe("4 города");
+  expect(formatCityCount(86, "ru")).toBe("86 городов");
+});
+
+test("formats a month and year in both languages", () => {
+  expect(formatMonthYear(2026, 7, "en")).toBe("Jul 2026");
+  expect(formatMonthYear(2026, 7, "ru")).toBe("Июл 2026");
 });

--- a/src/lib/travel/index.test.ts
+++ b/src/lib/travel/index.test.ts
@@ -11,13 +11,16 @@ import {
   formatTripCount,
   formatVisitCount,
   getCountriesByContinent,
+  getJourneys,
   getTravelFacts,
   getUnmappedCountries,
   continentsTotal,
   continentsVisited,
   countries,
   datedTrips,
+  journeys,
   trips,
+  tripsCount,
   type Trip,
 } from "./index";
 
@@ -209,10 +212,26 @@ test("continent totals cover the 195 countries the site counts", () => {
   expect(total).toBe(195);
 });
 
-// The continents view silently drops a country with no continent, and the
-// per-continent fractions still add up, so nothing on the page looks wrong.
+// A country with no continent would be dropped from the view while the
+// per-continent fractions still added up, so nothing on the page would look
+// wrong. Two guards, because the interesting failure is a data edit rather
+// than a code one: the build refuses to render the view at all, and this names
+// the countries that caused it.
 test("every visited country has a continent", () => {
   expect(getUnmappedCountries(trips)).toEqual([]);
+});
+
+test("refuses to draw the view with a country it cannot place", () => {
+  const unmapped: Trip[] = [
+    {
+      year: 2024,
+      month: 5,
+      endMonth: null,
+      destinations: [{ cities: ["Nowhere"], country: ["zz", "zzz"] }],
+    },
+  ];
+  expect(getUnmappedCountries(unmapped)).toEqual(["ZZZ"]);
+  expect(() => getCountriesByContinent(unmapped)).toThrow("ZZZ");
 });
 
 test("every visited country appears under exactly one continent", () => {
@@ -319,12 +338,64 @@ test("has no facts to report for an empty history", () => {
   });
 });
 
-test("counts every dated trip exactly once across the years", () => {
+// Two afternoons at Shymbulak, recorded so the landmarks have a date to hang
+// on. They are entries on the timeline, not journeys.
+const outingTripsData: Trip[] = [
+  {
+    year: 2024,
+    month: 8,
+    endMonth: null,
+    kind: "outing",
+    destinations: [
+      { cities: ["Almaty"], country: ["kz", "kaz"], landmarks: ["shymbulak"] },
+    ],
+  },
+  {
+    year: 2025,
+    month: 10,
+    endMonth: null,
+    kind: "outing",
+    destinations: [
+      { cities: ["Almaty"], country: ["kz", "kaz"], landmarks: ["shymbulak"] },
+    ],
+  },
+  {
+    year: 2026,
+    month: 3,
+    endMonth: null,
+    destinations: [{ cities: ["Almaty"], country: ["kz", "kaz"] }],
+  },
+];
+
+test("a day out from home is not a trip", () => {
+  expect(getJourneys(outingTripsData).map((trip) => trip.year)).toEqual([2026]);
+
+  const facts = getTravelFacts(outingTripsData);
+  expect(facts.tripsByYear).toEqual([{ year: 2026, trips: 1 }]);
+  expect(facts.mostVisitedCity!.visits).toBe(1);
+  expect(facts.mostVisitedCountry!.visits).toBe(1);
+});
+
+// An outing is still the day I first stood in the country, so it keeps its
+// place in the one fact that is about first sightings rather than counts.
+test("a country first seen on an outing keeps that date", () => {
+  expect(getTravelFacts(outingTripsData).latestNewCountry).toEqual({
+    name: { en: "Kazakhstan", ru: "Казахстан" },
+    a2: "kz",
+    year: 2024,
+    month: 8,
+  });
+});
+
+test("the trips counter and the by-year bars count the same thing", () => {
   const total = getTravelFacts(trips).tripsByYear.reduce(
     (sum, entry) => sum + entry.trips,
     0,
   );
-  expect(total).toBe(datedTrips.length);
+  expect(total).toBe(tripsCount);
+  expect(tripsCount).toBe(journeys.length);
+  expect(journeys.every((trip) => trip.kind !== "outing")).toBe(true);
+  expect(journeys.length).toBeLessThanOrEqual(datedTrips.length);
 });
 
 // -----------------------------------------------------------------------------

--- a/src/lib/travel/index.ts
+++ b/src/lib/travel/index.ts
@@ -25,9 +25,11 @@ export interface Trip {
   // moving to Almaty in Jan 2023 the places around it are reached from home, so
   // they have no trip to hang on — but they still happened on a date, and a
   // landmark has no date of its own (it inherits the entry's). Recording them
-  // as entries keeps that date truthful; this flag keeps them distinguishable
-  // from real travel if the timeline ever wants to render them differently.
-  // Country and city stats are Sets, so a repeat entry cannot inflate them.
+  // as entries keeps that date truthful; this flag keeps them out of anything
+  // that counts journeys. Where the stats are Sets — countries, cities,
+  // landmarks — an outing is welcome and cannot inflate anything; where they
+  // are counts, `getJourneys` drops them, or two afternoons at Shymbulak would
+  // report themselves as two visits to Almaty and two trips to Kazakhstan.
   kind?: "outing";
 }
 
@@ -138,6 +140,14 @@ export function getTbaTrips(data: Trip[]): Trip[] {
 // Get only dated trips (non-TBA)
 export function getDatedTrips(data: Trip[]): Trip[] {
   return data.filter((trip) => trip.year !== null);
+}
+
+// The journeys proper: dated trips that actually went somewhere. The timeline
+// still lists an outing — it happened, and its landmarks hang off its date —
+// but a counter that says "trips" is answering a question a day out is not an
+// answer to.
+export function getJourneys(data: Trip[]): Trip[] {
+  return getDatedTrips(data).filter((trip) => trip.kind !== "outing");
 }
 
 // Group trips by year (only dated trips)
@@ -421,7 +431,16 @@ export function getCountriesByContinent(data: Trip[]): ContinentGroup[] {
 
   for (const country of ranked) {
     const id = COUNTRY_CONTINENTS[country.code];
-    if (!id) continue;
+    // Skipping it quietly is the one failure this view cannot survive: the
+    // country would vanish from it while every fraction on the page still
+    // added up, so nothing would look wrong. The travel page is prerendered,
+    // so throwing here fails the build — the loudest of the places this could
+    // be found out, and the only one that cannot ship.
+    if (!id) {
+      throw new Error(
+        `No continent for ${country.code} — add it to COUNTRY_CONTINENTS in src/lib/travel/index.ts`,
+      );
+    }
     if (!byContinent.has(id)) byContinent.set(id, []);
     byContinent.get(id)!.push(country);
   }
@@ -448,11 +467,12 @@ export function getCountriesByContinent(data: Trip[]): ContinentGroup[] {
   );
 }
 
-// Visited countries that COUNTRY_CONTINENTS has no entry for. They would be
-// dropped from the continents view without a trace, and the per-continent
-// fractions would still add up, so nothing on the page would look wrong. The
-// test pins this to empty; adding a country to trips.json without adding it
-// here is what it is there to catch.
+// Visited countries that COUNTRY_CONTINENTS has no entry for. The build
+// already refuses to draw the view with one of these in it, but a stack trace
+// out of a map/filter names the country and nothing else; this answers the
+// question the person reading it actually has — which ones, all of them — and
+// is what the test asserts on so a failure reads as a list rather than a
+// crash.
 export function getUnmappedCountries(data: Trip[]): string[] {
   return getCountriesWithCities(data)
     .map((country) => country.code)
@@ -514,7 +534,6 @@ export function getTravelFacts(data: Trip[]): TravelFacts {
 
   for (const trip of chronological) {
     const year = trip.year!;
-    tripsPerYear.set(year, (tripsPerYear.get(year) ?? 0) + 1);
 
     // Counted once per trip, not once per destination: the Oct 2024 trip
     // reaches England and Scotland as two destinations under the same alpha-3,
@@ -533,14 +552,23 @@ export function getTravelFacts(data: Trip[]): TravelFacts {
       }
     }
 
+    // A country is first seen however it was reached — an afternoon across the
+    // border is still the day I first stood there — so this runs for outings
+    // too. Everything below it counts journeys, and an outing is not one.
+    for (const [code, a2] of countriesThisTrip) {
+      if (!firstVisits.has(code)) {
+        firstVisits.set(code, { a2, year, month: trip.month ?? 1 });
+      }
+    }
+
+    if (trip.kind === "outing") continue;
+
+    tripsPerYear.set(year, (tripsPerYear.get(year) ?? 0) + 1);
+
     for (const [code, a2] of countriesThisTrip) {
       const entry = countryVisits.get(code);
       if (entry) entry.trips++;
       else countryVisits.set(code, { a2, trips: 1 });
-
-      if (!firstVisits.has(code)) {
-        firstVisits.set(code, { a2, year, month: trip.month ?? 1 });
-      }
     }
 
     for (const [city, a2] of citiesThisTrip) {
@@ -646,7 +674,10 @@ export function formatMonthYear(
 
 export const trips = tripsData as Trip[];
 export const datedTrips = getDatedTrips(trips);
-export const tripsCount = datedTrips.length;
+// Journeys, not entries: the counter and the by-year bars in the stats view are
+// answering the same question, so they count the same thing.
+export const journeys = getJourneys(trips);
+export const tripsCount = journeys.length;
 export const countries = getCountries(datedTrips);
 export const cities = new Set([...getCities(datedTrips), ...homeCities]);
 export const visitedLandmarks = getLandmarks(datedTrips);

--- a/src/lib/travel/index.ts
+++ b/src/lib/travel/index.ts
@@ -236,46 +236,135 @@ export function getCountryName(a3: string, lang: "en" | "ru"): string {
   return entry ? entry[lang] : a3.toUpperCase();
 }
 
+/**
+ * The flag code for a country, as opposed to for a place inside it.
+ *
+ * A destination carries the alpha-2 of what was actually visited, and for the
+ * United Kingdom that is a nation of it: `gb-eng`, `gb-sct`. The timeline wants
+ * exactly that — it draws both flags for a trip through England — but anything
+ * listing the country itself does not, and every such view was showing the
+ * October 2024 journey's first destination and so flying the flag of England
+ * over the word "United Kingdom".
+ */
+function countryFlag(a2: string): string {
+  return a2.split("-")[0];
+}
+
+export interface CityVisits {
+  name: string;
+  /** How many trips touched this city. Counted once per trip and never for an
+      outing, so it is the same number the stats view calls a visit — the two
+      would be read side by side otherwise, and "Saint Petersburg (10)" has to
+      mean what "Most visited city: Saint Petersburg, 10 visits" means. */
+  visits: number;
+}
+
 export interface CountryWithCities {
   code: string;
   a2: string;
   name: { en: string; ru: string };
-  cities: string[];
-  tripCount: number;
+  cities: CityVisits[];
+  /** The year this country was first stood in — outings included, on the same
+      grounds getTravelFacts counts them for a first visit: an afternoon across
+      the border is still the day it happened. Null only for a country reached
+      solely by trips with no date. */
+  firstYear: number | null;
+  /** Where this country falls in the run of first sightings: 0 is the first
+      country of all, 1 the next, and so on.
+
+      A year on its own cannot order them. Four countries share 2019, and a
+      chronology that then fell back on how many cities each has would be
+      sorting by something that is not time. Two countries first reached on the
+      same journey can't even be told apart by a month — there the route's own
+      order is the order they were stood in, which is what walking the trips
+      captures and no pair of numbers can. Null alongside a null firstYear. */
+  firstSeen: number | null;
 }
 
 // Get visited countries with their cities
 export function getCountriesWithCities(data: Trip[]): CountryWithCities[] {
   const countryMap = new Map<
     string,
-    { a2: string; cities: Set<string>; tripCount: number }
+    {
+      a2: string;
+      cities: Map<string, number>;
+      firstYear: number | null;
+      firstSeen: number | null;
+    }
   >();
 
-  for (const trip of data) {
+  // Walked in the order the trips happened, which is what makes "first" mean
+  // first: trips.json is in no particular order, and taking the earliest year
+  // per country would still leave every country in a shared year unordered.
+  // Trips with no date have no place in a chronology and go last — they still
+  // bring their cities, they just can't be the first sighting of anything.
+  const dated = data.filter((trip) => trip.year !== null);
+  const undated = data.filter((trip) => trip.year === null);
+  const chronological = [
+    ...dated.sort(
+      (a, b) => a.year! - b.year! || (a.month ?? 0) - (b.month ?? 0),
+    ),
+    ...undated,
+  ];
+
+  let sightings = 0;
+
+  for (const trip of chronological) {
+    // Once per trip, not once per destination: the Oct 2024 journey reaches
+    // England and Scotland as two destinations under one alpha-3, and a route
+    // can pass back through a city it has already been to. Counting rows would
+    // report both twice.
+    const countedCities = new Set<string>();
+
     for (const dest of trip.destinations) {
       const [a2, a3] = dest.country;
       const code = a3.toUpperCase();
 
       if (!countryMap.has(code)) {
-        countryMap.set(code, { a2, cities: new Set(), tripCount: 0 });
+        countryMap.set(code, {
+          a2: countryFlag(a2),
+          cities: new Map(),
+          firstYear: null,
+          firstSeen: null,
+        });
       }
 
       const entry = countryMap.get(code)!;
-      entry.tripCount++;
+
+      // No Math.min needed, and no comparison of dates at all: the walk is in
+      // order, so the first trip to reach a country is the first visit, and the
+      // destinations within it are in the order the route took them.
+      if (entry.firstSeen === null && trip.year !== null) {
+        entry.firstSeen = sightings++;
+        entry.firstYear = trip.year;
+      }
+
       for (const city of dest.cities) {
-        entry.cities.add(city);
+        if (!entry.cities.has(city)) entry.cities.set(city, 0);
+        // An outing is not a visit, the same way it is not a journey. The city
+        // is still listed — I was there — it just doesn't score.
+        if (trip.kind !== "outing" && !countedCities.has(city)) {
+          countedCities.add(city);
+          entry.cities.set(city, entry.cities.get(city)! + 1);
+        }
       }
     }
   }
 
-  // Convert to array and sort by city count (descending)
+  // Convert to array and sort by city count (descending). The cities inside a
+  // country stay alphabetical by their English name: a country's line is read
+  // as a list, not as a ranking, and re-ordering it by visits would put the one
+  // city with a number beside it first and imply the rest were a tail.
   return Array.from(countryMap.entries())
     .map(([code, data]) => ({
       code,
       a2: data.a2,
       name: COUNTRY_NAMES[code] || { en: code, ru: code },
-      cities: Array.from(data.cities).sort(),
-      tripCount: data.tripCount,
+      cities: Array.from(data.cities)
+        .map(([name, visits]) => ({ name, visits }))
+        .sort((a, b) => a.name.localeCompare(b.name)),
+      firstYear: data.firstYear,
+      firstSeen: data.firstSeen,
     }))
     .sort((a, b) => b.cities.length - a.cities.length);
 }
@@ -546,7 +635,11 @@ export function getTravelFacts(data: Trip[]): TravelFacts {
     for (const dest of trip.destinations) {
       const [a2, a3] = dest.country;
       const code = a3.toUpperCase();
-      if (!countriesThisTrip.has(code)) countriesThisTrip.set(code, a2);
+      // The country's own flag for the country, the destination's for the city:
+      // a city inside England is still in England, and "Most visited country:
+      // United Kingdom" is not.
+      if (!countriesThisTrip.has(code))
+        countriesThisTrip.set(code, countryFlag(a2));
       for (const city of dest.cities) {
         if (!citiesThisTrip.has(city)) citiesThisTrip.set(city, a2);
       }
@@ -625,6 +718,32 @@ export function getTravelFacts(data: Trip[]): TravelFacts {
       .map(([year, trips]) => ({ year, trips }))
       .sort((a, b) => a.year - b.year),
   };
+}
+
+/**
+ * Every year from the first to the last, the empty ones included.
+ *
+ * `tripsByYear` only carries years that have trips in them, which is right for
+ * a list and wrong for an axis: 2014 and 2015 have no travel in them, so they
+ * were simply absent, and anything drawn from that series put 2013 next to 2016
+ * as though they were consecutive. A year with nothing in it is among the more
+ * interesting things a travel chart can say, and it can only say it if the year
+ * is there to be empty.
+ */
+export function fillYearGaps(
+  entries: { year: number; trips: number }[],
+): { year: number; trips: number }[] {
+  if (entries.length === 0) return [];
+
+  const counts = new Map(entries.map((entry) => [entry.year, entry.trips]));
+  const years = [...counts.keys()];
+  const filled: { year: number; trips: number }[] = [];
+
+  for (let year = Math.min(...years); year <= Math.max(...years); year++) {
+    filled.push({ year, trips: counts.get(year) ?? 0 });
+  }
+
+  return filled;
 }
 
 // -----------------------------------------------------------------------------

--- a/src/lib/travel/index.ts
+++ b/src/lib/travel/index.ts
@@ -2,6 +2,7 @@ import tripsData from "./trips.json";
 import citiesData from "./cities.json";
 import landmarksData from "./landmarks.json";
 import countryListRaw from "../../pages/travel/countries.md?raw";
+import { getCityName } from "./cities-i18n";
 
 // Types for the new trip format
 export interface Destination {
@@ -269,6 +270,380 @@ export function getCountriesWithCities(data: Trip[]): CountryWithCities[] {
     .sort((a, b) => b.cities.length - a.cities.length);
 }
 
+// -----------------------------------------------------------------------------
+// Continents
+// -----------------------------------------------------------------------------
+
+export type ContinentId =
+  | "europe"
+  | "asia"
+  | "africa"
+  | "north-america"
+  | "south-america"
+  | "oceania"
+  | "antarctica";
+
+export interface ContinentReference {
+  id: ContinentId;
+  name: { en: string; ru: string };
+  /** Sovereign states + UN observer states on this continent. */
+  total: number;
+}
+
+// The seven continents of the National Geographic model — the same model the
+// "Continents 2 / 7" stat card links out to, so the two never disagree about
+// how many there are. The totals are the conventional 195-country tally (193 UN
+// member states + the Vatican and Palestine as observers) split across them;
+// they sum to 195 exactly, which is the check that keeps this table honest.
+//
+// Deliberately NOT derived from countries.ts: 21 of its 193 entries carry no
+// continent at all and every Oceanian state bar Australia is among them, so a
+// derived Oceania total would read 1. Several of its entries also carry "XX"
+// placeholder ISO codes (Zambia, Zimbabwe and others), which is why the lookup
+// below goes by alpha-3 through a table of our own rather than through
+// countries.ts — getByCode("CHE") and getByCode("GBR") both come back
+// undefined there, which would quietly file Switzerland and the UK nowhere.
+const CONTINENTS: ContinentReference[] = [
+  { id: "europe", name: { en: "Europe", ru: "Европа" }, total: 44 },
+  { id: "asia", name: { en: "Asia", ru: "Азия" }, total: 48 },
+  { id: "africa", name: { en: "Africa", ru: "Африка" }, total: 54 },
+  {
+    id: "north-america",
+    name: { en: "North America", ru: "Северная Америка" },
+    total: 23,
+  },
+  {
+    id: "south-america",
+    name: { en: "South America", ru: "Южная Америка" },
+    total: 12,
+  },
+  {
+    id: "oceania",
+    name: { en: "Australia & Oceania", ru: "Австралия и Океания" },
+    total: 14,
+  },
+  {
+    id: "antarctica",
+    name: { en: "Antarctica", ru: "Антарктида" },
+    total: 0,
+  },
+];
+
+// Continent per alpha-3 code, covering every country COUNTRY_NAMES can name.
+// Russia sits in Europe and Türkiye and Kazakhstan in Asia, matching the split
+// the 195-country totals above are counted under; putting a transcontinental
+// country on the other side would make one continent's fraction overshoot.
+const COUNTRY_CONTINENTS: Record<string, ContinentId> = {
+  ALB: "europe",
+  ARE: "asia",
+  AUT: "europe",
+  BEL: "europe",
+  BIH: "europe",
+  BLR: "europe",
+  CHE: "europe",
+  CHN: "asia",
+  CZE: "europe",
+  DEU: "europe",
+  DNK: "europe",
+  EGY: "africa",
+  ESP: "europe",
+  EST: "europe",
+  FIN: "europe",
+  FRA: "europe",
+  GBR: "europe",
+  HKG: "asia",
+  HUN: "europe",
+  IND: "asia",
+  ISL: "europe",
+  ITA: "europe",
+  JPN: "asia",
+  KAZ: "asia",
+  KGZ: "asia",
+  KOR: "asia",
+  LKA: "asia",
+  LTU: "europe",
+  LVA: "europe",
+  MAC: "asia",
+  MAR: "africa",
+  MDA: "europe",
+  MNE: "europe",
+  MYS: "asia",
+  NLD: "europe",
+  NOR: "europe",
+  POL: "europe",
+  PRT: "europe",
+  RUS: "europe",
+  SJM: "europe",
+  SRB: "europe",
+  SVK: "europe",
+  SWE: "europe",
+  THA: "asia",
+  TJK: "asia",
+  TUR: "asia",
+  TWN: "asia",
+  UZB: "asia",
+  VAT: "europe",
+  VNM: "asia",
+};
+
+// Places that are on a continent but are not among the 195 the totals count:
+// two Chinese special administrative regions, a Norwegian territory, and a
+// state no UN seat recognises. They still appear in their continent's list —
+// they were visited — but counting them in the numerator would compare against
+// a denominator that never had room for them, and enough of them would push a
+// continent past 100%.
+const OUTSIDE_CONTINENT_TOTALS = new Set(["HKG", "MAC", "SJM", "TWN"]);
+
+export interface ContinentGroup {
+  id: ContinentId;
+  name: { en: string; ru: string };
+  /** Countries counted by the continent's total. Never exceeds `total`. */
+  visited: number;
+  total: number;
+  countries: CountryWithCities[];
+}
+
+// Visited countries grouped under their continent. All seven are returned,
+// including the ones with nothing under them — the view is a map of where
+// there is still to go as much as where I've been, and an absent Africa row
+// would read as a rendering bug rather than as zero.
+export function getCountriesByContinent(data: Trip[]): ContinentGroup[] {
+  const byContinent = new Map<ContinentId, CountryWithCities[]>();
+
+  // Most cities first, then alphabetically. Half of Europe is a one-city
+  // country, and without the second key their order falls out of where their
+  // trips happen to sit in trips.json — so editing one journey would reshuffle
+  // the tail of the list for no reason a reader could see.
+  const ranked = [...getCountriesWithCities(data)].sort(
+    (a, b) =>
+      b.cities.length - a.cities.length || a.name.en.localeCompare(b.name.en),
+  );
+
+  for (const country of ranked) {
+    const id = COUNTRY_CONTINENTS[country.code];
+    if (!id) continue;
+    if (!byContinent.has(id)) byContinent.set(id, []);
+    byContinent.get(id)!.push(country);
+  }
+
+  const referenceOrder = new Map(CONTINENTS.map((c, i) => [c.id, i]));
+
+  return CONTINENTS.map((continent): ContinentGroup => {
+    const countries = byContinent.get(continent.id) ?? [];
+    return {
+      id: continent.id,
+      name: continent.name,
+      visited: countries.filter(
+        (country) => !OUTSIDE_CONTINENT_TOTALS.has(country.code),
+      ).length,
+      total: continent.total,
+      countries,
+    };
+  }).sort(
+    // Continents I've actually been to come first; the rest keep the reference
+    // order above so the empty tail is stable rather than alphabetical noise.
+    (a, b) =>
+      b.countries.length - a.countries.length ||
+      referenceOrder.get(a.id)! - referenceOrder.get(b.id)!,
+  );
+}
+
+// Visited countries that COUNTRY_CONTINENTS has no entry for. They would be
+// dropped from the continents view without a trace, and the per-continent
+// fractions would still add up, so nothing on the page would look wrong. The
+// test pins this to empty; adding a country to trips.json without adding it
+// here is what it is there to catch.
+export function getUnmappedCountries(data: Trip[]): string[] {
+  return getCountriesWithCities(data)
+    .map((country) => country.code)
+    .filter((code) => !COUNTRY_CONTINENTS[code])
+    .sort();
+}
+
+// -----------------------------------------------------------------------------
+// Stats & facts
+// -----------------------------------------------------------------------------
+
+export interface VisitedPlace {
+  name: { en: string; ru: string };
+  a2: string;
+  visits: number;
+}
+
+export interface TravelFacts {
+  mostVisitedCity: VisitedPlace | null;
+  mostVisitedCountry: VisitedPlace | null;
+  mostActiveYear: { year: number; trips: number } | null;
+  latestNewCountry: {
+    name: { en: string; ru: string };
+    a2: string;
+    year: number;
+    month: number;
+  } | null;
+  /** Every year with at least one trip, oldest first. */
+  tripsByYear: { year: number; trips: number }[];
+}
+
+// Picks the entry with the highest count, falling back to the lowest key — the
+// first name alphabetically, or the earliest year. Without the tie-break the
+// answer would fall out of Map insertion order, i.e. out of the order the trips
+// happen to sit in trips.json, so editing an unrelated trip could silently
+// change which city the page calls the most visited one.
+function pickTop<K extends string | number, V>(
+  counts: Map<K, V>,
+  countOf: (value: V) => number,
+) {
+  return [...counts.entries()].sort(
+    ([keyA, a], [keyB, b]) =>
+      countOf(b) - countOf(a) || (keyA < keyB ? -1 : keyA > keyB ? 1 : 0),
+  )[0];
+}
+
+export function getTravelFacts(data: Trip[]): TravelFacts {
+  const cityVisits = new Map<string, { a2: string; trips: number }>();
+  const countryVisits = new Map<string, { a2: string; trips: number }>();
+  const tripsPerYear = new Map<number, number>();
+  const firstVisits = new Map<
+    string,
+    { a2: string; year: number; month: number }
+  >();
+
+  const chronological = [...getDatedTrips(data)].sort(
+    (a, b) => a.year! - b.year! || (a.month ?? 0) - (b.month ?? 0),
+  );
+
+  for (const trip of chronological) {
+    const year = trip.year!;
+    tripsPerYear.set(year, (tripsPerYear.get(year) ?? 0) + 1);
+
+    // Counted once per trip, not once per destination: the Oct 2024 trip
+    // reaches England and Scotland as two destinations under the same alpha-3,
+    // and counting rows would report two visits to the United Kingdom for one
+    // journey. The same guard covers a route that returns to a city it already
+    // passed through.
+    const countriesThisTrip = new Map<string, string>();
+    const citiesThisTrip = new Map<string, string>();
+
+    for (const dest of trip.destinations) {
+      const [a2, a3] = dest.country;
+      const code = a3.toUpperCase();
+      if (!countriesThisTrip.has(code)) countriesThisTrip.set(code, a2);
+      for (const city of dest.cities) {
+        if (!citiesThisTrip.has(city)) citiesThisTrip.set(city, a2);
+      }
+    }
+
+    for (const [code, a2] of countriesThisTrip) {
+      const entry = countryVisits.get(code);
+      if (entry) entry.trips++;
+      else countryVisits.set(code, { a2, trips: 1 });
+
+      if (!firstVisits.has(code)) {
+        firstVisits.set(code, { a2, year, month: trip.month ?? 1 });
+      }
+    }
+
+    for (const [city, a2] of citiesThisTrip) {
+      const entry = cityVisits.get(city);
+      if (entry) entry.trips++;
+      else cityVisits.set(city, { a2, trips: 1 });
+    }
+  }
+
+  const topCity = pickTop(cityVisits, (entry) => entry.trips);
+  const topCountry = pickTop(countryVisits, (entry) => entry.trips);
+  const topYear = pickTop(tripsPerYear, (count) => count);
+
+  // The most recent country seen for the first time. Nothing filters out trips
+  // dated in the future, because there are none to filter: a journey that has
+  // not happened yet is recorded with a null year and lives in the TBA list,
+  // which getDatedTrips already drops.
+  const newest = [...firstVisits.entries()].sort(
+    ([codeA, a], [codeB, b]) =>
+      b.year - a.year || b.month - a.month || codeA.localeCompare(codeB),
+  )[0];
+
+  return {
+    mostVisitedCity: topCity
+      ? {
+          name: { en: topCity[0], ru: getCityName(topCity[0], "ru") },
+          a2: topCity[1].a2,
+          visits: topCity[1].trips,
+        }
+      : null,
+    mostVisitedCountry: topCountry
+      ? {
+          name: {
+            en: getCountryName(topCountry[0], "en"),
+            ru: getCountryName(topCountry[0], "ru"),
+          },
+          a2: topCountry[1].a2,
+          visits: topCountry[1].trips,
+        }
+      : null,
+    mostActiveYear: topYear ? { year: topYear[0], trips: topYear[1] } : null,
+    latestNewCountry: newest
+      ? {
+          name: {
+            en: getCountryName(newest[0], "en"),
+            ru: getCountryName(newest[0], "ru"),
+          },
+          a2: newest[1].a2,
+          year: newest[1].year,
+          month: newest[1].month,
+        }
+      : null,
+    tripsByYear: [...tripsPerYear.entries()]
+      .map(([year, trips]) => ({ year, trips }))
+      .sort((a, b) => a.year - b.year),
+  };
+}
+
+// -----------------------------------------------------------------------------
+// Counted nouns
+// -----------------------------------------------------------------------------
+
+// Russian agrees a noun with the number in front of it three ways, so "17
+// поездок", "2 поездки" and "1 поездка" are all needed for the same label — an
+// English-shaped `${n} ${word}` would print "17 поездка" on the Russian page.
+function pluralRu(n: number, [one, few, many]: [string, string, string]) {
+  const mod10 = n % 10;
+  const mod100 = n % 100;
+  if (mod10 === 1 && mod100 !== 11) return one;
+  if (mod10 >= 2 && mod10 <= 4 && (mod100 < 12 || mod100 > 14)) return few;
+  return many;
+}
+
+export function formatTripCount(n: number, lang: "en" | "ru"): string {
+  if (lang === "ru") {
+    return `${n} ${pluralRu(n, ["поездка", "поездки", "поездок"])}`;
+  }
+  return `${n} ${n === 1 ? "trip" : "trips"}`;
+}
+
+export function formatVisitCount(n: number, lang: "en" | "ru"): string {
+  if (lang === "ru") {
+    return `${n} ${pluralRu(n, ["визит", "визита", "визитов"])}`;
+  }
+  return `${n} ${n === 1 ? "visit" : "visits"}`;
+}
+
+export function formatCityCount(n: number, lang: "en" | "ru"): string {
+  if (lang === "ru") {
+    return `${n} ${pluralRu(n, ["город", "города", "городов"])}`;
+  }
+  return `${n} ${n === 1 ? "city" : "cities"}`;
+}
+
+export function formatMonthYear(
+  year: number,
+  month: number,
+  lang: "en" | "ru",
+): string {
+  const monthNames = lang === "ru" ? MONTH_NAMES_RU : MONTH_NAMES_EN;
+  return `${monthNames[month - 1]} ${year}`;
+}
+
 export const trips = tripsData as Trip[];
 export const datedTrips = getDatedTrips(trips);
 export const tripsCount = datedTrips.length;
@@ -280,5 +655,12 @@ export const cityCoordinates = citiesData as unknown as Record<
   [number, number]
 >;
 export const countryListSize = getCountryListSize(countryListRaw);
-export const continentsVisited = 2;
-export const continentsTotal = 7;
+// Both were literals — a 2 that had to be remembered and bumped by hand the
+// first time a trip reached a third continent, and a 7 sitting one file away
+// from the table that actually lists them. The continents view has to work out
+// which continents have a country under them anyway, so the stat card reads
+// its number off the same answer and the two can no longer disagree.
+export const continentsVisited = getCountriesByContinent(datedTrips).filter(
+  (continent) => continent.countries.length > 0,
+).length;
+export const continentsTotal = CONTINENTS.length;

--- a/src/pages/kit/index.astro
+++ b/src/pages/kit/index.astro
@@ -720,6 +720,28 @@ import { Icon } from "astro-icon/components";
           <ProgressBar value={42} max={195} label="42 of 195 countries" />
           <ProgressBar value={5} max={7} label="5 of 7 continents" />
         </div>
+
+        <h3>Extra Attributes</h3>
+        <p>
+          Anything beyond the props above lands on the inner element — the one
+          carrying <code>role="progressbar"</code> — rather than on the row, so
+          it reaches the thing a screen reader actually announces. That is how a
+          bilingual page translates the label: <code>label</code> renders the
+          bar's <code>aria-label</code>, and <code>data-aria-label-en</code> /
+          <code>data-aria-label-ru</code> let <code>LangInit</code> swap it on
+          load. Without them the label stays in whichever language it was
+          written in, whatever the rest of the page is reading as.
+        </p>
+        <div class="progress-demo">
+          <ProgressBar
+            value={23}
+            max={44}
+            label="Europe: 23 of 44 countries visited"
+            data-aria-label-en="Europe: 23 of 44 countries visited"
+            data-aria-label-ru="Европа: посещено 23 из 44 стран"
+            accent
+          />
+        </div>
       </section>
 
       <!-- ================================================================

--- a/src/pages/kit/index.astro
+++ b/src/pages/kit/index.astro
@@ -214,7 +214,11 @@ import { Icon } from "astro-icon/components";
             Not glass at all: the page's own colour closing over what scrolls
             beneath it. Used by the pinned header strip and
             <code>/travel</code>'s sticky year. A capsule is a neutral tint you
-            look through; this one belongs to the page.
+            look through; this one belongs to the page. It stays translucent on
+            purpose: a page with an ambient background has that behind the veil
+            too, and an opaque strip cuts a flat rectangle out of it. The frost
+            is what keeps what passes underneath from being readable — which is
+            why the blur is heavier here than the number it started at.
           </dd>
         </dl>
 
@@ -447,6 +451,89 @@ import { Icon } from "astro-icon/components";
           />
         </div>
 
+        <h3>Quiet Tone</h3>
+        <p>
+          <code>tone="quiet"</code> on the separated variant marks the current
+          item with ink and the wash it already answers a cursor with, instead
+          of the accent capsule. For a row that shares its space with something
+          already louder — /travel's country sort sits in a heading forty pixels
+          under the pinned view rail, and at full accent it was the brightest
+          thing on the page. Ink rather than a second glass capsule on purpose:
+          glass there would read as a smaller copy of the rail and make the two
+          compete for the same job.
+        </p>
+        <div class="component-row" id="toggle-quiet-demo">
+          <ToggleGroup
+            variant="separated"
+            tone="quiet"
+            size="sm"
+            items={[
+              { id: "cities", label: "By cities" },
+              { id: "name", label: "A–Z" },
+              { id: "first", label: "By first visit" },
+            ]}
+            value="cities"
+          />
+        </div>
+
+        <h3>Tabs Variant</h3>
+        <p>
+          The only variant that is not a set of toggles. It renders a real
+          <code>role="tablist"</code> — <code>aria-selected</code> rather than
+          <code>aria-pressed</code>, <code>aria-controls</code> pointing at the
+          panel, and a roving <code>tabindex</code> so the rail is one stop in
+          the tab order with the arrow keys moving inside it. Pass
+          <code>controls</code> on each item with the id of its panel; the tab
+          takes the id <code>{`${"{controls}"}-tab`}</code>, which is what the
+          panel points back at with <code>aria-labelledby</code>.
+        </p>
+        <p>
+          The current tab is a lens — the chrome's glass capsule, sliding behind
+          the label on the dock's easing. Same idiom as the magnetic dock and
+          the language switcher, with one part swapped: their indicator is an
+          accent gradient, which suits a small nav floating in the chrome, while
+          a tab rail is pinned over content that is already spending the accent.
+          One lens for the whole rail, so it travels and the row reads as one
+          instrument.
+        </p>
+        <p>
+          Needs a driver:
+          <code>import {`{ initToggleTabs }`} from "@client/toggle-tabs"</code>,
+          called with the tablist element and a callback that shows the matching
+          panel. It handles the keyboard, the marker and the edge fades; nothing
+          happens without it beyond the tab the server rendered.
+        </p>
+        <div class="component-row component-row--stack" id="toggle-tabs-demo">
+          <ToggleGroup
+            variant="tabs"
+            size="sm"
+            scrollable
+            items={[
+              { id: "timeline", label: "Timeline", count: 47, controls: "kit-tab-timeline" },
+              { id: "countries", label: "Countries", count: 32, controls: "kit-tab-countries" },
+              { id: "continents", label: "Continents", count: "2/7", controls: "kit-tab-continents" },
+              { id: "stats", label: "Stats", controls: "kit-tab-stats" },
+            ]}
+            value="timeline"
+          />
+          <div class="kit-tab-panels">
+            <div id="kit-tab-timeline" role="tabpanel" aria-labelledby="kit-tab-timeline-tab" tabindex="0">47 trips, newest first.</div>
+            <div id="kit-tab-countries" role="tabpanel" aria-labelledby="kit-tab-countries-tab" tabindex="0" hidden>32 countries and the cities in them.</div>
+            <div id="kit-tab-continents" role="tabpanel" aria-labelledby="kit-tab-continents-tab" tabindex="0" hidden>2 of 7 continents.</div>
+            <div id="kit-tab-stats" role="tabpanel" aria-labelledby="kit-tab-stats-tab" tabindex="0" hidden>No count on this tab — it is not a list of anything.</div>
+          </div>
+        </div>
+
+        <h3>Counts</h3>
+        <p>
+          Pass <code>count</code> to an item — a number, or a fraction like
+          <code>"2/7"</code> where "of how many" is the point. It says what the
+          label cannot: how much is behind the tab, so the row answers whether
+          a view is worth opening before it is opened. Language-neutral by
+          design; a count that needed translating would be a second label. An
+          item may go without one, and the gap says something too.
+        </p>
+
         <h3>With Icons</h3>
         <p>Pass <code>icon</code> to items. Icon size adjusts to toggle size (14px for sm, 16px for md).</p>
         <div class="component-row" id="toggle-icons-demo">
@@ -579,6 +666,15 @@ import { Icon } from "astro-icon/components";
           The <strong>box</strong> variant is for a single standalone boolean,
           where an unchecked capsule and an absent one would look the same.
         </p>
+        <p>
+          The box is a socket, and the tick is the fill lying in it. ProgressBar
+          states the rule this follows: <code>--glass-rim</code> is a lens edge
+          lit from the top left, so a channel sunk into the same surface is its
+          inverse. A checkbox has two states and the chrome has exactly those
+          two opposite treatments — and both halves here are the progress bar's,
+          value for value, because at this size a checkbox is a meter with two
+          stops.
+        </p>
 
         <h3>Pill</h3>
         <div class="kit-checkbox-group">
@@ -603,6 +699,32 @@ import { Icon } from "astro-icon/components";
         <div class="kit-checkbox-group">
           <Checkbox variant="box" size="sm" checked>SM</Checkbox>
           <Checkbox variant="box" size="md" checked>MD</Checkbox>
+        </div>
+
+        <h3>The mark on its own</h3>
+        <p>
+          <code>.kit-check</code> is the box without an input around it, for a
+          ticked state that is not a control — /travel's checklist marks 250
+          countries as seen or not, and none of them is something to click. Add
+          <code>.kit-check--on</code> for the ticked state and set
+          <code>--kit-check-size</code> for anything other than the kit's own
+          two. It exists so that idea has one appearance on the site rather than
+          growing a second one in a page's own stylesheet, which is where it had
+          got to.
+        </p>
+        <div class="component-row kit-check-demo">
+          <span class="kit-check kit-check--on" aria-hidden="true">
+            <svg viewBox="0 0 12 12" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="2.5 6 5 8.5 9.5 3.5" />
+            </svg>
+          </span>
+          <span class="kit-check" aria-hidden="true"></span>
+          <span class="kit-check kit-check--on" style="--kit-check-size: 22px" aria-hidden="true">
+            <svg viewBox="0 0 12 12" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="2.5 6 5 8.5 9.5 3.5" />
+            </svg>
+          </span>
+          <span class="kit-check" style="--kit-check-size: 22px" aria-hidden="true"></span>
         </div>
       </section>
 
@@ -1193,6 +1315,18 @@ import { Icon } from "astro-icon/components";
     margin-bottom: 1.5rem;
   }
 
+  /* A tab rail is only half a control without the thing it swaps, so its demo
+     stacks the rail over its panels rather than laying them out side by side. */
+  .component-row--stack {
+    display: block;
+  }
+
+  .kit-tab-panels {
+    padding: 0.9rem 0.1rem;
+    font-size: 0.9rem;
+    color: light-dark(#555, #b4b4b8);
+  }
+
   /* Glass badges are meant to be read against a photo, so the demo gives them
      something to sit on — a flat swatch would flatter them unfairly. */
   .badge-on-photo {
@@ -1286,6 +1420,7 @@ import { Icon } from "astro-icon/components";
 <script>
   // Tooltips — the demo below is inert without this.
   import { initTooltips } from '@client/tooltip';
+  import { initToggleTabs } from '@client/toggle-tabs';
   initTooltips();
 
   // Modal demo
@@ -1331,7 +1466,20 @@ import { Icon } from "astro-icon/components";
 
   initToggleGroup('toggle-pill-demo');
   initToggleGroup('toggle-separated-demo');
+  initToggleGroup('toggle-quiet-demo');
   initToggleGroup('toggle-icons-demo');
+
+  // The tabs variant has a real driver rather than a demo one — it is the same
+  // module /travel calls, so what is on show here is what a caller gets.
+  const tabsDemo = document.querySelector<HTMLElement>('#toggle-tabs-demo [role="tablist"]');
+  if (tabsDemo) {
+    const panels = document.querySelectorAll<HTMLElement>('.kit-tab-panels > [role="tabpanel"]');
+    initToggleTabs(tabsDemo, (id) => {
+      panels.forEach((panel) => {
+        panel.toggleAttribute('hidden', panel.id !== `kit-tab-${id}`);
+      });
+    });
+  }
 
   // Toast demo
   const toastContainer = document.getElementById('toast-container');

--- a/src/pages/kit/index.astro
+++ b/src/pages/kit/index.astro
@@ -715,22 +715,33 @@ import { Icon } from "astro-icon/components";
         </div>
 
         <h3>Custom Values</h3>
-        <p>Pass <code>value</code> and <code>max</code> — percent is calculated automatically.</p>
+        <p>
+          Pass <code>value</code> and <code>max</code> — percent is calculated
+          automatically. A <code>max</code> of <code>0</code> reads as 0% rather
+          than as the <code>NaN</code> the division would otherwise put in
+          <code>aria-valuenow</code> and in the fill's width; a bar with nothing
+          to measure against is usually better left unrendered, but it will not
+          break the page.
+        </p>
         <div class="progress-demo">
           <ProgressBar value={42} max={195} label="42 of 195 countries" />
           <ProgressBar value={5} max={7} label="5 of 7 continents" />
+          <ProgressBar value={0} max={0} label="Nothing to measure" />
         </div>
 
         <h3>Extra Attributes</h3>
         <p>
-          Anything beyond the props above lands on the inner element — the one
-          carrying <code>role="progressbar"</code> — rather than on the row, so
-          it reaches the thing a screen reader actually announces. That is how a
+          A <code>data-*</code> attribute, or an <code>aria-label</code> of your
+          own, lands on the inner element — the one carrying
+          <code>role="progressbar"</code> — rather than on the row, so it
+          reaches the thing a screen reader actually announces. That is how a
           bilingual page translates the label: <code>label</code> renders the
           bar's <code>aria-label</code>, and <code>data-aria-label-en</code> /
           <code>data-aria-label-ru</code> let <code>LangInit</code> swap it on
           load. Without them the label stays in whichever language it was
-          written in, whatever the rest of the page is reading as.
+          written in, whatever the rest of the page is reading as. Nothing else
+          gets through, so a misspelled prop is a type error here rather than a
+          stray attribute in the HTML and a default silently left in place.
         </p>
         <div class="progress-demo">
           <ProgressBar

--- a/src/pages/travel/index.astro
+++ b/src/pages/travel/index.astro
@@ -5,13 +5,11 @@ import LangInit from "@components/LangInit.astro";
 import TravelMap from "@components/travel/TravelMap.astro";
 import TravelStats from "@components/travel/TravelStats.astro";
 import TravelTripList from "@components/travel/TravelTripList.astro";
-// import TravelViewSwitcher from "@components/travel/TravelViewSwitcher.astro";
-// import TravelCountries from "@components/travel/TravelCountries.astro";
-// import TravelChecklist from "@components/travel/TravelChecklist.astro";
-// import TravelContinents from "@components/travel/TravelContinents.astro";
-// import TravelStatsDashboard from "@components/travel/TravelStatsDashboard.astro";
-// import TravelFirstVisits from "@components/travel/TravelFirstVisits.astro";
-// import TravelRepeatDestinations from "@components/travel/TravelRepeatDestinations.astro";
+import TravelViewSwitcher from "@components/travel/TravelViewSwitcher.astro";
+import TravelCountries from "@components/travel/TravelCountries.astro";
+import TravelContinents from "@components/travel/TravelContinents.astro";
+import TravelStatsDashboard from "@components/travel/TravelStatsDashboard.astro";
+import TravelChecklist from "@components/travel/TravelChecklist.astro";
 
 export const prerender = true;
 ---
@@ -39,17 +37,17 @@ export const prerender = true;
       condenseOnScroll
     />
     <TravelMap />
+    {/* The four counters stay outside the switcher: they answer "how much" for
+        the whole page, and the map and every view below are read against them.
+        The stats view answers a different question — which city, which country,
+        which year — and is a panel you go and look at. */}
     <TravelStats />
-    <TravelTripList />
-    <!-- <TravelViewSwitcher currentView="timeline" />
+    <TravelViewSwitcher currentView="timeline" />
     <div id="view-timeline" class="travel-view" data-view="timeline">
       <TravelTripList />
     </div>
     <div id="view-countries" class="travel-view" data-view="countries" hidden>
       <TravelCountries />
-    </div>
-    <div id="view-checklist" class="travel-view" data-view="checklist" hidden>
-      <TravelChecklist />
     </div>
     <div id="view-continents" class="travel-view" data-view="continents" hidden>
       <TravelContinents />
@@ -57,12 +55,9 @@ export const prerender = true;
     <div id="view-stats" class="travel-view" data-view="stats" hidden>
       <TravelStatsDashboard />
     </div>
-    <div id="view-first-visits" class="travel-view" data-view="first-visits" hidden>
-      <TravelFirstVisits />
+    <div id="view-checklist" class="travel-view" data-view="checklist" hidden>
+      <TravelChecklist />
     </div>
-    <div id="view-repeats" class="travel-view" data-view="repeats" hidden>
-      <TravelRepeatDestinations />
-    </div> -->
   </main>
 </PageLayout>
 

--- a/src/pages/travel/index.astro
+++ b/src/pages/travel/index.astro
@@ -11,6 +11,15 @@ import TravelContinents from "@components/travel/TravelContinents.astro";
 import TravelStatsDashboard from "@components/travel/TravelStatsDashboard.astro";
 import TravelChecklist from "@components/travel/TravelChecklist.astro";
 
+// The flags, as a URL rather than an import. Imported the ordinary way, this
+// lands in the page's bundled stylesheet — and flag-icons is 501 KB of inlined
+// SVG for two hundred and seventy-one flags, five times the weight of the
+// entire HTML document and render-blocking in front of it. Every one of the six
+// travel components used to import it, which is a lot of ways to say the same
+// thing and no way at all to control when it arrives. Asked for by URL, it
+// stays a file this page decides how to load — see the head below.
+import flagIcons from "flag-icons/css/flag-icons.min.css?url";
+
 export const prerender = true;
 ---
 
@@ -20,7 +29,24 @@ export const prerender = true;
   <Fragment slot="head">
     <link rel="preconnect" href="https://tiles.openfreemap.org" crossorigin />
     <link rel="preconnect" href="https://demotiles.maplibre.org" crossorigin />
+    {/* Fetched at the same priority a stylesheet would be, but not waited on:
+        as a preload it downloads alongside everything else without holding up
+        the first paint, and the script below promotes it the moment the
+        document is parsed. The flags then arrive a frame or two after the text
+        they sit in, which is the trade — a page that renders now with the
+        flags catching up beats a page that renders when half a megabyte of
+        country outlines has landed.
+
+        Promoted by a hoisted script rather than an onload attribute on the link
+        — Astro may well inline it, and the site's CSP allows that either way,
+        but the behaviour belongs in a script rather than in an attribute where
+        nothing can typecheck or lint it. */}
+    <link rel="preload" as="style" href={flagIcons} id="flag-icons" />
+    <noscript><link rel="stylesheet" href={flagIcons} /></noscript>
   </Fragment>
+  <script>
+    document.getElementById("flag-icons")?.setAttribute("rel", "stylesheet");
+  </script>
   <LangInit />
   <div class="blob blob-1"></div>
   <div class="blob blob-2"></div>
@@ -42,21 +68,74 @@ export const prerender = true;
         The stats view answers a different question — which city, which country,
         which year — and is a panel you go and look at. */}
     <TravelStats />
+    {/* The rail and its panels share one box because a sticky element can only
+        travel as far as its containing block, and the rail has to stay pinned
+        for the whole length of whichever view is open — a hundred and
+        twenty-five rows, in the checklist's case. Wrapped together, its
+        containing block is this column and it reaches the end of the view;
+        left as a direct child of the page grid, its containing block is a grid
+        area holding nothing but itself. */}
+    <div class="travel-views">
     <TravelViewSwitcher currentView="timeline" />
-    <div id="view-timeline" class="travel-view" data-view="timeline">
+    {/* Panels of the rail above. tabindex="0" because three of the five hold
+        no focusable element at all — without it a keyboard reader arrowing to
+        the checklist would have two hundred and fifty rows they cannot reach
+        or scroll from the keyboard. The ids are what the tabs point at with
+        aria-controls, and each tab's own id is this one plus "-tab". */}
+    <div
+      id="view-timeline"
+      class="travel-view"
+      data-view="timeline"
+      role="tabpanel"
+      aria-labelledby="view-timeline-tab"
+      tabindex="0"
+    >
       <TravelTripList />
     </div>
-    <div id="view-countries" class="travel-view" data-view="countries" hidden>
+    <div
+      id="view-countries"
+      class="travel-view"
+      data-view="countries"
+      role="tabpanel"
+      aria-labelledby="view-countries-tab"
+      tabindex="0"
+      hidden
+    >
       <TravelCountries />
     </div>
-    <div id="view-continents" class="travel-view" data-view="continents" hidden>
+    <div
+      id="view-continents"
+      class="travel-view"
+      data-view="continents"
+      role="tabpanel"
+      aria-labelledby="view-continents-tab"
+      tabindex="0"
+      hidden
+    >
       <TravelContinents />
     </div>
-    <div id="view-stats" class="travel-view" data-view="stats" hidden>
+    <div
+      id="view-checklist"
+      class="travel-view"
+      data-view="checklist"
+      role="tabpanel"
+      aria-labelledby="view-checklist-tab"
+      tabindex="0"
+      hidden
+    >
+      <TravelChecklist />
+    </div>
+    <div
+      id="view-stats"
+      class="travel-view"
+      data-view="stats"
+      role="tabpanel"
+      aria-labelledby="view-stats-tab"
+      tabindex="0"
+      hidden
+    >
       <TravelStatsDashboard />
     </div>
-    <div id="view-checklist" class="travel-view" data-view="checklist" hidden>
-      <TravelChecklist />
     </div>
   </main>
 </PageLayout>
@@ -94,7 +173,21 @@ export const prerender = true;
     --accent-end: rgb(237, 87, 96);
   }
 
-  /* Ambient background blobs */
+  /* Ambient light, and over everything on purpose.
+
+     These are siblings of <main>, so their z-index competes with main's own,
+     and the obvious reading of "background blob" is to put them under it. That
+     was tried and it is wrong, because it makes the ambience something the
+     chrome can block: the pinned veil then covers the glow in the top strip
+     while the page below still has it, and the strip reads as a flat rectangle
+     cut out of the page, ending in a hard line where the colour resumes.
+
+     At 80px of blur and a tenth of opacity this is a light source, not a
+     surface. Light falls on the furniture too. Laid last, it tints the page,
+     the glass and the veil by the same amount, so there is no seam to find —
+     and that is what lets --veil-bg be opaque enough to stop anything reading
+     through it, which was the whole complaint. Below the tooltip (z-index
+     1000), which has to stay clean because it is text on a bead of glass. */
   .blob {
     position: fixed;
     border-radius: 50%;
@@ -162,6 +255,17 @@ export const prerender = true;
        why only resizing showed it. */
     grid-template-columns: minmax(0, 1fr);
     gap: 1.25rem;
+  }
+
+  /* Carries the page grid's own gap, so the rail sits the same 1.25rem above
+     its view that the map sits above the counters. Flex rather than grid on
+     purpose: a flex item's containing block is the flex container, which is
+     the whole column — see the note on the wrapper above. */
+  .travel-views {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+    min-width: 0;
   }
 
   .travel-view {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -31,6 +31,17 @@
   --glass-shadow:
     0 10px 30px light-dark(rgba(20, 20, 40, 0.12), rgba(0, 0, 0, 0.38)),
     0 2px 6px light-dark(rgba(20, 20, 40, 0.06), rgba(0, 0, 0, 0.28));
+  /* The same lift, cut for something chip-sized. --glass-shadow is drawn for a
+     capsule floating over the page — a 2.7rem header pill with a whole document
+     behind it — and under a 32px lens lying in a rail it stops reading as lift
+     and starts reading as a halo. In the light scheme that is the entire
+     problem: the tint is nearly the page colour and the border is white on
+     white, so the halo becomes the only thing you can see and the capsule
+     turns into a soft white blob. */
+  --glass-shadow-sm:
+    0 3px 10px light-dark(rgba(20, 20, 40, 0.1), rgba(0, 0, 0, 0.34)),
+    0 1px 2px light-dark(rgba(20, 20, 40, 0.07), rgba(0, 0, 0, 0.24));
+
   --glass-rim:
     inset 1.5px 1.5px 1px -1px
       light-dark(rgba(255, 255, 255, 1), rgba(255, 255, 255, 0.32)),
@@ -44,8 +55,29 @@
      headings on /travel. Not --glass-*: a capsule is a neutral tint you look
      through, while this is the page's own colour closing over what passes
      beneath. The two were separately hardcoded, a hex and a blur radius apart. */
-  --veil-bg: light-dark(rgba(248, 248, 255, 0.9), rgba(25, 25, 25, 0.9));
-  --veil-filter: blur(16px);
+  /* The blur went up and the saturation arrived — it was the one material on
+     the site without any, and at 16px a heading's worth of text underneath
+     smeared into word-shaped smudges instead of dissolving.
+
+     The tint went with it, from a tenth of light passed to a thirtieth. A tenth
+     of near-white text on a near-black page is twenty-five levels above the
+     ground, which is enough to read the rows going under a heading, and blur
+     alone will not fix that: it attacks high frequencies, so it turns text into
+     a smudge and leaves a large soft shape — a row's hover wash — plain to see.
+
+     Going opaque is only safe because of where a page's ambience sits. On
+     /travel it is two blurred blobs laid over everything, chrome included, so
+     they tint this strip and the page below it by the same amount and there is
+     no seam. Under the page instead, this tint would cover the glow in the
+     strip while the page kept it, and the veil would read as a flat rectangle
+     cut out of the page — which is exactly what it did when both were tried the
+     other way round.
+
+     What passes through regardless is the mask's own fade: the bottom 2.75rem
+     of this strip runs every alpha down to nothing by design, and a sticky
+     heading is meant to be sitting over that stretch, covering it. */
+  --veil-bg: light-dark(rgba(248, 248, 255, 0.97), rgba(25, 25, 25, 0.97));
+  --veil-filter: blur(24px) saturate(140%);
 
   /* A card's tint. Cards take their border, shadow and rim from the tokens
      above but keep a tint of their own, heavier than the chrome's 0.55: a card

--- a/src/styles/kit/checkbox.css
+++ b/src/styles/kit/checkbox.css
@@ -121,6 +121,19 @@
    A lone boolean has no row to belong to, so the capsule has nothing to say —
    an unchecked capsule and an absent one look the same. The box states its own
    emptiness.
+
+   It states it as a socket. The rule this needs was already written down on
+   this site, in ProgressBar: --glass-rim is a lens edge lit from the top left,
+   so a channel sunk into that same surface is its inverse — shadow at the top
+   left, a catch of light along the bottom right. A checkbox has two states and
+   the chrome has exactly those two opposite treatments, so an empty box is the
+   channel and a ticked one is the fill lying in it. Both halves are the
+   progress bar's own, value for value: at this size a checkbox is a meter with
+   two stops, and it should not need a second set of numbers to say so.
+
+   What this replaced was a flat 2px grey ring over a flat tint, which is the
+   Material checkbox every framework ships — the one thing in the kit that could
+   have come from any of them.
    ============================================================================= */
 
 .kit-checkbox--box {
@@ -128,69 +141,96 @@
   color: light-dark(#333, #ccc);
 }
 
-.kit-checkbox__box {
+/* The socket, and the same socket standing on its own — see the note on
+   .kit-check at the end of this block. */
+.kit-checkbox__box,
+.kit-check {
   position: relative;
   flex-shrink: 0;
-  background: light-dark(rgba(255, 255, 255, 0.8), rgba(30, 30, 35, 0.8));
-  box-shadow: inset 0 0 0 2px light-dark(#ddd, #444);
-  transition: all 0.2s cubic-bezier(0.16, 1, 0.3, 1);
+  width: var(--kit-check-size, 16px);
+  height: var(--kit-check-size, 16px);
+  /* A third of the box, so the corner keeps the same softness at every size
+     the kit ships and at whatever size a caller sets. */
+  border-radius: calc(var(--kit-check-size, 16px) / 3);
+  background-color: light-dark(rgba(0, 0, 0, 0.06), rgba(0, 0, 0, 0.28));
+  box-shadow:
+    inset 1.5px 1.5px 2px -1px light-dark(rgba(0, 0, 0, 0.28), rgba(0, 0, 0, 0.6)),
+    inset -1px -1px 1px -0.5px
+      light-dark(rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0.07));
+  transition:
+    background-color 0.2s cubic-bezier(0.16, 1, 0.3, 1),
+    box-shadow 0.2s cubic-bezier(0.16, 1, 0.3, 1);
 }
 
-.kit-checkbox--box:hover:not(:has(.kit-checkbox__input:disabled))
+/* Pointing at an empty one cuts it a little deeper. Nothing else moves: the
+   socket has no edge to light up, and giving it one would be inventing a third
+   state for a control that has two. */
+.kit-checkbox--box:hover:not(:has(.kit-checkbox__input:disabled)):not(
+    :has(.kit-checkbox__input:checked)
+  )
   .kit-checkbox__box {
-  box-shadow: inset 0 0 0 2px light-dark(#bbb, #555);
+  background-color: light-dark(rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.4));
 }
 
-.kit-checkbox--box:has(.kit-checkbox__input:checked) .kit-checkbox__box {
-  background: linear-gradient(135deg, var(--accent-start), var(--accent-end));
-  box-shadow: 0 4px 16px rgba(237, 87, 96, 0.45);
+/* The fill lying in the channel — the progress bar's accent fill exactly, down
+   to the light along its top edge, the shading under it and the glow. */
+.kit-checkbox--box:has(.kit-checkbox__input:checked) .kit-checkbox__box,
+.kit-check--on {
+  background-color: transparent;
+  background-image:
+    linear-gradient(
+      to bottom,
+      rgba(255, 255, 255, 0.3),
+      rgba(255, 255, 255, 0) 55%
+    ),
+    linear-gradient(135deg, var(--accent-start), var(--accent-end));
+  box-shadow:
+    inset 0 -1px 1px light-dark(rgba(0, 0, 0, 0.15), rgba(0, 0, 0, 0.3)),
+    0 0 8px rgba(237, 87, 96, 0.45);
 }
 
 /* The checkmark grows into place rather than appearing, so the eye can follow
    what changed when a whole column of them is on screen. */
-.kit-checkbox__box svg {
+.kit-checkbox__box svg,
+.kit-check svg {
   position: absolute;
   inset: 0;
   margin: auto;
+  width: calc(var(--kit-check-size, 16px) * 0.66);
+  height: calc(var(--kit-check-size, 16px) * 0.66);
   opacity: 0;
   transform: scale(0.5);
   transition: all 0.15s cubic-bezier(0.16, 1, 0.3, 1);
 }
 
-.kit-checkbox--box:has(.kit-checkbox__input:checked) .kit-checkbox__box svg {
+.kit-checkbox--box:has(.kit-checkbox__input:checked) .kit-checkbox__box svg,
+.kit-check--on svg {
   opacity: 1;
   transform: scale(1);
 }
 
 .kit-checkbox--box.kit-checkbox--sm {
+  --kit-check-size: 16px;
   font-size: 0.75rem;
 }
 
-.kit-checkbox--box.kit-checkbox--sm .kit-checkbox__box {
-  width: 16px;
-  height: 16px;
-  border-radius: 5px;
-}
-
-.kit-checkbox--box.kit-checkbox--sm .kit-checkbox__box svg {
-  width: 10px;
-  height: 10px;
-}
-
 .kit-checkbox--box.kit-checkbox--md {
+  --kit-check-size: 18px;
   font-size: 0.8rem;
 }
 
-.kit-checkbox--box.kit-checkbox--md .kit-checkbox__box {
-  width: 18px;
-  height: 18px;
-  border-radius: 6px;
-}
+/* =============================================================================
+   The mark on its own
 
-.kit-checkbox--box.kit-checkbox--md .kit-checkbox__box svg {
-  width: 12px;
-  height: 12px;
-}
+   A ticked state that is not a control. The travel checklist marks two hundred
+   and fifty countries as seen or not seen, and none of them is something to
+   click — but every one of them is the same idea, and it had grown its own
+   version of it in a page's stylesheet: a 1.5px border that turned accent, with
+   the tick drawn in currentColor and a viewBox of a different size.
+
+   `.kit-check` is the box above without the input around it. Set
+   --kit-check-size for anything other than the kit's own two.
+   ============================================================================= */
 
 /* =============================================================================
    Group
@@ -214,7 +254,9 @@
 @media (prefers-reduced-motion: reduce) {
   .kit-checkbox,
   .kit-checkbox__box,
-  .kit-checkbox__box svg {
+  .kit-check,
+  .kit-checkbox__box svg,
+  .kit-check svg {
     transition: none;
   }
 }
@@ -226,24 +268,41 @@
     box-shadow: inset 0 0 0 2px light-dark(#999, #666);
   }
 
-  .kit-checkbox__box {
+  /* A socket is a gradient of light, which is the first thing to go when
+     contrast is turned up. Both states get a hard edge back instead. */
+  .kit-checkbox__box,
+  .kit-check {
     box-shadow: inset 0 0 0 2px light-dark(#999, #777);
   }
 
-  .kit-checkbox--box:has(.kit-checkbox__input:checked) .kit-checkbox__box {
+  .kit-checkbox--box:has(.kit-checkbox__input:checked) .kit-checkbox__box,
+  .kit-check--on {
     box-shadow: inset 0 0 0 2px light-dark(#333, #ccc);
   }
 }
 
-/* The glow is the one soft thing here; without it the checked state still
-   reads, so only the shadow goes. */
+/* The glow is the one soft thing on the checked state; without it it still
+   reads, so only the shadow goes. The socket is soft all the way through,
+   though — it is nothing but a tint and two inset lights — so it needs an
+   opaque ground and a real edge here or it disappears. */
 @media (prefers-reduced-transparency: reduce) {
-  .kit-checkbox--pill:has(.kit-checkbox__input:checked),
-  .kit-checkbox--box:has(.kit-checkbox__input:checked) .kit-checkbox__box {
+  .kit-checkbox__box,
+  .kit-check {
+    background-color: light-dark(#e9e9ee, #1c1c20);
+    box-shadow: inset 0 0 0 1.5px light-dark(#c8c8d0, #4a4a52);
+  }
+
+  .kit-checkbox--pill:has(.kit-checkbox__input:checked) {
     box-shadow: none;
   }
 
-  .kit-checkbox__box {
-    background: light-dark(#fff, #2a2a2e);
+  .kit-checkbox--box:has(.kit-checkbox__input:checked) .kit-checkbox__box,
+  .kit-check--on {
+    background-image: linear-gradient(
+      135deg,
+      var(--accent-start),
+      var(--accent-end)
+    );
+    box-shadow: none;
   }
 }

--- a/src/styles/kit/toggle-group.css
+++ b/src/styles/kit/toggle-group.css
@@ -411,6 +411,12 @@ a.kit-toggle-item[aria-pressed="true"]:visited {
 .kit-toggle-group--tabs.kit-toggle-group--scrollable {
   padding: 14px;
   margin: -14px;
+  /* And the edge fade has to start where the tabs do, not where the clip box
+     does. A mask is painted over the border box, so a sixteen-pixel gradient
+     against fourteen pixels of empty padding spends all but two of them on
+     nothing — the fade was there, measurable, and invisible: the rail read as
+     a hard cut. See --fade-inset below. */
+  --fade-inset: 14px;
 }
 
 /* =============================================================================
@@ -454,21 +460,29 @@ a.kit-toggle-item[aria-pressed="true"]:visited {
   display: none;
 }
 
-/* Edge fade masks */
+/* Edge fade masks.
+
+   Every stop is measured from --fade-inset rather than from zero, because a
+   mask is painted over the border box and a variant with padding would
+   otherwise spend its gradient on the padding instead of on the items. Zero
+   here, so a row with no padding fades exactly as before; the tabs variant
+   sets it to its own padding. */
 .kit-toggle-group--scrollable {
+  --fade-inset: 0px;
+
   mask-image: linear-gradient(
     to right,
-    transparent,
-    black 16px,
-    black calc(100% - 16px),
-    transparent
+    transparent var(--fade-inset),
+    black calc(var(--fade-inset) + 16px),
+    black calc(100% - var(--fade-inset) - 16px),
+    transparent calc(100% - var(--fade-inset))
   );
   -webkit-mask-image: linear-gradient(
     to right,
-    transparent,
-    black 16px,
-    black calc(100% - 16px),
-    transparent
+    transparent var(--fade-inset),
+    black calc(var(--fade-inset) + 16px),
+    black calc(100% - var(--fade-inset) - 16px),
+    transparent calc(100% - var(--fade-inset))
   );
 }
 
@@ -476,20 +490,30 @@ a.kit-toggle-item[aria-pressed="true"]:visited {
   mask-image: linear-gradient(
     to right,
     black,
-    black calc(100% - 16px),
-    transparent
+    black calc(100% - var(--fade-inset) - 16px),
+    transparent calc(100% - var(--fade-inset))
   );
   -webkit-mask-image: linear-gradient(
     to right,
     black,
-    black calc(100% - 16px),
-    transparent
+    black calc(100% - var(--fade-inset) - 16px),
+    transparent calc(100% - var(--fade-inset))
   );
 }
 
 .kit-toggle-group--scrollable.at-end {
-  mask-image: linear-gradient(to right, transparent, black 16px, black);
-  -webkit-mask-image: linear-gradient(to right, transparent, black 16px, black);
+  mask-image: linear-gradient(
+    to right,
+    transparent var(--fade-inset),
+    black calc(var(--fade-inset) + 16px),
+    black
+  );
+  -webkit-mask-image: linear-gradient(
+    to right,
+    transparent var(--fade-inset),
+    black calc(var(--fade-inset) + 16px),
+    black
+  );
 }
 
 .kit-toggle-group--scrollable.at-start.at-end {

--- a/src/styles/kit/toggle-group.css
+++ b/src/styles/kit/toggle-group.css
@@ -193,6 +193,29 @@ a.kit-toggle-item[aria-pressed="true"]:visited {
   box-shadow: 0 4px 16px rgba(237, 87, 96, 0.45);
 }
 
+/* A separated row with the volume down: the current item is ink and the wash it
+   already answers a cursor with, instead of the accent capsule and its glow.
+
+   The loud version is right when the row is the loudest thing in its area — the
+   wishlist's categories sit above the items they filter and have the page to
+   themselves. It is wrong for a control tucked into a heading beside something
+   else that is already pinned: /travel's sort sits forty pixels under the view
+   rail, and at full accent it was the brightest thing on the page, brighter
+   than the tab that says which view you are in.
+
+   Ink rather than a second glass capsule, deliberately. Glass here would read
+   as a smaller copy of the rail above it and make the two compete for the same
+   job; the wash says "this one" without claiming to be the same kind of
+   control. */
+.kit-toggle-group--separated.kit-toggle-group--quiet
+  .kit-toggle-item[aria-pressed="true"],
+.kit-toggle-group--separated.kit-toggle-group--quiet .kit-toggle-item.is-active {
+  background: light-dark(rgba(0, 0, 0, 0.075), rgba(255, 255, 255, 0.1));
+  box-shadow: none;
+  color: light-dark(#111, #fff);
+  font-weight: 600;
+}
+
 /* Separated sizes — capsules, like every other pill in the chrome. */
 .kit-toggle-group--separated.kit-toggle-group--sm .kit-toggle-item {
   height: 32px;
@@ -206,6 +229,188 @@ a.kit-toggle-item[aria-pressed="true"]:visited {
   padding: 0 1.1rem;
   font-size: 0.8rem;
   border-radius: 999px;
+}
+
+/* =============================================================================
+   Tabs — a rail of views, not a row of filters.
+
+   `separated` and this look alike at rest and are still two different controls.
+   A filter chip narrows what a list contains; a tab swaps the whole panel
+   underneath it, so it is marked up as role="tablist" and driven by the arrow
+   keys (see @client/toggle-tabs).
+
+   The current tab is a lens: the chrome's own glass capsule, sliding behind the
+   label on the dock's easing. That idiom is already on the site twice — the
+   magnetic dock and the language switcher both rest a sliding indicator under
+   the item that is on — and this is the same thing with one part swapped. Their
+   indicator is an accent gradient, which is right for a two- or four-item nav
+   floating in the chrome with nothing beneath it. A tab rail is pinned over
+   content that already spends the accent on three progress bars and two hundred
+   and fifty tick boxes, so this one is cut from the same glass as the header
+   pills and leaves the accent alone.
+
+   One lens for the whole rail rather than a surface per item: it travels, and
+   five buttons with one piece of glass between them read as an instrument
+   rather than as five things each making their own case.
+   ============================================================================= */
+.kit-toggle-group--tabs {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 0.15rem;
+  padding: 0;
+  background: transparent;
+  border-radius: 0;
+}
+
+/* Capsules, like every other pill in the chrome — and above the lens, which
+   slides behind them. */
+.kit-toggle-group--tabs .kit-toggle-item {
+  position: relative;
+  z-index: 1;
+  background: transparent;
+  border: none;
+  box-shadow: none;
+  border-radius: 999px;
+  color: light-dark(#666, #9a9aa0);
+  transition:
+    background-color 0.25s ease,
+    color 0.3s ease;
+}
+
+/* Hover answers with the wash, not with the lens. The dock moves its indicator
+   to whatever the pointer is over, because there "current" means the page you
+   are about to go to; here it means the panel you are reading, and a control
+   that slid off it while you browsed the row would stop saying where you are. */
+.kit-toggle-group--tabs
+  .kit-toggle-item:hover:not(:disabled):not([aria-selected="true"]),
+.kit-toggle-group--tabs
+  .kit-toggle-item:focus-visible:not([aria-selected="true"]) {
+  background-color: light-dark(rgba(0, 0, 0, 0.055), rgba(255, 255, 255, 0.07));
+  color: light-dark(#111, #fff);
+}
+
+/* The rail is a scroll container, and a scroll container clips an outline drawn
+   outside the border box — on a narrow screen the focus ring would be sheared
+   off on exactly the tabs nearest the edges. Drawn inside instead, it survives.
+   The base rule's colour and width are kept. */
+.kit-toggle-group--tabs .kit-toggle-item:focus-visible {
+  outline-offset: -2px;
+}
+
+/* Ink, on glass. Also undoes the flat raised capsule the base active rule
+   paints, which is the pill variant's answer and not this one's. */
+.kit-toggle-group--tabs .kit-toggle-item[aria-selected="true"],
+.kit-toggle-group--tabs .kit-toggle-item.is-active {
+  background: transparent;
+  box-shadow: none;
+  color: light-dark(#111, #fafafa);
+}
+
+/* The lens itself. Geometry arrives in four custom properties from the script,
+   exactly as the dock sets --dock-*, and the easing, the 0.42s and the scale-in
+   are the dock's too — two sliding indicators on one page have no business
+   moving differently.
+
+   The material is .liquid-glass, on the element, rather than the same values
+   copied out of it. That utility is what the home pill, the compact title and
+   the language switcher are made of, and this had everything it has except the
+   frost: the comment here used to argue the blur was wasted because the rail
+   carried a blurred veil of its own. The rail does not carry one any more, so
+   the argument expired and what was left was the one capsule in the chrome you
+   could read straight through. Taking the class instead of the values means it
+   cannot drift again. */
+.kit-toggle-group__marker {
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 0;
+  box-sizing: border-box;
+  width: var(--marker-w, 0);
+  height: var(--marker-h, 0);
+  border-radius: 999px;
+  opacity: 0;
+  transform: translate(var(--marker-x, 0), var(--marker-y, 0)) scale(0.9);
+  transition:
+    transform 0.42s cubic-bezier(0.16, 1, 0.3, 1),
+    width 0.42s cubic-bezier(0.16, 1, 0.3, 1),
+    opacity 0.3s ease;
+  pointer-events: none;
+}
+
+/* Everything about the material comes from .liquid-glass except the lift, which
+   is the one part of it drawn for a bigger surface. See --glass-shadow-sm. */
+.kit-toggle-group--tabs .kit-toggle-group__marker {
+  box-shadow: var(--glass-shadow-sm);
+}
+
+/* Both the reveal and the travel wait for `has-marker`, which the script adds a
+   frame after the first measurement — so the lens grows into place where it
+   belongs instead of sweeping in from the left edge of the rail on load. */
+.kit-toggle-group--tabs.has-marker .kit-toggle-group__marker {
+  opacity: 1;
+  transform: translate(var(--marker-x, 0), var(--marker-y, 0)) scale(1);
+}
+
+/* Until the lens has been measured — the first frame, and for good on a page
+   with no script — the selected tab wears the same glass itself. */
+.kit-toggle-group--tabs:not(.has-marker)
+  .kit-toggle-item[aria-selected="true"] {
+  background-color: var(--glass-bg);
+  background-image: var(--glass-sheen);
+  box-shadow: var(--glass-shadow), var(--glass-rim);
+}
+
+/* A count beside the label: how much is behind this tab, so the row answers
+   "is it worth opening" before it is opened. Muted and tabular — it is a
+   figure attached to a word, not a second word. */
+.kit-toggle-item__count {
+  font-weight: 500;
+  font-size: 0.9em;
+  font-variant-numeric: tabular-nums;
+  color: light-dark(#888, #8a8a90);
+  transition: color 0.3s ease;
+}
+
+.kit-toggle-group--tabs
+  .kit-toggle-item[aria-selected="true"]
+  .kit-toggle-item__count {
+  color: light-dark(#666, #9a9aa0);
+}
+
+/* Tab sizes — the separated chip's capsule geometry, with a little more room
+   inside: the lens is a surface you aim at rather than a label you glance over,
+   and it needs the width to read as glass rather than as a highlight. */
+.kit-toggle-group--tabs.kit-toggle-group--sm .kit-toggle-item {
+  height: 32px;
+  padding: 0 0.9rem;
+  font-size: 0.75rem;
+  border-radius: 999px;
+}
+
+.kit-toggle-group--tabs.kit-toggle-group--md .kit-toggle-item {
+  height: 38px;
+  padding: 0 1.15rem;
+  font-size: 0.8rem;
+  border-radius: 999px;
+}
+
+/* Room for the lens's shadow to land in.
+
+   `scrollable` sets overflow-x, which makes this a scroll container, and a
+   scroll container clips. The lens's shadow reaches some thirteen pixels below
+   it and was being cut off flat at the group's edge — what survived was the
+   part beside the capsule and not the part beneath it, which left two dark
+   crescents at its bottom corners. They read as a rendering fault rather than
+   as lift, because a shadow that stops in a straight line is not the shadow of
+   anything.
+
+   The padding gives it somewhere to fall inside the clip box; the matching
+   negative margin puts the row back exactly where it was, so nothing moves and
+   the height the rail publishes is unchanged. */
+.kit-toggle-group--tabs.kit-toggle-group--scrollable {
+  padding: 14px;
+  margin: -14px;
 }
 
 /* =============================================================================
@@ -300,6 +505,12 @@ a.kit-toggle-item[aria-pressed="true"]:visited {
   .kit-toggle-item {
     transition: none;
   }
+
+  /* The line still moves — it has to, it is the only thing marking the current
+     tab — it just arrives there rather than travelling. */
+  .kit-toggle-group--tabs.has-marker .kit-toggle-group__marker {
+    transition: none;
+  }
 }
 
 @media (prefers-contrast: more) {
@@ -313,6 +524,23 @@ a.kit-toggle-item[aria-pressed="true"]:visited {
     .kit-toggle-item:not([aria-pressed="true"]):not(.is-active) {
     box-shadow: inset 0 0 0 2px light-dark(#999, #666);
   }
+
+  /* A tab rail is not a box: the border above would draw a frame around the
+     whole row, when the thing that needs an edge is the one capsule inside it.
+     The lens gets a real outline and the labels resolve fully. */
+  .kit-toggle-group--tabs {
+    border: none;
+  }
+
+  .kit-toggle-group--tabs .kit-toggle-item {
+    color: light-dark(#333, #ddd);
+  }
+
+  .kit-toggle-group__marker,
+  .kit-toggle-group--tabs:not(.has-marker)
+    .kit-toggle-item[aria-selected="true"] {
+    border: 2px solid light-dark(#333, #eee);
+  }
 }
 
 /* Nothing for prefers-reduced-transparency: the row is opaque by design now —
@@ -325,5 +553,22 @@ a.kit-toggle-item[aria-pressed="true"]:visited {
   .kit-toggle-item[aria-pressed="true"],
   .kit-toggle-item.is-active {
     background: light-dark(#fff, #444);
+  }
+
+  /* The rail never had a surface to lose — it is transparent by design, and a
+     slab behind it here would be the one thing on the page inventing one. Its
+     lens does have one, and --glass-bg stays translucent under this query by
+     design (see the note on the token), so the opaque tint is named here the
+     way every other re-declaration of the recipe names its own. */
+  .kit-toggle-group--tabs,
+  .kit-toggle-group--tabs .kit-toggle-item.is-active {
+    background: transparent;
+  }
+
+  .kit-toggle-group__marker,
+  .kit-toggle-group--tabs:not(.has-marker)
+    .kit-toggle-item[aria-selected="true"] {
+    background-color: light-dark(#fff, #35353a);
+    background-image: none;
   }
 }

--- a/src/styles/travel.css
+++ b/src/styles/travel.css
@@ -43,15 +43,32 @@
   /* How far a row's wash reaches past its text. ListItem's 0.75rem. */
   --travel-row-inset: 0.75rem;
 
-  /* A key or a count beside content — the colour and size of the timeline's
-     date column. */
-  --travel-muted: light-dark(#888, #9a9aa0);
+  /* Everything on these views that is not the content itself: a key or a count
+     beside it, the cities trailing a country, the years under the chart.
 
-  /* Secondary text that is still read as text rather than glanced at as a
-     label: the cities trailing a country, the note under the continents. Kept
-     darker than --travel-muted because a sentence at #888 on this page is
-     under 3.5:1. */
-  --travel-quiet: light-dark(#666, #9a9aa0);
+     This was two tokens, and the second one existed only to work around the
+     first. --travel-muted was #888 in the light scheme, which is 3.35:1 against
+     this page — under the 4.5 small text needs — so anything that had to be
+     read as a sentence rather than glanced at as a label took a --travel-quiet
+     of #666 instead, and its comment said as much. Fixing the first at the root
+     leaves nothing for the second to do: at a legible value the two are a
+     thirtieth of a step apart in the light scheme and were already the same
+     value in the dark one. One token, and it passes. */
+  --travel-muted: light-dark(#6a6a6a, #9a9aa0);
+}
+
+/* A panel is focusable so the keyboard can reach and scroll views that hold
+   nothing focusable of their own (see the note in pages/travel/index.astro).
+   Only the keyboard gets the ring: a click inside a three-thousand-pixel block
+   would otherwise draw an outline around the entire page. */
+.travel-view:focus {
+  outline: none;
+}
+
+.travel-view:focus-visible {
+  outline: 2px solid light-dark(#333, #fff);
+  outline-offset: 6px;
+  border-radius: 6px;
 }
 
 /* The stack of sections a view is made of. 1.5rem is YearGroup's gap between
@@ -77,13 +94,24 @@
   justify-content: space-between;
   gap: 1rem;
   position: sticky;
-  /* PageHeader publishes its stuck height on <main>, so the heading docks
-     below the floating pills instead of colliding with them. */
-  top: var(--sticky-header-offset, 0px);
+  /* Two things are already pinned above this one, and each publishes its own
+     stuck height on <main>: PageHeader's floating pills
+     (--sticky-header-offset, from page-header-condense.ts) and the view rail
+     under them (--sticky-rail-offset, from TravelViewSwitcher). Adding both is
+     what makes a heading dock below the rail rather than slide under it.
+     YearGroup — the timeline's year, the heading this one is a restatement of
+     — reads the same pair. */
+  top: calc(var(--sticky-header-offset, 0px) + var(--sticky-rail-offset, 0px));
   z-index: 10;
   background-color: var(--veil-bg);
   backdrop-filter: var(--veil-filter);
-  padding: 0.5rem 0;
+  /* Out to the same edge a row's hover wash reaches, and back in by the same
+     amount so the title still starts on the content edge. Everything on this
+     page that draws a surface or a rule now ends on one line — the counters,
+     the rail, this, and the wash — instead of the wash alone hanging 12px
+     past the rest. */
+  padding: 0.5rem var(--travel-row-inset);
+  margin-inline: calc(-1 * var(--travel-row-inset));
   margin-bottom: 0.5rem;
   border-bottom: var(--glass-border);
 }
@@ -100,17 +128,22 @@
   color: light-dark(#333, #fafafa);
 }
 
-/* A label sitting over a number rather than heading a list — the four facts in
-   the stats view. This is the spec the counters above the switcher use for
-   their own labels, because it is the same thing: a caption for the figure
-   below it. It deliberately has no rule under it; a hairline is what made
-   those four read as sections. */
+/* The quiet text bracketing a figure rather than heading a list — the four
+   facts in the stats view, where it is both the question above the answer and
+   the amount below it. One spec for the pair on purpose: they are the two soft
+   lines around the one loud one, and when they differed by a twentieth of a rem
+   and a hundred units of weight, the difference read as a wobble rather than as
+   a decision. It is also what the counters above the switcher label themselves
+   with, because that is the same job again.
+
+   It deliberately has no rule under it; a hairline is what made those four read
+   as sections. */
 .travel-caption {
   margin: 0;
   font-size: 0.85rem;
   font-weight: 500;
   letter-spacing: normal;
-  color: var(--travel-quiet);
+  color: var(--travel-muted);
 }
 
 /* Every number in these views: the count in a section head, the cities beside
@@ -204,7 +237,7 @@
 
 /* A name that is a place still to go rather than one that has been. */
 .travel-name--muted {
-  color: var(--travel-quiet);
+  color: var(--travel-muted);
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/styles/travel.css
+++ b/src/styles/travel.css
@@ -1,0 +1,132 @@
+/* The design code shared by the views behind /travel's switcher.
+   ============================================================================
+
+   Five views draw the same handful of things — a section with a label and a
+   count, a country as a flag and a name and a number — and until this file
+   they each drew them their own way. Measured on the page, one country's name
+   came out at 14.4px/600/#111 in the countries view, 13.6px/400/#111 in the
+   continents view and 13.6px/400/#555 in the checklist; its flag at three
+   sizes on two different baselines; the count beside it as a 9.6px filled
+   chip, as plain 12.8px/500, and as "(17)" at 12.8px/400. None of that was a
+   decision anyone made — it is three components written on three days.
+
+   The rules below are the page's own, not a new invention:
+
+   - The rhythm and the hairline come from the timeline's year heading
+     (YearGroup.astro), which is the oldest view and the one the page opens on.
+     1.5rem between blocks, and --glass-border for the rule, rather than the
+     hand-written `1px solid rgba(0,0,0,.1)` the checklist had grown.
+   - Nothing here paints a surface. The four counters above the switcher are
+     the page's only cards; the continents and stats views had grown a second
+     set in the same material, directly under them, which read as the counter
+     strip printed twice. Below the switcher the page is flat.
+   - The section label is an eyebrow, not a heading: a year is a landmark and
+     stays 1.25rem, but "Europe" and "Trips by year" are labels for what
+     follows and sit at the size of the numbers they introduce. */
+
+/* The stack of sections a view is made of. */
+.travel-sections {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+/* Label left, count right, hairline under — the year heading without the
+   sticky positioning, which only the timeline needs because only the timeline
+   is long enough to scroll a heading out of view.
+
+   The rule is NOT --glass-border, which is what the year heading uses. That
+   token is the lit edge of a glass capsule: rgba(255,255,255,0.7) in the light
+   scheme, which is a highlight, not a line. Measured against the page it draws
+   70%-white on rgb(248,248,255) and disappears entirely; the year heading gets
+   away with it only because it is sticky and has the veil behind it. A divider
+   lying on the page has to be darker than the page. */
+.travel-section-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  padding-bottom: 0.5rem;
+  margin-bottom: 0.5rem;
+  border-bottom: 1px solid
+    light-dark(rgba(0, 0, 0, 0.09), rgba(255, 255, 255, 0.1));
+}
+
+.travel-section-title {
+  margin: 0;
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: light-dark(#666, #888);
+}
+
+/* Every number in these views: the count in a section head, the cities beside
+   a country, the trips in a year. One size, one colour, always tabular so
+   columns of them line up instead of wandering with the digit widths. */
+.travel-metric {
+  font-size: 0.8rem;
+  color: light-dark(#888, #8a8a90);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+/* Pushed to the end of its row so the numbers line up down the column rather
+   than trailing each name at a different offset. */
+.travel-metric--trailing {
+  margin-left: auto;
+  padding-left: 0.5rem;
+}
+
+/* Countries in columns. Multi-column rather than grid so a sorted list fills
+   downwards and the reader can scan one column at a time — the continents view
+   is sorted by size, so its first column is the countries worth reading and
+   the second is the one-city tail. `columns` also balances the last block
+   itself, which a grid cannot do without knowing the row count. */
+.travel-grid {
+  columns: var(--travel-columns, 2);
+  column-gap: 1.5rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+/* break-inside keeps a row whole at the column boundary, which multi-column
+   layout will otherwise split mid-line. */
+.travel-row {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.25rem 0;
+  break-inside: avoid;
+  font-size: 0.85rem;
+}
+
+.travel-flag {
+  flex-shrink: 0;
+  font-size: 0.85rem;
+  border-radius: 2px;
+}
+
+/* Medium rather than semibold. In the countries view the name leads a line
+   that goes on to list cities, which is why it used to be 600 there and 400
+   in the other two; but the "—" and the colour already separate it from the
+   cities, so one weight in the middle carries both jobs. */
+.travel-name {
+  font-weight: 500;
+  color: light-dark(#111, #eee);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* A name that is a place still to go rather than one that has been. */
+.travel-name--muted {
+  color: light-dark(#666, #9a9aa0);
+}
+
+@media (max-width: 520px) {
+  .travel-grid {
+    columns: 1;
+  }
+}

--- a/src/styles/travel.css
+++ b/src/styles/travel.css
@@ -1,72 +1,125 @@
 /* The design code shared by the views behind /travel's switcher.
    ============================================================================
 
-   Five views draw the same handful of things — a section with a label and a
-   count, a country as a flag and a name and a number — and until this file
-   they each drew them their own way. Measured on the page, one country's name
-   came out at 14.4px/600/#111 in the countries view, 13.6px/400/#111 in the
-   continents view and 13.6px/400/#555 in the checklist; its flag at three
-   sizes on two different baselines; the count beside it as a 9.6px filled
-   chip, as plain 12.8px/500, and as "(17)" at 12.8px/400. None of that was a
-   decision anyone made — it is three components written on three days.
+   The timeline is the page's oldest view, the one it opens on, and the one
+   every other view is read against — so it is the reference here, and these
+   rules are its rules restated for lists it does not itself draw. Nothing
+   below is a new invention: measured on the page, each value is either
+   ListItem's (the timeline's row) or YearGroup's (its year heading).
 
-   The rules below are the page's own, not a new invention:
+   What the four other views had instead, measured: a row hover in three
+   different answers — the countries view washed at rgba(0,0,0,.03) over a 6px
+   radius in 0.15s, while continents, checklist and stats had no hover at all
+   against the timeline's rgba(0,0,0,.055) over 14px in 0.25s; row text at
+   13.6px where the timeline sets 16px, and a count beside it at 12.8px where
+   the timeline's date is 14.4px; a section label as a 12.8px uppercase eyebrow
+   where a year is 20px and semibold; flags at 18px against the timeline's 21px;
+   and every row carrying 8px of margin nobody wrote, inherited from the
+   document's `li` typography, which is what made these lists sit looser than
+   the timeline they sat next to.
 
-   - The rhythm and the hairline come from the timeline's year heading
-     (YearGroup.astro), which is the oldest view and the one the page opens on.
-     1.5rem between blocks, and --glass-border for the rule, rather than the
-     hand-written `1px solid rgba(0,0,0,.1)` the checklist had grown.
-   - Nothing here paints a surface. The four counters above the switcher are
-     the page's only cards; the continents and stats views had grown a second
-     set in the same material, directly under them, which read as the counter
-     strip printed twice. Below the switcher the page is flat.
-   - The section label is an eyebrow, not a heading: a year is a landmark and
-     stays 1.25rem, but "Europe" and "Trips by year" are labels for what
-     follows and sit at the size of the numbers they introduce. */
+   Two things the timeline does that are easy to miss and are the whole reason
+   its rows read as rows:
 
-/* The stack of sections a view is made of. */
+   - The hover wash bleeds into the gutter. A row is padded 0.75rem inline and
+     pulled back by the same amount, so the text still starts on the page's
+     content edge — level with the heading above it — while the wash reaches
+     past it. Every row here does the same, which is also what fixed the
+     countries view sitting 8px to the right of every other view.
+   - A group heading is a landmark: the group's name at 1.25rem, sticky under
+     the page header, with the page's own veil behind it so rows pass beneath.
+     The four other views had labels a third that size, so switching tabs used
+     to change what a heading *was*.
+
+   Nothing here paints a surface. The four counters above the switcher are the
+   page's only cards; below the switcher the page is flat. */
+
+.travel-view {
+  /* The wash that means "the thing being pointed at". ListItem's, and the
+     wishlist's filter chips' and popover buttons' — one alpha for the whole
+     site. */
+  --travel-hover: light-dark(rgba(0, 0, 0, 0.055), rgba(255, 255, 255, 0.07));
+
+  /* How far a row's wash reaches past its text. ListItem's 0.75rem. */
+  --travel-row-inset: 0.75rem;
+
+  /* A key or a count beside content — the colour and size of the timeline's
+     date column. */
+  --travel-muted: light-dark(#888, #9a9aa0);
+
+  /* Secondary text that is still read as text rather than glanced at as a
+     label: the cities trailing a country, the note under the continents. Kept
+     darker than --travel-muted because a sentence at #888 on this page is
+     under 3.5:1. */
+  --travel-quiet: light-dark(#666, #9a9aa0);
+}
+
+/* The stack of sections a view is made of. 1.5rem is YearGroup's gap between
+   one year and the next. */
 .travel-sections {
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
 }
 
-/* Label left, count right, hairline under — the year heading without the
-   sticky positioning, which only the timeline needs because only the timeline
-   is long enough to scroll a heading out of view.
+/* ============================================================================
+   A group heading — the year heading, for groups that are not years.
 
-   The rule is NOT --glass-border, which is what the year heading uses. That
-   token is the lit edge of a glass capsule: rgba(255,255,255,0.7) in the light
-   scheme, which is a highlight, not a line. Measured against the page it draws
-   70%-white on rgb(248,248,255) and disappears entirely; the year heading gets
-   away with it only because it is sticky and has the veil behind it. A divider
-   lying on the page has to be darker than the page. */
+   Identical to YearGroup.astro on purpose, down to the veil and the sticky
+   offset: a continent, a checklist category and "Trips by year" are the same
+   kind of landmark a year is, and the two must move together. The one thing
+   added is room for a count at the end of the line, which a year has no use
+   for.
+   ============================================================================ */
 .travel-section-head {
   display: flex;
   align-items: baseline;
   justify-content: space-between;
   gap: 1rem;
-  padding-bottom: 0.5rem;
+  position: sticky;
+  /* PageHeader publishes its stuck height on <main>, so the heading docks
+     below the floating pills instead of colliding with them. */
+  top: var(--sticky-header-offset, 0px);
+  z-index: 10;
+  background-color: var(--veil-bg);
+  backdrop-filter: var(--veil-filter);
+  padding: 0.5rem 0;
   margin-bottom: 0.5rem;
-  border-bottom: 1px solid
-    light-dark(rgba(0, 0, 0, 0.09), rgba(255, 255, 255, 0.1));
+  border-bottom: var(--glass-border);
 }
 
 .travel-section-title {
   margin: 0;
-  font-size: 0.8rem;
+  font-size: 1.25rem;
   font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: light-dark(#666, #888);
+  /* Both reset the document's heading typography, which would otherwise arrive
+     at 700 and -0.02em — a year heading is a div and gets neither. */
+  letter-spacing: normal;
+  text-transform: none;
+  font-variant-numeric: tabular-nums;
+  color: light-dark(#333, #fafafa);
+}
+
+/* A label sitting over a number rather than heading a list — the four facts in
+   the stats view. This is the spec the counters above the switcher use for
+   their own labels, because it is the same thing: a caption for the figure
+   below it. It deliberately has no rule under it; a hairline is what made
+   those four read as sections. */
+.travel-caption {
+  margin: 0;
+  font-size: 0.85rem;
+  font-weight: 500;
+  letter-spacing: normal;
+  color: var(--travel-quiet);
 }
 
 /* Every number in these views: the count in a section head, the cities beside
-   a country, the trips in a year. One size, one colour, always tabular so
-   columns of them line up instead of wandering with the digit widths. */
+   a country, the year beside a bar. The timeline's date column exactly — one
+   size, one colour, always tabular so columns of them line up instead of
+   wandering with the digit widths. */
 .travel-metric {
-  font-size: 0.8rem;
-  color: light-dark(#888, #8a8a90);
+  font-size: 0.9rem;
+  color: var(--travel-muted);
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
 }
@@ -78,43 +131,72 @@
   padding-left: 0.5rem;
 }
 
+/* ============================================================================
+   The row
+   ============================================================================ */
+
 /* Countries in columns. Multi-column rather than grid so a sorted list fills
    downwards and the reader can scan one column at a time — the continents view
    is sorted by size, so its first column is the countries worth reading and
    the second is the one-city tail. `columns` also balances the last block
-   itself, which a grid cannot do without knowing the row count. */
+   itself, which a grid cannot do without knowing the row count.
+
+   The gap is 2rem rather than 1.5rem because rows now bleed 0.75rem of wash on
+   each side; at 1.5rem two hovered rows in neighbouring columns would touch. */
 .travel-grid {
   columns: var(--travel-columns, 2);
-  column-gap: 1.5rem;
+  column-gap: 2rem;
   margin: 0;
   padding: 0;
   list-style: none;
 }
 
-/* break-inside keeps a row whole at the column boundary, which multi-column
-   layout will otherwise split mid-line. */
 .travel-row {
   display: flex;
   align-items: center;
-  gap: 0.4rem;
-  padding: 0.25rem 0;
+  /* The 4px the timeline puts between a flag and the city beside it. */
+  gap: 0.25rem;
+  font-size: 1rem;
+  line-height: 1.9;
+  color: light-dark(#111, #fafafa);
+  /* The wash reaches into the gutter while the text stays on the content edge
+     — see the note at the top of this file. ListItem's padding exactly, which
+     is what makes a row here the same height as a trip: 0.5rem against a 1.9
+     line comes out at the timeline's 46px. */
+  padding: 0.5rem var(--travel-row-inset);
+  margin-inline: calc(-1 * var(--travel-row-inset));
+  /* Without this, the document's list typography adds 8px under every row: the
+     pitch these lists used to have, which nobody chose. */
+  margin-block: 0;
+  border-radius: 14px;
+  transition: background-color 0.25s ease;
+  /* break-inside keeps a row whole at the column boundary, which multi-column
+     layout will otherwise split mid-line. */
   break-inside: avoid;
-  font-size: 0.85rem;
+}
+
+.travel-row:hover {
+  background-color: var(--travel-hover);
+}
+
+/* A row whose content is a running line rather than a few fixed parts — the
+   countries view, where the cities go on until they wrap. Same shell, laid out
+   as text; the 1.9 line-height above is the timeline's, so a wrapped list of
+   cities breathes exactly as a wrapped journey does. */
+.travel-row--flow {
+  display: block;
 }
 
 .travel-flag {
   flex-shrink: 0;
-  font-size: 0.85rem;
-  border-radius: 2px;
+  /* Not a size of its own: flag-icons scales with the font, so leaving this
+     alone is what keeps a flag here the same width as a flag in the timeline. */
+  border-radius: 3px;
 }
 
-/* Medium rather than semibold. In the countries view the name leads a line
-   that goes on to list cities, which is why it used to be 600 there and 400
-   in the other two; but the "—" and the colour already separate it from the
-   cities, so one weight in the middle carries both jobs. */
 .travel-name {
-  font-weight: 500;
-  color: light-dark(#111, #eee);
+  /* No weight and no colour of its own: a name in these rows is the row's
+     content, exactly as a city name is in the timeline, and inherits both. */
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -122,7 +204,13 @@
 
 /* A name that is a place still to go rather than one that has been. */
 .travel-name--muted {
-  color: light-dark(#666, #9a9aa0);
+  color: var(--travel-quiet);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .travel-row {
+    transition: none;
+  }
 }
 
 @media (max-width: 520px) {


### PR DESCRIPTION
The travel page has had a view switcher sitting commented out in
`src/pages/travel/index.astro` for a while, along with five views behind it.
This turns it back on with three of them — the timeline and the countries list
that already existed, plus two new ones — and drops the two that were never
written.

### Continents

Cards per continent, each with the countries under it and a bar reading
`visited / total`. All seven are named: half the point of the view is what is
left to go, and an absent Africa would read as a rendering bug rather than as
zero, so the untouched five collapse into one closing "Still to go" card.

The totals are the conventional 195-country tally — 193 UN members plus the
Vatican and Palestine — split across the seven continents of the National
Geographic model, which is the model the "Continents 2 / 7" stat card already
links out to. They sum to 195 exactly, and a test holds them to it.

Two things are deliberate and worth knowing before touching the table:

- **The continent per country is its own table, not derived from
  `countries.ts`.** 21 of that file's 193 entries carry no continent at all,
  and every Oceanian state bar Australia is among them, so a derived Oceania
  total would read 1. Several entries also carry `XX` placeholder ISO codes,
  and `getByCode("CHE")` and `getByCode("GBR")` both come back undefined —
  Switzerland and the UK would be quietly filed nowhere.
- **Hong Kong, Macau, Svalbard and Taiwan appear in their continent's list but
  are not counted in its numerator.** They were visited, but the denominator
  never had room for them, and enough of them would push a continent past 100%.

Adding a country to `trips.json` without adding it here would drop it from the
view without a trace — the per-continent fractions would still add up and
nothing on the page would look wrong. `getUnmappedCountries` exists for that
and a test pins it to empty.

### Stats

Most visited city, most visited country, busiest year, latest country seen for
the first time, and a bar per year. Every "top" answer takes a tie-break on the
key — the first name alphabetically, the earliest year — because otherwise the
answer falls out of `Map` insertion order, i.e. out of where the trips happen
to sit in `trips.json`, and editing an unrelated trip could silently change
which city the page calls the most visited one.

Places are counted once per trip, not once per destination row: the Oct 2024
trip reaches England and Scotland under the same alpha-3 and is one visit to
the United Kingdom, not two.

The four counters at the top of the page stay outside the switcher. They answer
"how much" for the whole page and the map and every view below are read against
them; the stats view answers a different question and is a panel you go and
look at.

### Along the way

- **`continentsVisited` stopped being a literal.** It was a `2` that had to be
  remembered and bumped by hand the first time a trip reached a third
  continent, sitting one file away from a `7`. The continents view works out
  which continents have a country under them anyway, so the stat card reads its
  number off the same answer and the two can no longer disagree. It still says
  2 / 7.
- **The switcher stopped carrying a second copy of its own view list.** Its
  script validated the URL hash against a hardcoded array, so adding a view
  meant editing both places, and forgetting the array left the new view
  reachable by its button but not by its own link — the hash fell through to
  the default and the page opened on the timeline.
- **A country's row in the countries list says how many cities it is about to
  list.**
- **The progress bars announce themselves in Russian.** Every bar on the page
  carried an English-only `aria-label`, including the two that predate this
  branch. `LangInit` already translates labels from `data-aria-label-en/ru`,
  but the attribute lands on `ProgressBar`'s inner element, which a caller had
  no way to address — so `ProgressBar` now forwards leftover props to it, the
  way `Badge` already does. `/kit` documents it.

### Checks

`bun test` 29 passing, `astro check` 0 errors, `bun run build` clean. Rebased
onto `main` past the Drizzle move; no conflicts.

### One design code for the five views

Each view had been written on its own day and had invented its own version of
the same few things. Measured on the built page, one country's name came out
three ways — 14.4px/600/#111 in the countries view, 13.6px/400/#111 in the
continents view, 13.6px/400/#555 in the checklist — its flag at three sizes on
two baselines, and the count beside it as a 9.6px filled `Badge`, as plain
12.8px/500, and as "(17)". Three surfaces, three rhythms, two heading styles.

`src/styles/travel.css` now holds the one set: a section head, a metric, a
country row, a column grid, a rhythm. The values are the page's own rather than
new — the 1.5rem between blocks and the labelled-block-with-a-rule shape come
from the timeline's year heading, the oldest view and the one the page opens
on.

**Nothing below the switcher paints a surface any more.** The continents and
stats views had grown glass cards in the same material as the four counters
above them, directly under them, which read as the counter strip printed twice.
The counters keep their cards and stay the page's only ones.

Two things worth knowing:

- The section rule is a hand-written hairline, *not* `--glass-border` — which
  is what the year heading uses. That token is the lit edge of a glass capsule,
  `rgba(255,255,255,0.7)` in the light scheme; measured against the page it
  draws 70%-white on `rgb(248,248,255)` and vanishes. The year heading gets
  away with it only because it is sticky with the veil behind it.
- The checklist's countries now fill down each column rather than across the
  row, matching the continents view. Its flags also lost `role="img"` with an
  `aria-label`, which had a screen reader announce every country twice.

**The timeline is deliberately untouched.** It is the reference the other four
were pulled toward, so `/travel` looks unchanged until you click a tab.

### The switcher drops its icons

A flag before "Countries", a globe before "Continents", a bar chart before
"Stats", a tick before "Checklist" — five pictograms restating five short
words. `ToggleGroup` still draws one for items that ask, and the `/kit` demo
still does.
