### PR TITLE
Tanenbaum's Computer Networks joins the wishlist, in two editions

### DIFF
--- a/scripts/db/seed.ts
+++ b/scripts/db/seed.ts
@@ -1032,6 +1032,24 @@ async function seed() {
       received: false,
       createdAt: now,
     },
+    {
+      id: 73,
+      title: "Andrew Tanenbaum — Computer Networks",
+      titleRu: "Книга «Компьютерные сети», Эндрю Таненбаум",
+      // Tenge: no rate on file, so this one sits out the cheapest-option
+      // comparison and the card falls back to the Amazon price.
+      price: "₸25,940",
+      imageUrl: "tanenbaum-computer-networks.jpg",
+      url: "https://www.meloman.kz/tanenbaum-je-s-fimster-n-komp-juternye-seti-6-e-izd.html",
+      description:
+        "The sixth edition. Physical layer up to applications, security chapter rewritten",
+      descriptionRu:
+        "Шестое издание. От физического уровня до прикладного, глава о безопасности переписана",
+      category: "books",
+      priority: "low",
+      received: false,
+      createdAt: now,
+    },
   ]);
 
   // A couple of items that can be bought in more than one place. The item's own
@@ -1062,6 +1080,15 @@ async function seed() {
       labelRu: "Discogs, запечатанный",
       price: "$72",
       url: "https://www.discogs.com/sell/item/3742200592",
+      position: 0,
+    },
+    {
+      id: 4,
+      itemId: 73, // Tanenbaum — Computer Networks
+      label: "Pearson, Global Edition, English",
+      labelRu: "Pearson, Global Edition, на английском",
+      price: "$60.88",
+      url: "https://www.amazon.com/dp/1292374063",
       position: 0,
     },
   ]);

--- a/scripts/db/seed.ts
+++ b/scripts/db/seed.ts
@@ -1041,10 +1041,6 @@ async function seed() {
       price: "₸25,940",
       imageUrl: "tanenbaum-computer-networks.jpg",
       url: "https://www.meloman.kz/tanenbaum-je-s-fimster-n-komp-juternye-seti-6-e-izd.html",
-      description:
-        "The sixth edition. Physical layer up to applications, security chapter rewritten",
-      descriptionRu:
-        "Шестое издание. От физического уровня до прикладного, глава о безопасности переписана",
       category: "books",
       priority: "low",
       received: false,

--- a/src/styles/wishlist.css
+++ b/src/styles/wishlist.css
@@ -688,8 +688,15 @@
   line-height: 1.5;
 }
 
+/* The price never shrinks — it is nowrap, and a flex item's automatic minimum
+   size is its min-content, which for unwrappable text is the whole string — so
+   on a 280px column (the grid's floor) the squeeze lands entirely on the pill
+   and pushes it out through the card's padding. Let the row break instead: the
+   pill drops under the price and both stay whole. It is the shape the ≤768px
+   layout already stacks into, arrived at by content rather than by viewport. */
 .item-footer {
   display: flex;
+  flex-wrap: wrap;
   justify-content: space-between;
   align-items: center;
   margin-top: auto;
@@ -871,6 +878,9 @@
   display: flex;
   align-items: center;
   gap: 0.5rem;
+  /* Holds the pill at the right edge on a wrapped line too, where it is the
+     only thing on the row and space-between has nothing to push it against. */
+  margin-left: auto;
 }
 
 .message-btn {
@@ -1365,6 +1375,13 @@ textarea.message-popover-input:focus {
   .item-footer {
     flex-direction: column;
     align-items: stretch;
+  }
+
+  /* A cross-axis auto margin suppresses `align-items: stretch`, which is what
+     the stacked footer relies on — the pill has to span the card, not hug the
+     right edge. */
+  .reserve-actions {
+    margin-left: 0;
   }
 
   /* The stacked footer stretches .reserve-actions, not the pill inside it, so


### PR DESCRIPTION
The first wishlist item that is genuinely one gift from two shops: the Питер
translation at Meloman, and Pearson's Global Edition on Amazon as an
`ItemOption` beside it. Production had no `ItemOption` rows at all until now —
the multi-option work from #47 shipped without a live item exercising it.

## What's here

One entry in `scripts/db/seed.ts` — the item plus its option — so local
development matches production:

| | |
|---|---|
| title / titleRu | Andrew Tanenbaum — Computer Networks · Книга «Компьютерные сети», Эндрю Таненбаум |
| own price/url | ₸25,940 · meloman.kz (Питер, 6-е изд., ISBN 978-5-4461-1766-6) |
| option | "Pearson, Global Edition, English" · $60.88 · amazon.com/dp/1292374063 |
| category | books · priority low · weight 0 |

## The tenge price converts to nothing, on purpose

`parsePrice` has no `₸` prefix, so the Meloman price is stored as written and
sits out the cheapest-option comparison; the card's "from" falls back to the
Amazon price. That is what `getWishlistItems` already does with any currency it
has no rate for, so nothing had to change to accommodate it.

Adding KZT properly is more than a prefix: `ExchangeRate.rate` is an `integer`
holding whole roubles per unit, and one tenge is about a sixth of a rouble. That
needs a scaled or fractional column and a migration, which is its own change.

## Already applied outside this diff

- `WishlistItem` #73 and `ItemOption` #1 inserted into production Turso, ISR purged.
- Card image generated through `scripts/wishlist-images` and published to R2 as
  `wishlist/styled/073-…-v1-268afb30.jpg` with a dark twin. Rollback file is
  `out/rollback-1786122235125.json`.
- The cover original lives at the bucket root as `tanenbaum-computer-networks.jpg`,
  which is what the seed entry points at — same convention as the other books.

`astro check`: 0 errors.