### PR TITLE
A price reads the same on a card and in the dashboard

### DIFF
--- a/src/components/wishlist/WishlistItem.astro
+++ b/src/components/wishlist/WishlistItem.astro
@@ -51,12 +51,16 @@ const options = item.options
       ...option,
       labelEn: option.label || host,
       labelRu: option.labelRu || option.label || host,
-      priceUsdLabel: option.priceUsd
-        ? `$${(option.priceUsd / 100).toFixed(0)}`
-        : null,
-      priceRubLabel: option.priceRub
-        ? `₽${(option.priceRub / 100).toFixed(0)}`
-        : null,
+      // `!== null`: null is "no price we can read", 0 is a price that rounds to
+      // nothing, and only the first of those should leave the label off.
+      priceUsdLabel:
+        option.priceUsd !== null
+          ? `$${(option.priceUsd / 100).toFixed(0)}`
+          : null,
+      priceRubLabel:
+        option.priceRub !== null
+          ? `₽${(option.priceRub / 100).toFixed(0)}`
+          : null,
     };
   })
   // A row with no label and no price of its own would be an empty line: that
@@ -256,10 +260,10 @@ const [darkAvif, lightAvif, lightWebp] = darkImageUrl
       <span
         class="item-price"
         data-price-original={item.price}
-        data-price-usd={item.priceUsd
+        data-price-usd={item.priceUsd !== null
           ? `$${(item.priceUsd / 100).toFixed(0)}`
           : null}
-        data-price-rub={item.priceRub
+        data-price-rub={item.priceRub !== null
           ? `₽${(item.priceRub / 100).toFixed(0)}`
           : null}
         data-original-is-usd={item.price.startsWith("$") ? "true" : null}

--- a/src/components/wishlist/admin/ItemList.tsx
+++ b/src/components/wishlist/admin/ItemList.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useCallback } from "react";
+import { parsePrice } from "@lib/price";
 import type {
   WishlistItem,
   Reservation,
@@ -6,39 +7,21 @@ import type {
   ExchangeRates,
 } from "./types";
 
-// Currency prefixes for parsing prices
-const currencyPrefixes = [
-  { prefix: "AU$", currency: "AUD" },
-  { prefix: "$", currency: "USD" },
-  { prefix: "£", currency: "GBP" },
-  { prefix: "€", currency: "EUR" },
-  { prefix: "₹", currency: "INR" },
-  { prefix: "₸", currency: "KZT" },
-] as const;
-
-// Parse price string and convert to RUB
+// Parse price string and convert to RUB. The parser is the one the public cards
+// use — the dashboard had its own until it drifted (parseInt there, parseFloat
+// here) and every price with cents in it came out short.
 function convertToRub(
   price: string,
   exchangeRates: ExchangeRates,
 ): number | null {
-  const trimmed = price.trim();
+  const parsed = parsePrice(price);
+  if (!parsed) return null;
 
-  for (const { prefix, currency } of currencyPrefixes) {
-    if (trimmed.startsWith(prefix)) {
-      const amount = parseInt(
-        trimmed.slice(prefix.length).replace(/,/g, ""),
-        10,
-      );
-      if (isNaN(amount)) return null;
+  const rate = exchangeRates[parsed.currency];
+  if (!rate) return null;
 
-      const rate = exchangeRates[currency];
-      if (!rate) return null;
-
-      return Math.round(amount * rate);
-    }
-  }
-
-  return null;
+  // parsePrice counts in cents; this row of the dashboard shows whole roubles.
+  return Math.round((parsed.amount * rate) / 100);
 }
 
 // Format number as RUB price

--- a/src/lib/price.test.ts
+++ b/src/lib/price.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parsePrice, priceInUsdCents, type RubRates } from "./wishlist";
+import { parsePrice, priceInUsdCents, type RubRates } from "./price";
 
 describe("parsePrice", () => {
   it("reads every currency the wishlist writes prices in", () => {
@@ -17,6 +17,24 @@ describe("parsePrice", () => {
     expect(parsePrice("€6.50")).toEqual({ amount: 650, currency: "EUR" });
   });
 
+  it("groups thousands with a space as readily as with a comma", () => {
+    // How a Kazakh shop prints it, and how it arrives when pasted. The second
+    // is escaped because a paste carries a non-breaking space, which reads
+    // exactly like an ordinary one in every editor.
+    expect(parsePrice("₸3 900")).toEqual({
+      amount: 390000,
+      currency: "KZT",
+    });
+    expect(parsePrice("₸3\u00a0900")).toEqual({
+      amount: 390000,
+      currency: "KZT",
+    });
+    expect(parsePrice("₸25 940.50")).toEqual({
+      amount: 2594050,
+      currency: "KZT",
+    });
+  });
+
   it("prefers AU$ to the $ it starts with", () => {
     expect(parsePrice("AU$140")?.currency).toBe("AUD");
   });
@@ -25,6 +43,14 @@ describe("parsePrice", () => {
     expect(parsePrice("free")).toBeNull();
     expect(parsePrice("64")).toBeNull();
     expect(parsePrice("$")).toBeNull();
+  });
+
+  it("reads no part of a price it cannot read whole", () => {
+    // The alternative is worse than nothing: an option read as 3 rather than
+    // rejected wins the cheapest-option comparison outright.
+    expect(parsePrice("$64 or so")).toBeNull();
+    expect(parsePrice("₸3 900 tenge")).toBeNull();
+    expect(parsePrice("$12.34.56")).toBeNull();
   });
 });
 
@@ -41,6 +67,11 @@ describe("priceInUsdCents", () => {
 
   it("takes a USD price as it stands", () => {
     expect(priceInUsdCents("$64", rates)).toBe(6400);
+  });
+
+  it("takes a USD price even with no rouble rate on file", () => {
+    // It needs no conversion, so the missing row is none of its business
+    expect(priceInUsdCents("$64", {})).toBe(6400);
   });
 
   it("converts through roubles", () => {
@@ -60,6 +91,13 @@ describe("priceInUsdCents", () => {
     const meloman = priceInUsdCents("₸25,940", rates);
     expect(meloman).not.toBeNull();
     expect(meloman!).toBeLessThan(amazon!);
+  });
+
+  it("says a price costs 0 cents rather than that it has none", () => {
+    // A fractional rate puts real prices within rounding distance of zero, and
+    // 0 has to stay 0: null would drop the option out of the comparison, which
+    // is not the same answer.
+    expect(priceInUsdCents("₸2", rates)).toBe(0);
   });
 
   it("has nothing to say without a rate on file", () => {

--- a/src/lib/price.ts
+++ b/src/lib/price.ts
@@ -1,0 +1,98 @@
+/**
+ * Prices as the wishlist writes them, and what one is worth against another.
+ *
+ * This lives apart from wishlist.ts because wishlist.ts opens the database at
+ * module scope: the admin panel is React running in the browser and needs the
+ * same parser the public cards use, and only a module with no imports can be
+ * had by both. Everything here is a pure function of its arguments.
+ */
+
+export type Currency = "USD" | "EUR" | "GBP" | "AUD" | "INR" | "RUB" | "KZT";
+
+export type ParsedPrice = {
+  amount: number; // In cents
+  currency: Currency;
+};
+
+// Currency prefixes mapping. AU$ comes before $, or it never matches.
+const currencyPrefixes: { prefix: string; currency: Currency }[] = [
+  { prefix: "AU$", currency: "AUD" },
+  { prefix: "$", currency: "USD" },
+  { prefix: "£", currency: "GBP" },
+  { prefix: "€", currency: "EUR" },
+  { prefix: "₹", currency: "INR" },
+  { prefix: "₽", currency: "RUB" },
+  { prefix: "₸", currency: "KZT" },
+];
+
+/**
+ * What may sit between the digits of an amount: a comma or a space grouping
+ * thousands. `\s` covers the non-breaking and thin spaces a paste out of a shop
+ * carries, which matters because tenge prices run to four and five digits and
+ * so arrive grouped one way or the other — "₸3,900" or "₸3 900".
+ */
+const groupingSeparators = /[\s,]/g;
+
+/**
+ * What has to be left once the grouping is out: an amount, optionally with a
+ * fraction, and nothing else. A price that fails this reads as unreadable
+ * rather than as whatever prefix of itself parseFloat could salvage — an option
+ * with no readable price sits out the comparison that picks an item's cheapest
+ * way to buy, while one read as 3 instead of 3900 wins it outright.
+ */
+const amountPattern = /^\d+(\.\d+)?$/;
+
+// Parse price string like "$64", "£25", "€300", "AU$140", "₽768", "₸25,940"
+export function parsePrice(price: string): ParsedPrice | null {
+  const trimmed = price.trim();
+
+  for (const { prefix, currency } of currencyPrefixes) {
+    if (trimmed.startsWith(prefix)) {
+      const digits = trimmed
+        .slice(prefix.length)
+        .replace(groupingSeparators, "");
+      if (!amountPattern.test(digits)) return null;
+
+      // parseFloat, not parseInt: "€6.20" and "€6.50" both read as 6 otherwise,
+      // and picking the cheapest of an item's options has to be able to tell
+      // them apart.
+      return { amount: Math.round(parseFloat(digits) * 100), currency };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * The rates as the ExchangeRate table holds them: roubles for one unit of the
+ * currency. Some of them are fractions — a tenge is worth about 0.15 of a
+ * rouble — which is why the column is real and not integer.
+ */
+export type RubRates = Partial<Record<Currency, number>>;
+
+/**
+ * What a price string is worth in US cents, or null if nothing on file can say
+ * — an unreadable price, or a currency with no rate. Null is not zero: an
+ * option priced this way sits out the comparison that picks an item's cheapest
+ * way to buy rather than winning it.
+ */
+export function priceInUsdCents(
+  price: string,
+  toRubRates: RubRates,
+): number | null {
+  const parsed = parsePrice(price);
+  if (!parsed) return null;
+
+  // Dollars are already the answer. Asking for the USD→RUB rate first would
+  // lose every dollar price whenever the table happens not to carry that row.
+  if (parsed.currency === "USD") return parsed.amount;
+
+  // Convert to USD: amount_in_currency * (rate_to_rub / usd_to_rub_rate). Both
+  // rates are real numbers, so the rounding happens once, at the end, on a
+  // count of cents — not on the rate that got us there.
+  const usdToRub = toRubRates.USD;
+  const rateToRub = toRubRates[parsed.currency];
+  if (!usdToRub || !rateToRub) return null;
+
+  return Math.round((parsed.amount * rateToRub) / usdToRub);
+}

--- a/src/lib/wishlist.ts
+++ b/src/lib/wishlist.ts
@@ -5,6 +5,7 @@ import {
   Reservation,
   ExchangeRate,
 } from "@lib/db";
+import { priceInUsdCents, type Currency, type RubRates } from "@lib/price";
 import { CDN_DOMAIN, CDN_DEV_DOMAIN } from "astro:env/server";
 
 // CDN domain helper - uses production domain in prod, dev domain otherwise
@@ -24,13 +25,6 @@ export function getCdnImageUrl(filename: string): string {
 export const RESERVATION_MESSAGE_MAX_LENGTH = 200;
 
 // Types
-export type Currency = "USD" | "EUR" | "GBP" | "AUD" | "INR" | "RUB" | "KZT";
-
-export type ParsedPrice = {
-  amount: number; // In cents
-  currency: Currency;
-};
-
 /**
  * One way to buy an item. The item's own price/url is one of these (with a null
  * id and no label); ItemOption rows are the rest.
@@ -139,69 +133,6 @@ const priorityOrder: Record<string, number> = {
   low: 2,
 };
 
-// Currency prefixes mapping
-const currencyPrefixes: { prefix: string; currency: Currency }[] = [
-  { prefix: "AU$", currency: "AUD" },
-  { prefix: "$", currency: "USD" },
-  { prefix: "£", currency: "GBP" },
-  { prefix: "€", currency: "EUR" },
-  { prefix: "₹", currency: "INR" },
-  { prefix: "₽", currency: "RUB" },
-  { prefix: "₸", currency: "KZT" },
-];
-
-// Parse price string like "$64", "£25", "€300", "AU$140", "₽768", "₸25,940"
-export function parsePrice(price: string): ParsedPrice | null {
-  const trimmed = price.trim();
-
-  for (const { prefix, currency } of currencyPrefixes) {
-    if (trimmed.startsWith(prefix)) {
-      // parseFloat, not parseInt: "€6.20" and "€6.50" both read as 6 otherwise,
-      // and picking the cheapest of an item's options has to be able to tell
-      // them apart.
-      const amount = parseFloat(trimmed.slice(prefix.length).replace(/,/g, ""));
-      return isNaN(amount)
-        ? null
-        : { amount: Math.round(amount * 100), currency };
-    }
-  }
-
-  return null;
-}
-
-/**
- * The rates as the ExchangeRate table holds them: roubles for one unit of the
- * currency, which is a fraction below a rouble's worth (a tenge is about 0.15).
- */
-export type RubRates = Partial<Record<Currency, number>>;
-
-/**
- * What a price string is worth in US cents, or null if nothing on file can say
- * — an unreadable price, or a currency with no rate. Null is not zero: an
- * option priced this way sits out the comparison that picks an item's cheapest
- * way to buy rather than winning it.
- */
-export function priceInUsdCents(
-  price: string,
-  toRubRates: RubRates,
-): number | null {
-  const parsed = parsePrice(price);
-  const usdToRub = toRubRates.USD;
-  if (!parsed || !usdToRub) return null;
-
-  if (parsed.currency === "USD") {
-    return parsed.amount;
-  }
-
-  // Convert to USD: amount_in_currency * (rate_to_rub / usd_to_rub_rate). Both
-  // rates are real numbers, so the rounding happens once, at the end, on a
-  // count of cents — not on the rate that got us there.
-  const rateToRub = toRubRates[parsed.currency];
-  if (!rateToRub) return null;
-
-  return Math.round((parsed.amount * rateToRub) / usdToRub);
-}
-
 /** How a shop link reads on a card: bare host and path, no scheme, no trailing slash. */
 export function formatUrlLabel(url: string): string {
   return url.replace(/^https?:\/\/(www\.)?/, "").replace(/\/$/, "");
@@ -264,9 +195,14 @@ export async function getWishlistItems(
     const priceUsd = priceInUsdCents(price, toRubRates);
     return {
       priceUsd,
-      // Rounded, because a fractional USD→RUB rate would otherwise leave
-      // fractions of a kopeck in a field the rest of the code counts in cents.
-      priceRub: priceUsd && usdToRub ? Math.round(priceUsd * usdToRub) : null,
+      // `!== null`, not truthiness: a price small enough to round to 0 cents is
+      // still a price, and the comparison below admits it on `!== null` — so
+      // treating it as absent here would let it win the item's "from" price and
+      // then have no roubles to show for it. Rounded, because a fractional
+      // USD→RUB rate would otherwise leave fractions of a kopeck in a field the
+      // rest of the code counts in cents.
+      priceRub:
+        priceUsd !== null && usdToRub ? Math.round(priceUsd * usdToRub) : null,
     };
   }
 


### PR DESCRIPTION
The admin panel kept its own copy of the parser and it had drifted: still parseInt, so every price with cents in it came out short — €6.20 at 98 roubles showed ₽588 where the card said ₽608, and €12.80 showed ₽1176 against ₽1254. Adding tenge meant adding the currency to two tables by hand, which is the moment to stop keeping two. parsePrice and priceInUsdCents move to src/lib/price.ts, which imports nothing and so can be had by React in the browser as well as by wishlist.ts, and the dashboard shares the parser now, keeping only its own rate lookup.

Three more things that code got wrong.

Thousands grouped with a space read as a price a thousandth of the size: "₸3 900" came out as 3 tenge, which then beat every other option on the card and put "from ₸3 900" under an item whose cheapest way to buy was $7.13. Tenge run to four and five digits, so they always arrive grouped one way or the other. Grouping is stripped whatever space it is written with, including the non-breaking one a paste out of a shop carries. Anything left over that is not a plain amount now makes the price unreadable rather than a prefix of itself — an option with no readable price sits the comparison out and its raw text still shows, which is the honest answer, while one read as 3 instead of 3900 wins the comparison outright.

A dollar price needed a USD→RUB rate on file to be worth anything, though it needs no conversion at all. Without that row every multi-option item lost its cheapest-option price, and every card lost its tooltip and its roubles, dollar-priced ones included. The USD case answers before the rates are consulted.

A price rounding to 0 US cents counted as no price when its roubles were worked out, but as a price when the cheapest option was picked — so it could win an item's "from" price and have no roubles to show for it. Rates below one put real prices within rounding distance of zero for the first time; before tenge, 0 could only come from a literal zero. Both ends test `!== null` now, and so do the two labels on the card.

The tests move with the functions, which also stops a test of two pure functions from constructing a libSQL client and leaving an empty local.db in the repo root.


Claude-Session: https://claude.ai/code/session_01GEGABjzPRqXpGjvhGC3fNT