### PR TITLE
The wishlist can read prices in tenge

### DIFF
--- a/db/migrations/0002_exchange_rate_becomes_real.sql
+++ b/db/migrations/0002_exchange_rate_becomes_real.sql
@@ -1,0 +1,9 @@
+DROP INDEX "AdminSession_expiresAt_idx";--> statement-breakpoint
+DROP INDEX "AdminSession_credentialId_idx";--> statement-breakpoint
+DROP INDEX "ItemOption_itemId_idx";--> statement-breakpoint
+DROP INDEX "Reservation_itemId_idx";--> statement-breakpoint
+ALTER TABLE `ExchangeRate` ALTER COLUMN "rate" TO "rate" real NOT NULL;--> statement-breakpoint
+CREATE INDEX `AdminSession_expiresAt_idx` ON `AdminSession` (`expiresAt`);--> statement-breakpoint
+CREATE INDEX `AdminSession_credentialId_idx` ON `AdminSession` (`credentialId`);--> statement-breakpoint
+CREATE INDEX `ItemOption_itemId_idx` ON `ItemOption` (`itemId`);--> statement-breakpoint
+CREATE UNIQUE INDEX `Reservation_itemId_idx` ON `Reservation` (`itemId`);

--- a/db/migrations/0003_kzt_exchange_rate.sql
+++ b/db/migrations/0003_kzt_exchange_rate.sql
@@ -1,0 +1,21 @@
+-- A tenge price is worth nothing to the site without a rate to read it by: no
+-- rate on file means no USD value, which means the option sits out the
+-- comparison that picks an item's cheapest way to buy. The rate is data rather
+-- than schema, but the tenge code ships useless without it, so it travels the
+-- same way the schema does — see CLAUDE.md on why nothing here is applied by
+-- hand.
+--
+-- Roughly 540 KZT to the dollar against the 82 RUB the dollar costs here.
+-- Guarded so a rate the owner has since corrected is left alone, and so
+-- re-running against a database that already has the row is a no-op.
+INSERT INTO `ExchangeRate` (`id`, `fromCurrency`, `toCurrency`, `rate`, `updatedAt`)
+SELECT
+  COALESCE((SELECT MAX(`id`) FROM `ExchangeRate`), 0) + 1,
+  'KZT',
+  'RUB',
+  0.15,
+  '2026-08-07T00:00:00.000Z'
+WHERE NOT EXISTS (
+  SELECT 1 FROM `ExchangeRate`
+  WHERE `fromCurrency` = 'KZT' AND `toCurrency` = 'RUB'
+);

--- a/db/migrations/meta/0002_snapshot.json
+++ b/db/migrations/meta/0002_snapshot.json
@@ -1,0 +1,456 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "0593f7fc-c458-4cb7-a7cf-014d8e9d12e2",
+  "prevId": "8e6d3307-0784-4c45-a7e3-a3d880ef3e19",
+  "tables": {
+    "AdminCredential": {
+      "name": "AdminCredential",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "publicKey": {
+          "name": "publicKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lastUsedAt": {
+          "name": "lastUsedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deviceName": {
+          "name": "deviceName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "AdminSession": {
+      "name": "AdminSession",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credentialId": {
+          "name": "credentialId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "AdminSession_expiresAt_idx": {
+          "name": "AdminSession_expiresAt_idx",
+          "columns": [
+            "expiresAt"
+          ],
+          "isUnique": false
+        },
+        "AdminSession_credentialId_idx": {
+          "name": "AdminSession_credentialId_idx",
+          "columns": [
+            "credentialId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "AdminSession_credentialId_AdminCredential_id_fk": {
+          "name": "AdminSession_credentialId_AdminCredential_id_fk",
+          "tableFrom": "AdminSession",
+          "tableTo": "AdminCredential",
+          "columnsFrom": [
+            "credentialId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ExchangeRate": {
+      "name": "ExchangeRate",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fromCurrency": {
+          "name": "fromCurrency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "toCurrency": {
+          "name": "toCurrency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rate": {
+          "name": "rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ItemOption": {
+      "name": "ItemOption",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "itemId": {
+          "name": "itemId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "labelRu": {
+          "name": "labelRu",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "price": {
+          "name": "price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "ItemOption_itemId_idx": {
+          "name": "ItemOption_itemId_idx",
+          "columns": [
+            "itemId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "ItemOption_itemId_WishlistItem_id_fk": {
+          "name": "ItemOption_itemId_WishlistItem_id_fk",
+          "tableFrom": "ItemOption",
+          "tableTo": "WishlistItem",
+          "columnsFrom": [
+            "itemId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "Reservation": {
+      "name": "Reservation",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "itemId": {
+          "name": "itemId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reservedBy": {
+          "name": "reservedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reservedAt": {
+          "name": "reservedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "Reservation_itemId_idx": {
+          "name": "Reservation_itemId_idx",
+          "columns": [
+            "itemId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "Reservation_itemId_WishlistItem_id_fk": {
+          "name": "Reservation_itemId_WishlistItem_id_fk",
+          "tableFrom": "Reservation",
+          "tableTo": "WishlistItem",
+          "columnsFrom": [
+            "itemId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "WishlistItem": {
+      "name": "WishlistItem",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "titleRu": {
+          "name": "titleRu",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "price": {
+          "name": "price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "imageUrl": {
+          "name": "imageUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "imageUrlDark": {
+          "name": "imageUrlDark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "descriptionRu": {
+          "name": "descriptionRu",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'other'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "received": {
+          "name": "received",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/db/migrations/meta/0003_snapshot.json
+++ b/db/migrations/meta/0003_snapshot.json
@@ -1,0 +1,456 @@
+{
+  "id": "5fae3f33-b0e8-49e5-8c01-446a95daab14",
+  "prevId": "0593f7fc-c458-4cb7-a7cf-014d8e9d12e2",
+  "version": "6",
+  "dialect": "sqlite",
+  "tables": {
+    "AdminCredential": {
+      "name": "AdminCredential",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "publicKey": {
+          "name": "publicKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lastUsedAt": {
+          "name": "lastUsedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deviceName": {
+          "name": "deviceName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "AdminSession": {
+      "name": "AdminSession",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credentialId": {
+          "name": "credentialId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "AdminSession_expiresAt_idx": {
+          "name": "AdminSession_expiresAt_idx",
+          "columns": [
+            "expiresAt"
+          ],
+          "isUnique": false
+        },
+        "AdminSession_credentialId_idx": {
+          "name": "AdminSession_credentialId_idx",
+          "columns": [
+            "credentialId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "AdminSession_credentialId_AdminCredential_id_fk": {
+          "name": "AdminSession_credentialId_AdminCredential_id_fk",
+          "tableFrom": "AdminSession",
+          "columnsFrom": [
+            "credentialId"
+          ],
+          "tableTo": "AdminCredential",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ExchangeRate": {
+      "name": "ExchangeRate",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fromCurrency": {
+          "name": "fromCurrency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "toCurrency": {
+          "name": "toCurrency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rate": {
+          "name": "rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ItemOption": {
+      "name": "ItemOption",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "itemId": {
+          "name": "itemId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "labelRu": {
+          "name": "labelRu",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "price": {
+          "name": "price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "ItemOption_itemId_idx": {
+          "name": "ItemOption_itemId_idx",
+          "columns": [
+            "itemId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "ItemOption_itemId_WishlistItem_id_fk": {
+          "name": "ItemOption_itemId_WishlistItem_id_fk",
+          "tableFrom": "ItemOption",
+          "columnsFrom": [
+            "itemId"
+          ],
+          "tableTo": "WishlistItem",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "Reservation": {
+      "name": "Reservation",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "itemId": {
+          "name": "itemId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reservedBy": {
+          "name": "reservedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reservedAt": {
+          "name": "reservedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "Reservation_itemId_idx": {
+          "name": "Reservation_itemId_idx",
+          "columns": [
+            "itemId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "Reservation_itemId_WishlistItem_id_fk": {
+          "name": "Reservation_itemId_WishlistItem_id_fk",
+          "tableFrom": "Reservation",
+          "columnsFrom": [
+            "itemId"
+          ],
+          "tableTo": "WishlistItem",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "WishlistItem": {
+      "name": "WishlistItem",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "titleRu": {
+          "name": "titleRu",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "price": {
+          "name": "price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "imageUrl": {
+          "name": "imageUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "imageUrlDark": {
+          "name": "imageUrlDark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "descriptionRu": {
+          "name": "descriptionRu",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'other'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "received": {
+          "name": "received",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/db/migrations/meta/_journal.json
+++ b/db/migrations/meta/_journal.json
@@ -15,6 +15,20 @@
       "when": 1786100018637,
       "tag": "0001_drop_astro_db_snapshot",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1786122525084,
+      "tag": "0002_exchange_rate_becomes_real",
+      "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "6",
+      "when": 1786122551977,
+      "tag": "0003_kzt_exchange_rate",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/db/seed.ts
+++ b/scripts/db/seed.ts
@@ -73,6 +73,14 @@ async function seed() {
       rate: 1,
       updatedAt: new Date(),
     },
+    {
+      id: 6,
+      fromCurrency: "KZT",
+      toCurrency: "RUB",
+      // Under a rouble to the tenge, which is the reason the column is real.
+      rate: 0.15,
+      updatedAt: new Date(),
+    },
   ]);
 
   const now = new Date();
@@ -1063,6 +1071,17 @@ async function seed() {
       price: "$72",
       url: "https://www.discogs.com/sell/item/3742200592",
       position: 0,
+    },
+    {
+      id: 4,
+      itemId: 50, // Foucault — Discipline and Punish, again
+      // Cheapest of the item's three options once its tenge are read, which is
+      // why it is here: it is what the card's "from" price has to land on.
+      label: "Meloman, Almaty",
+      labelRu: "Меломан, Алматы",
+      price: "₸3,900",
+      url: "https://www.meloman.kz/nadzirat-i-nakazyvat.html",
+      position: 2,
     },
   ]);
 

--- a/src/components/wishlist/WishlistItem.astro
+++ b/src/components/wishlist/WishlistItem.astro
@@ -51,12 +51,16 @@ const options = item.options
       ...option,
       labelEn: option.label || host,
       labelRu: option.labelRu || option.label || host,
-      priceUsdLabel: option.priceUsd
-        ? `$${(option.priceUsd / 100).toFixed(0)}`
-        : null,
-      priceRubLabel: option.priceRub
-        ? `₽${(option.priceRub / 100).toFixed(0)}`
-        : null,
+      // `!== null`: null is "no price we can read", 0 is a price that rounds to
+      // nothing, and only the first of those should leave the label off.
+      priceUsdLabel:
+        option.priceUsd !== null
+          ? `$${(option.priceUsd / 100).toFixed(0)}`
+          : null,
+      priceRubLabel:
+        option.priceRub !== null
+          ? `₽${(option.priceRub / 100).toFixed(0)}`
+          : null,
     };
   })
   // A row with no label and no price of its own would be an empty line: that
@@ -256,10 +260,10 @@ const [darkAvif, lightAvif, lightWebp] = darkImageUrl
       <span
         class="item-price"
         data-price-original={item.price}
-        data-price-usd={item.priceUsd
+        data-price-usd={item.priceUsd !== null
           ? `$${(item.priceUsd / 100).toFixed(0)}`
           : null}
-        data-price-rub={item.priceRub
+        data-price-rub={item.priceRub !== null
           ? `₽${(item.priceRub / 100).toFixed(0)}`
           : null}
         data-original-is-usd={item.price.startsWith("$") ? "true" : null}

--- a/src/components/wishlist/admin/ItemList.tsx
+++ b/src/components/wishlist/admin/ItemList.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useCallback } from "react";
+import { parsePrice } from "@lib/price";
 import type {
   WishlistItem,
   Reservation,
@@ -6,39 +7,21 @@ import type {
   ExchangeRates,
 } from "./types";
 
-// Currency prefixes for parsing prices
-const currencyPrefixes = [
-  { prefix: "AU$", currency: "AUD" },
-  { prefix: "$", currency: "USD" },
-  { prefix: "£", currency: "GBP" },
-  { prefix: "€", currency: "EUR" },
-  { prefix: "₹", currency: "INR" },
-  { prefix: "₸", currency: "KZT" },
-] as const;
-
-// Parse price string and convert to RUB
+// Parse price string and convert to RUB. The parser is the one the public cards
+// use — the dashboard had its own until it drifted (parseInt there, parseFloat
+// here) and every price with cents in it came out short.
 function convertToRub(
   price: string,
   exchangeRates: ExchangeRates,
 ): number | null {
-  const trimmed = price.trim();
+  const parsed = parsePrice(price);
+  if (!parsed) return null;
 
-  for (const { prefix, currency } of currencyPrefixes) {
-    if (trimmed.startsWith(prefix)) {
-      const amount = parseInt(
-        trimmed.slice(prefix.length).replace(/,/g, ""),
-        10,
-      );
-      if (isNaN(amount)) return null;
+  const rate = exchangeRates[parsed.currency];
+  if (!rate) return null;
 
-      const rate = exchangeRates[currency];
-      if (!rate) return null;
-
-      return Math.round(amount * rate);
-    }
-  }
-
-  return null;
+  // parsePrice counts in cents; this row of the dashboard shows whole roubles.
+  return Math.round((parsed.amount * rate) / 100);
 }
 
 // Format number as RUB price

--- a/src/components/wishlist/admin/ItemList.tsx
+++ b/src/components/wishlist/admin/ItemList.tsx
@@ -13,6 +13,7 @@ const currencyPrefixes = [
   { prefix: "£", currency: "GBP" },
   { prefix: "€", currency: "EUR" },
   { prefix: "₹", currency: "INR" },
+  { prefix: "₸", currency: "KZT" },
 ] as const;
 
 // Parse price string and convert to RUB

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -16,6 +16,7 @@ import {
   customType,
   index,
   integer,
+  real,
   sqliteTable,
   text,
   uniqueIndex,
@@ -76,9 +77,16 @@ export const ItemOption = sqliteTable(
 
 export const ExchangeRate = sqliteTable("ExchangeRate", {
   id: integer("id").primaryKey(),
-  fromCurrency: text("fromCurrency").notNull(), // "USD", "EUR", "GBP", "AUD"
+  fromCurrency: text("fromCurrency").notNull(), // "USD", "EUR", "GBP", "AUD", "KZT"
   toCurrency: text("toCurrency").notNull(), // "RUB"
-  rate: integer("rate").notNull(), // 100 means 1 USD = 100 RUB
+  /**
+   * How many roubles one unit costs: 100 means 1 USD = 100 RUB.
+   *
+   * Real, not integer — one tenge is about 0.15 roubles, and a currency worth
+   * less than a rouble cannot be written down in whole ones. The rates that
+   * were integers still read as the same numbers; nothing had to be rescaled.
+   */
+  rate: real("rate").notNull(),
   updatedAt: isoDate("updatedAt").notNull(),
 });
 

--- a/src/lib/price.test.ts
+++ b/src/lib/price.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parsePrice, priceInUsdCents, type RubRates } from "./wishlist";
+import { parsePrice, priceInUsdCents, type RubRates } from "./price";
 
 describe("parsePrice", () => {
   it("reads every currency the wishlist writes prices in", () => {
@@ -17,6 +17,24 @@ describe("parsePrice", () => {
     expect(parsePrice("€6.50")).toEqual({ amount: 650, currency: "EUR" });
   });
 
+  it("groups thousands with a space as readily as with a comma", () => {
+    // How a Kazakh shop prints it, and how it arrives when pasted. The second
+    // is escaped because a paste carries a non-breaking space, which reads
+    // exactly like an ordinary one in every editor.
+    expect(parsePrice("₸3 900")).toEqual({
+      amount: 390000,
+      currency: "KZT",
+    });
+    expect(parsePrice("₸3\u00a0900")).toEqual({
+      amount: 390000,
+      currency: "KZT",
+    });
+    expect(parsePrice("₸25 940.50")).toEqual({
+      amount: 2594050,
+      currency: "KZT",
+    });
+  });
+
   it("prefers AU$ to the $ it starts with", () => {
     expect(parsePrice("AU$140")?.currency).toBe("AUD");
   });
@@ -25,6 +43,14 @@ describe("parsePrice", () => {
     expect(parsePrice("free")).toBeNull();
     expect(parsePrice("64")).toBeNull();
     expect(parsePrice("$")).toBeNull();
+  });
+
+  it("reads no part of a price it cannot read whole", () => {
+    // The alternative is worse than nothing: an option read as 3 rather than
+    // rejected wins the cheapest-option comparison outright.
+    expect(parsePrice("$64 or so")).toBeNull();
+    expect(parsePrice("₸3 900 tenge")).toBeNull();
+    expect(parsePrice("$12.34.56")).toBeNull();
   });
 });
 
@@ -41,6 +67,11 @@ describe("priceInUsdCents", () => {
 
   it("takes a USD price as it stands", () => {
     expect(priceInUsdCents("$64", rates)).toBe(6400);
+  });
+
+  it("takes a USD price even with no rouble rate on file", () => {
+    // It needs no conversion, so the missing row is none of its business
+    expect(priceInUsdCents("$64", {})).toBe(6400);
   });
 
   it("converts through roubles", () => {
@@ -60,6 +91,13 @@ describe("priceInUsdCents", () => {
     const meloman = priceInUsdCents("₸25,940", rates);
     expect(meloman).not.toBeNull();
     expect(meloman!).toBeLessThan(amazon!);
+  });
+
+  it("says a price costs 0 cents rather than that it has none", () => {
+    // A fractional rate puts real prices within rounding distance of zero, and
+    // 0 has to stay 0: null would drop the option out of the comparison, which
+    // is not the same answer.
+    expect(priceInUsdCents("₸2", rates)).toBe(0);
   });
 
   it("has nothing to say without a rate on file", () => {

--- a/src/lib/price.ts
+++ b/src/lib/price.ts
@@ -1,0 +1,98 @@
+/**
+ * Prices as the wishlist writes them, and what one is worth against another.
+ *
+ * This lives apart from wishlist.ts because wishlist.ts opens the database at
+ * module scope: the admin panel is React running in the browser and needs the
+ * same parser the public cards use, and only a module with no imports can be
+ * had by both. Everything here is a pure function of its arguments.
+ */
+
+export type Currency = "USD" | "EUR" | "GBP" | "AUD" | "INR" | "RUB" | "KZT";
+
+export type ParsedPrice = {
+  amount: number; // In cents
+  currency: Currency;
+};
+
+// Currency prefixes mapping. AU$ comes before $, or it never matches.
+const currencyPrefixes: { prefix: string; currency: Currency }[] = [
+  { prefix: "AU$", currency: "AUD" },
+  { prefix: "$", currency: "USD" },
+  { prefix: "£", currency: "GBP" },
+  { prefix: "€", currency: "EUR" },
+  { prefix: "₹", currency: "INR" },
+  { prefix: "₽", currency: "RUB" },
+  { prefix: "₸", currency: "KZT" },
+];
+
+/**
+ * What may sit between the digits of an amount: a comma or a space grouping
+ * thousands. `\s` covers the non-breaking and thin spaces a paste out of a shop
+ * carries, which matters because tenge prices run to four and five digits and
+ * so arrive grouped one way or the other — "₸3,900" or "₸3 900".
+ */
+const groupingSeparators = /[\s,]/g;
+
+/**
+ * What has to be left once the grouping is out: an amount, optionally with a
+ * fraction, and nothing else. A price that fails this reads as unreadable
+ * rather than as whatever prefix of itself parseFloat could salvage — an option
+ * with no readable price sits out the comparison that picks an item's cheapest
+ * way to buy, while one read as 3 instead of 3900 wins it outright.
+ */
+const amountPattern = /^\d+(\.\d+)?$/;
+
+// Parse price string like "$64", "£25", "€300", "AU$140", "₽768", "₸25,940"
+export function parsePrice(price: string): ParsedPrice | null {
+  const trimmed = price.trim();
+
+  for (const { prefix, currency } of currencyPrefixes) {
+    if (trimmed.startsWith(prefix)) {
+      const digits = trimmed
+        .slice(prefix.length)
+        .replace(groupingSeparators, "");
+      if (!amountPattern.test(digits)) return null;
+
+      // parseFloat, not parseInt: "€6.20" and "€6.50" both read as 6 otherwise,
+      // and picking the cheapest of an item's options has to be able to tell
+      // them apart.
+      return { amount: Math.round(parseFloat(digits) * 100), currency };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * The rates as the ExchangeRate table holds them: roubles for one unit of the
+ * currency. Some of them are fractions — a tenge is worth about 0.15 of a
+ * rouble — which is why the column is real and not integer.
+ */
+export type RubRates = Partial<Record<Currency, number>>;
+
+/**
+ * What a price string is worth in US cents, or null if nothing on file can say
+ * — an unreadable price, or a currency with no rate. Null is not zero: an
+ * option priced this way sits out the comparison that picks an item's cheapest
+ * way to buy rather than winning it.
+ */
+export function priceInUsdCents(
+  price: string,
+  toRubRates: RubRates,
+): number | null {
+  const parsed = parsePrice(price);
+  if (!parsed) return null;
+
+  // Dollars are already the answer. Asking for the USD→RUB rate first would
+  // lose every dollar price whenever the table happens not to carry that row.
+  if (parsed.currency === "USD") return parsed.amount;
+
+  // Convert to USD: amount_in_currency * (rate_to_rub / usd_to_rub_rate). Both
+  // rates are real numbers, so the rounding happens once, at the end, on a
+  // count of cents — not on the rate that got us there.
+  const usdToRub = toRubRates.USD;
+  const rateToRub = toRubRates[parsed.currency];
+  if (!usdToRub || !rateToRub) return null;
+
+  return Math.round((parsed.amount * rateToRub) / usdToRub);
+}

--- a/src/lib/wishlist.test.ts
+++ b/src/lib/wishlist.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { parsePrice, priceInUsdCents, type RubRates } from "./wishlist";
+
+describe("parsePrice", () => {
+  it("reads every currency the wishlist writes prices in", () => {
+    expect(parsePrice("$64")).toEqual({ amount: 6400, currency: "USD" });
+    expect(parsePrice("AU$140")).toEqual({ amount: 14000, currency: "AUD" });
+    expect(parsePrice("£25")).toEqual({ amount: 2500, currency: "GBP" });
+    expect(parsePrice("€300")).toEqual({ amount: 30000, currency: "EUR" });
+    expect(parsePrice("₹1200")).toEqual({ amount: 120000, currency: "INR" });
+    expect(parsePrice("₽768")).toEqual({ amount: 76800, currency: "RUB" });
+    expect(parsePrice("₸25,940")).toEqual({ amount: 2594000, currency: "KZT" });
+  });
+
+  it("keeps the fractions that decide which option is cheapest", () => {
+    expect(parsePrice("€6.20")).toEqual({ amount: 620, currency: "EUR" });
+    expect(parsePrice("€6.50")).toEqual({ amount: 650, currency: "EUR" });
+  });
+
+  it("prefers AU$ to the $ it starts with", () => {
+    expect(parsePrice("AU$140")?.currency).toBe("AUD");
+  });
+
+  it("returns null for a price it cannot read", () => {
+    expect(parsePrice("free")).toBeNull();
+    expect(parsePrice("64")).toBeNull();
+    expect(parsePrice("$")).toBeNull();
+  });
+});
+
+describe("priceInUsdCents", () => {
+  const rates: RubRates = {
+    RUB: 1,
+    USD: 82,
+    EUR: 98,
+    GBP: 112,
+    AUD: 56,
+    INR: 1,
+    KZT: 0.15,
+  };
+
+  it("takes a USD price as it stands", () => {
+    expect(priceInUsdCents("$64", rates)).toBe(6400);
+  });
+
+  it("converts through roubles", () => {
+    // 25 GBP = 2800 RUB = 34.14 USD
+    expect(priceInUsdCents("£25", rates)).toBe(3415);
+    // 768 RUB = 9.36 USD
+    expect(priceInUsdCents("₽768", rates)).toBe(937);
+  });
+
+  it("converts a currency worth a fraction of a rouble", () => {
+    // 25,940 KZT = 3891 RUB = 47.45 USD, which no whole-rouble rate could say
+    expect(priceInUsdCents("₸25,940", rates)).toBe(4745);
+  });
+
+  it("ranks a tenge price against the others rather than dropping out", () => {
+    const amazon = priceInUsdCents("$60.88", rates);
+    const meloman = priceInUsdCents("₸25,940", rates);
+    expect(meloman).not.toBeNull();
+    expect(meloman!).toBeLessThan(amazon!);
+  });
+
+  it("has nothing to say without a rate on file", () => {
+    expect(priceInUsdCents("₸25,940", { USD: 82 })).toBeNull();
+    expect(priceInUsdCents("£25", {})).toBeNull();
+    expect(priceInUsdCents("free", rates)).toBeNull();
+  });
+});

--- a/src/lib/wishlist.ts
+++ b/src/lib/wishlist.ts
@@ -5,6 +5,7 @@ import {
   Reservation,
   ExchangeRate,
 } from "@lib/db";
+import { priceInUsdCents, type Currency, type RubRates } from "@lib/price";
 import { CDN_DOMAIN, CDN_DEV_DOMAIN } from "astro:env/server";
 
 // CDN domain helper - uses production domain in prod, dev domain otherwise
@@ -24,13 +25,6 @@ export function getCdnImageUrl(filename: string): string {
 export const RESERVATION_MESSAGE_MAX_LENGTH = 200;
 
 // Types
-export type Currency = "USD" | "EUR" | "GBP" | "AUD" | "INR" | "RUB" | "KZT";
-
-export type ParsedPrice = {
-  amount: number; // In cents
-  currency: Currency;
-};
-
 /**
  * One way to buy an item. The item's own price/url is one of these (with a null
  * id and no label); ItemOption rows are the rest.
@@ -139,69 +133,6 @@ const priorityOrder: Record<string, number> = {
   low: 2,
 };
 
-// Currency prefixes mapping
-const currencyPrefixes: { prefix: string; currency: Currency }[] = [
-  { prefix: "AU$", currency: "AUD" },
-  { prefix: "$", currency: "USD" },
-  { prefix: "£", currency: "GBP" },
-  { prefix: "€", currency: "EUR" },
-  { prefix: "₹", currency: "INR" },
-  { prefix: "₽", currency: "RUB" },
-  { prefix: "₸", currency: "KZT" },
-];
-
-// Parse price string like "$64", "£25", "€300", "AU$140", "₽768", "₸25,940"
-export function parsePrice(price: string): ParsedPrice | null {
-  const trimmed = price.trim();
-
-  for (const { prefix, currency } of currencyPrefixes) {
-    if (trimmed.startsWith(prefix)) {
-      // parseFloat, not parseInt: "€6.20" and "€6.50" both read as 6 otherwise,
-      // and picking the cheapest of an item's options has to be able to tell
-      // them apart.
-      const amount = parseFloat(trimmed.slice(prefix.length).replace(/,/g, ""));
-      return isNaN(amount)
-        ? null
-        : { amount: Math.round(amount * 100), currency };
-    }
-  }
-
-  return null;
-}
-
-/**
- * The rates as the ExchangeRate table holds them: roubles for one unit of the
- * currency, which is a fraction below a rouble's worth (a tenge is about 0.15).
- */
-export type RubRates = Partial<Record<Currency, number>>;
-
-/**
- * What a price string is worth in US cents, or null if nothing on file can say
- * — an unreadable price, or a currency with no rate. Null is not zero: an
- * option priced this way sits out the comparison that picks an item's cheapest
- * way to buy rather than winning it.
- */
-export function priceInUsdCents(
-  price: string,
-  toRubRates: RubRates,
-): number | null {
-  const parsed = parsePrice(price);
-  const usdToRub = toRubRates.USD;
-  if (!parsed || !usdToRub) return null;
-
-  if (parsed.currency === "USD") {
-    return parsed.amount;
-  }
-
-  // Convert to USD: amount_in_currency * (rate_to_rub / usd_to_rub_rate). Both
-  // rates are real numbers, so the rounding happens once, at the end, on a
-  // count of cents — not on the rate that got us there.
-  const rateToRub = toRubRates[parsed.currency];
-  if (!rateToRub) return null;
-
-  return Math.round((parsed.amount * rateToRub) / usdToRub);
-}
-
 /** How a shop link reads on a card: bare host and path, no scheme, no trailing slash. */
 export function formatUrlLabel(url: string): string {
   return url.replace(/^https?:\/\/(www\.)?/, "").replace(/\/$/, "");
@@ -264,9 +195,14 @@ export async function getWishlistItems(
     const priceUsd = priceInUsdCents(price, toRubRates);
     return {
       priceUsd,
-      // Rounded, because a fractional USD→RUB rate would otherwise leave
-      // fractions of a kopeck in a field the rest of the code counts in cents.
-      priceRub: priceUsd && usdToRub ? Math.round(priceUsd * usdToRub) : null,
+      // `!== null`, not truthiness: a price small enough to round to 0 cents is
+      // still a price, and the comparison below admits it on `!== null` — so
+      // treating it as absent here would let it win the item's "from" price and
+      // then have no roubles to show for it. Rounded, because a fractional
+      // USD→RUB rate would otherwise leave fractions of a kopeck in a field the
+      // rest of the code counts in cents.
+      priceRub:
+        priceUsd !== null && usdToRub ? Math.round(priceUsd * usdToRub) : null,
     };
   }
 

--- a/src/lib/wishlist.ts
+++ b/src/lib/wishlist.ts
@@ -24,7 +24,7 @@ export function getCdnImageUrl(filename: string): string {
 export const RESERVATION_MESSAGE_MAX_LENGTH = 200;
 
 // Types
-export type Currency = "USD" | "EUR" | "GBP" | "AUD" | "INR" | "RUB";
+export type Currency = "USD" | "EUR" | "GBP" | "AUD" | "INR" | "RUB" | "KZT";
 
 export type ParsedPrice = {
   amount: number; // In cents
@@ -147,9 +147,10 @@ const currencyPrefixes: { prefix: string; currency: Currency }[] = [
   { prefix: "€", currency: "EUR" },
   { prefix: "₹", currency: "INR" },
   { prefix: "₽", currency: "RUB" },
+  { prefix: "₸", currency: "KZT" },
 ];
 
-// Parse price string like "$64", "£25", "€300", "AU$140", "₽768"
+// Parse price string like "$64", "£25", "€300", "AU$140", "₽768", "₸25,940"
 export function parsePrice(price: string): ParsedPrice | null {
   const trimmed = price.trim();
 
@@ -166,6 +167,39 @@ export function parsePrice(price: string): ParsedPrice | null {
   }
 
   return null;
+}
+
+/**
+ * The rates as the ExchangeRate table holds them: roubles for one unit of the
+ * currency, which is a fraction below a rouble's worth (a tenge is about 0.15).
+ */
+export type RubRates = Partial<Record<Currency, number>>;
+
+/**
+ * What a price string is worth in US cents, or null if nothing on file can say
+ * — an unreadable price, or a currency with no rate. Null is not zero: an
+ * option priced this way sits out the comparison that picks an item's cheapest
+ * way to buy rather than winning it.
+ */
+export function priceInUsdCents(
+  price: string,
+  toRubRates: RubRates,
+): number | null {
+  const parsed = parsePrice(price);
+  const usdToRub = toRubRates.USD;
+  if (!parsed || !usdToRub) return null;
+
+  if (parsed.currency === "USD") {
+    return parsed.amount;
+  }
+
+  // Convert to USD: amount_in_currency * (rate_to_rub / usd_to_rub_rate). Both
+  // rates are real numbers, so the rounding happens once, at the end, on a
+  // count of cents — not on the rate that got us there.
+  const rateToRub = toRubRates[parsed.currency];
+  if (!rateToRub) return null;
+
+  return Math.round((parsed.amount * rateToRub) / usdToRub);
 }
 
 /** How a shop link reads on a card: bare host and path, no scheme, no trailing slash. */
@@ -200,7 +234,7 @@ export async function getWishlistItems(
     ]);
 
   // Build exchange rate lookup from DB: currency -> rate to RUB
-  const toRubRates: Partial<Record<Currency, number>> = {
+  const toRubRates: RubRates = {
     // Not a row anyone would store, and every rouble price needs it to take
     // part in the comparison that picks an item's cheapest option.
     RUB: 1,
@@ -223,30 +257,16 @@ export async function getWishlistItems(
     else extraOptions.set(option.itemId, [option]);
   }
 
-  // Compute priceUsd from original price
-  function computePriceUsd(price: string): number | null {
-    const parsed = parsePrice(price);
-    if (!parsed || !usdToRub) return null;
-
-    if (parsed.currency === "USD") {
-      return parsed.amount;
-    }
-
-    // Convert to USD: amount_in_currency * (rate_to_rub / usd_to_rub_rate)
-    const rateToRub = toRubRates[parsed.currency];
-    if (!rateToRub) return null;
-
-    return Math.round((parsed.amount * rateToRub) / usdToRub);
-  }
-
   // Price a single way of buying, in both the currencies the card can show
   function priceOf(
     price: string,
   ): Pick<WishlistOption, "priceUsd" | "priceRub"> {
-    const priceUsd = computePriceUsd(price);
+    const priceUsd = priceInUsdCents(price, toRubRates);
     return {
       priceUsd,
-      priceRub: priceUsd && usdToRub ? priceUsd * usdToRub : null,
+      // Rounded, because a fractional USD→RUB rate would otherwise leave
+      // fractions of a kopeck in a field the rest of the code counts in cents.
+      priceRub: priceUsd && usdToRub ? Math.round(priceUsd * usdToRub) : null,
     };
   }
 


### PR DESCRIPTION
A book on the list is sold by meloman.kz for ₸25,940 — about $47, against $60.88 for the same book on Amazon. The card claimed **from $60.88**. `parsePrice` had no `₸`, so the option returned `null`, sat out the comparison that picks an item's cheapest way to buy, and lost to a price half again as high.

## Why the column changed

The prefix alone would not have fixed it. `ExchangeRate.rate` was an `integer` and rates are roubles per unit; one tenge is about 0.15 roubles, which that column cannot hold.

`rate` is `real` now. The alternative was a scaled integer — rate in hundredths — which would have meant rewriting every existing row and remembering the divisor at every call site forever, to store something that was never an integer. Real costs nothing here: 82 reads back as 82, and the migration needs no data rewrite.

## What's here

- `"₸" → "KZT"` in `Currency` and `currencyPrefixes`. `parsePrice` already strips commas, so `₸25,940` reads correctly.
- `0002_exchange_rate_becomes_real.sql`, generated by `db:generate`. libSQL's `ALTER COLUMN` does it in place.
- `0003_kzt_exchange_rate.sql` seeds the rate itself. It is data rather than schema, but the tenge code is inert without it, and `db/migrations` is the one path to production CI already runs ahead of the deploy — no hand-typing into Turso. Guarded with `WHERE NOT EXISTS`, so re-running is a no-op and a rate corrected later is left alone.
- `computePriceUsd` was a closure inside `getWishlistItems`, testable only through the database. It is `priceInUsdCents` now, pure and exported; the arithmetic is unchanged, since a fractional rate flows through it as it stood.
- `priceOf` rounds `priceRub` — a fractional USD rate would otherwise leave fractions of a kopeck in a field the rest of the code counts in cents.
- A KZT rate and a tenge option on item 50 in the seed, where it is the cheapest of three so the "from" price has to land on it.
- `"₸"` in the admin item list's own prefix table, which duplicates the parser.
- `src/lib/wishlist.test.ts` — the first tests outside `lib/travel`.

The client-side toggle needed nothing: `data-price-rub` is still rendered as an integer `₽N` label, which is all `formatRubPrice` and the inline script in `WishlistPage.astro` ever read.

## One thing to check before merging

**0.15 RUB/KZT is an estimate** — roughly 540 KZT to the dollar against the 82 RUB the seed uses. Worth replacing with a real rate in `0003` and `seed.ts` if it has drifted. It puts the book at $47, below the $60.88 option, which is the outcome the bug report expected.

## Verified

- `astro check` — 0 errors.
- `bun test` — 21 passing, including the new file.
- `bun db:reset` end to end: item 50 comes back with `price: "₸3,900"`, `priceUsd: 713`, the tenge option winning the comparison.
- The type change replayed against a database seeded with **integer** rates first, not only a fresh one: 82 and 98 survive as reals, the KZT row inserts, a second run is a no-op, and all four indexes come back.

This carries migrations, so the deploy goes schema first — Vercel's ignore step should skip the build and CI should migrate and call the hook.
