### PR TITLE
The wishlist keeps the order it is dragged into

### DIFF
--- a/db/migrations/0004_weight_alone_orders_the_wishlist.sql
+++ b/db/migrations/0004_weight_alone_orders_the_wishlist.sql
@@ -1,0 +1,39 @@
+-- The wishlist used to rank by priority first and weight second, which left two
+-- mechanisms fighting over one order: dragging the admin list writes weights
+-- only, so a drag across a priority boundary saved without complaint and then
+-- sprang back on the next load. Weight alone decides the order now.
+--
+-- Left alone, that would reshuffle the live wishlist on deploy: priority is set
+-- on every item, weight on barely a dozen, so fifty items sharing a weight of 0
+-- would collapse into date order and the owner's arrangement would be gone. So
+-- the old order is written into the weights here, once, before the code that
+-- reads them ships — the list looks exactly as it did, and dragging edits it
+-- from there.
+--
+-- Highest weight sorts first, hence `total - position + 1`: the same numbering
+-- the admin panel's reorder produces, so a first drag after this changes only
+-- what the owner actually moved. Received items keep whatever weight they have
+-- — they sort to the end regardless.
+WITH `ranked` AS (
+  SELECT
+    `id`,
+    ROW_NUMBER() OVER (
+      ORDER BY
+        CASE `priority`
+          WHEN 'high' THEN 0
+          WHEN 'medium' THEN 1
+          WHEN 'low' THEN 2
+          ELSE 3
+        END ASC,
+        `weight` DESC,
+        `createdAt` DESC
+    ) AS `position`,
+    (SELECT COUNT(*) FROM `WishlistItem` WHERE `received` = 0) AS `total`
+  FROM `WishlistItem`
+  WHERE `received` = 0
+)
+UPDATE `WishlistItem`
+SET `weight` = (
+  SELECT `total` - `position` + 1 FROM `ranked` WHERE `ranked`.`id` = `WishlistItem`.`id`
+)
+WHERE `received` = 0;

--- a/db/migrations/meta/0004_snapshot.json
+++ b/db/migrations/meta/0004_snapshot.json
@@ -1,8 +1,8 @@
 {
+  "id": "2b57a3c2-21b9-4945-8987-9e541a269e0e",
+  "prevId": "5fae3f33-b0e8-49e5-8c01-446a95daab14",
   "version": "6",
   "dialect": "sqlite",
-  "id": "0593f7fc-c458-4cb7-a7cf-014d8e9d12e2",
-  "prevId": "5961b817-846f-4f0d-8a89-eb9281363ace",
   "tables": {
     "AdminCredential": {
       "name": "AdminCredential",
@@ -122,15 +122,15 @@
         "AdminSession_credentialId_AdminCredential_id_fk": {
           "name": "AdminSession_credentialId_AdminCredential_id_fk",
           "tableFrom": "AdminSession",
-          "tableTo": "AdminCredential",
           "columnsFrom": [
             "credentialId"
           ],
+          "tableTo": "AdminCredential",
           "columnsTo": [
             "id"
           ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
+          "onUpdate": "no action",
+          "onDelete": "no action"
         }
       },
       "compositePrimaryKeys": {},
@@ -249,15 +249,15 @@
         "ItemOption_itemId_WishlistItem_id_fk": {
           "name": "ItemOption_itemId_WishlistItem_id_fk",
           "tableFrom": "ItemOption",
-          "tableTo": "WishlistItem",
           "columnsFrom": [
             "itemId"
           ],
+          "tableTo": "WishlistItem",
           "columnsTo": [
             "id"
           ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
+          "onUpdate": "no action",
+          "onDelete": "no action"
         }
       },
       "compositePrimaryKeys": {},
@@ -316,15 +316,15 @@
         "Reservation_itemId_WishlistItem_id_fk": {
           "name": "Reservation_itemId_WishlistItem_id_fk",
           "tableFrom": "Reservation",
-          "tableTo": "WishlistItem",
           "columnsFrom": [
             "itemId"
           ],
+          "tableTo": "WishlistItem",
           "columnsTo": [
             "id"
           ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
+          "onUpdate": "no action",
+          "onDelete": "no action"
         }
       },
       "compositePrimaryKeys": {},
@@ -446,9 +446,9 @@
   "views": {},
   "enums": {},
   "_meta": {
+    "columns": {},
     "schemas": {},
-    "tables": {},
-    "columns": {}
+    "tables": {}
   },
   "internal": {
     "indexes": {}

--- a/db/migrations/meta/_journal.json
+++ b/db/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1786122551977,
       "tag": "0003_kzt_exchange_rate",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "6",
+      "when": 1786366736313,
+      "tag": "0004_weight_alone_orders_the_wishlist",
+      "breakpoints": true
     }
   ]
 }

--- a/src/components/wishlist/admin/AdminPanel.tsx
+++ b/src/components/wishlist/admin/AdminPanel.tsx
@@ -159,7 +159,8 @@ function AdminPanelInner({
           url: data.url || null,
           category: data.category,
           priority: data.priority || null,
-          weight: data.weight ?? 0,
+          // The server picked it — one above everything else in the table.
+          weight: result.weight ?? 0,
           received: false,
           createdAt: new Date(),
           options: result.options ?? [],

--- a/src/components/wishlist/admin/ItemList.tsx
+++ b/src/components/wishlist/admin/ItemList.tsx
@@ -195,9 +195,10 @@ function ItemCard({
               {item.priority}
             </span>
           )}
-          {item.weight > 0 && (
-            <span className="tag tag-weight">w:{item.weight}</span>
-          )}
+          {/* No weight badge. It read as a setting worth knowing back when a
+              handful of items had one; now that every item carries a position
+              it would sit on every card and say only what the card's own place
+              in the list already says. */}
         </div>
 
         {/* Descriptions (secondary info) */}

--- a/src/components/wishlist/admin/ItemModal.tsx
+++ b/src/components/wishlist/admin/ItemModal.tsx
@@ -47,7 +47,6 @@ export function ItemModal({
     url: "",
     category: "",
     priority: "",
-    weight: 0,
     options: [],
   }));
 
@@ -80,7 +79,6 @@ export function ItemModal({
         url: item.url || "",
         category: item.category,
         priority: item.priority || "",
-        weight: item.weight,
         options: item.options.map((option) => ({
           label: option.label || "",
           labelRu: option.labelRu || "",
@@ -101,7 +99,6 @@ export function ItemModal({
         url: "",
         category: "",
         priority: "",
-        weight: 0,
         options: [],
       });
       setSelectedCategories([]);
@@ -144,10 +141,7 @@ export function ItemModal({
     >,
   ) => {
     const { name, value } = e.target;
-    setFormData((prev) => ({
-      ...prev,
-      [name]: name === "weight" ? parseInt(value, 10) || 0 : value,
-    }));
+    setFormData((prev) => ({ ...prev, [name]: value }));
   };
 
   const addOption = () => {
@@ -535,6 +529,10 @@ export function ItemModal({
               </div>
             </div>
 
+            {/* No weight field beside this one any more. Weight is a position
+                now, written by dragging the list; a number typed here only ever
+                fought with the next drag, which rewrites them all. Priority
+                stays, but as a label on the card — it no longer sorts. */}
             <div className="form-row">
               <div className="form-group">
                 <label htmlFor="priority">Priority</label>
@@ -550,17 +548,6 @@ export function ItemModal({
                   <option value="medium">Medium</option>
                   <option value="low">Low</option>
                 </select>
-              </div>
-              <div className="form-group">
-                <label htmlFor="weight">Weight (higher = more important)</label>
-                <input
-                  type="number"
-                  id="weight"
-                  name="weight"
-                  value={formData.weight}
-                  onChange={handleInputChange}
-                  min={0}
-                />
               </div>
             </div>
           </form>

--- a/src/components/wishlist/admin/types.ts
+++ b/src/components/wishlist/admin/types.ts
@@ -56,7 +56,11 @@ export interface ItemFormData {
   url?: string;
   category: string;
   priority?: string;
-  weight: number;
+  /**
+   * Deliberately no `weight`. It is a position in the list, not a property of
+   * the item: dragging writes it, the create endpoint seeds it, and nothing
+   * about this form has an opinion on where the item sits.
+   */
   options: ItemOptionFormData[];
 }
 

--- a/src/components/wishlist/admin/useFilters.ts
+++ b/src/components/wishlist/admin/useFilters.ts
@@ -1,4 +1,5 @@
 import { useState, useCallback, useMemo, useEffect } from "react";
+import { comparePublic, compareAdmin } from "@lib/wishlist-sort";
 import type { WishlistItem, Reservation, Category } from "./types";
 
 type StatusFilter = "all" | "reserved" | "received";
@@ -68,12 +69,6 @@ export function useFilters({
     [categories]
   );
 
-  // Priority order for public sorting
-  const priorityOrder: Record<string, number> = useMemo(
-    () => ({ high: 0, medium: 1, low: 2 }),
-    []
-  );
-
   // Filtered and sorted items
   const filteredItems = useMemo(() => {
     let result = items;
@@ -107,31 +102,12 @@ export function useFilters({
       );
     }
 
-    // Sort based on mode
-    result = [...result].sort((a, b) => {
-      if (sortMode === "public") {
-        // Public sorting: received last → priority → weight → createdAt
-        if (a.received && !b.received) return 1;
-        if (!a.received && b.received) return -1;
-
-        const aPriority = a.priority ? (priorityOrder[a.priority] ?? 3) : 3;
-        const bPriority = b.priority ? (priorityOrder[b.priority] ?? 3) : 3;
-        if (aPriority !== bPriority) return aPriority - bPriority;
-
-        if (a.weight !== b.weight) return b.weight - a.weight;
-
-        return b.createdAt.getTime() - a.createdAt.getTime();
-      } else {
-        // Admin sorting: reserved first → createdAt (newest first)
-        const aReserved = reservations.has(a.id);
-        const bReserved = reservations.has(b.id);
-
-        if (aReserved && !bReserved) return -1;
-        if (!aReserved && bReserved) return 1;
-
-        return b.createdAt.getTime() - a.createdAt.getTime();
-      }
-    });
+    // "public" previews the visitor's order — the one dragging edits; "admin"
+    // is the owner's working order. Both comparators are shared with the pages
+    // that render them, so this preview cannot drift from the real thing.
+    result = [...result].sort(
+      sortMode === "public" ? comparePublic : compareAdmin(reservations)
+    );
 
     return result;
   }, [
@@ -141,7 +117,6 @@ export function useFilters({
     debouncedSearchQuery,
     reservations,
     sortMode,
-    priorityOrder,
   ]);
 
   // Check if any filters are active

--- a/src/lib/wishlist-sort.test.ts
+++ b/src/lib/wishlist-sort.test.ts
@@ -1,0 +1,70 @@
+import { expect, test } from "vitest";
+import { comparePublic, compareAdmin, type SortableItem } from "./wishlist-sort";
+
+function item(fields: Partial<SortableItem> & { id: number }): SortableItem {
+  return {
+    received: false,
+    weight: 0,
+    createdAt: new Date("2026-01-01"),
+    ...fields,
+  };
+}
+
+const ids = (items: SortableItem[]) => items.map((i) => i.id);
+
+test("puts heavier items first", () => {
+  const items = [
+    item({ id: 1, weight: 1 }),
+    item({ id: 2, weight: 5 }),
+    item({ id: 3, weight: 3 }),
+  ];
+
+  expect(ids([...items].sort(comparePublic))).toEqual([2, 3, 1]);
+});
+
+test("sinks received items regardless of weight", () => {
+  const items = [
+    item({ id: 1, weight: 99, received: true }),
+    item({ id: 2, weight: 1 }),
+  ];
+
+  expect(ids([...items].sort(comparePublic))).toEqual([2, 1]);
+});
+
+test("breaks a weight tie with the newer item", () => {
+  const items = [
+    item({ id: 1, weight: 2, createdAt: new Date("2026-01-01") }),
+    item({ id: 2, weight: 2, createdAt: new Date("2026-06-01") }),
+  ];
+
+  expect(ids([...items].sort(comparePublic))).toEqual([2, 1]);
+});
+
+test("orders received items among themselves too", () => {
+  const items = [
+    item({ id: 1, weight: 1, received: true }),
+    item({ id: 2, weight: 7, received: true }),
+  ];
+
+  expect(ids([...items].sort(comparePublic))).toEqual([2, 1]);
+});
+
+test("floats reserved items to the top of the admin's list", () => {
+  const items = [
+    item({ id: 1, createdAt: new Date("2026-06-01") }),
+    item({ id: 2, createdAt: new Date("2026-01-01") }),
+    item({ id: 3, createdAt: new Date("2026-03-01") }),
+  ];
+  const reserved = new Set([2]);
+
+  expect(ids([...items].sort(compareAdmin(reserved)))).toEqual([2, 1, 3]);
+});
+
+test("ignores weight in the admin's list", () => {
+  const items = [
+    item({ id: 1, weight: 0, createdAt: new Date("2026-06-01") }),
+    item({ id: 2, weight: 99, createdAt: new Date("2026-01-01") }),
+  ];
+
+  expect(ids([...items].sort(compareAdmin(new Set())))).toEqual([1, 2]);
+});

--- a/src/lib/wishlist-sort.ts
+++ b/src/lib/wishlist-sort.ts
@@ -1,0 +1,60 @@
+/**
+ * The two orders a wishlist is ever shown in. The public page renders one, the
+ * admin panel switches between both, and the admin page's SSR pass sorts with
+ * the same comparator the panel will use the moment it hydrates — so the list
+ * never rearranges itself under the owner's cursor.
+ *
+ * A module of its own rather than a corner of `@lib/wishlist`, because that one
+ * reaches for `astro:env/server` and a React hook in the browser cannot import
+ * it. Three copies of these comparators used to drift apart for exactly that
+ * reason.
+ */
+
+/** What either comparator reads. Both the public and the admin item satisfy it. */
+export type SortableItem = {
+  id: number;
+  received: boolean;
+  weight: number;
+  createdAt: Date;
+};
+
+/** Anything that can answer "is this item id reserved" — a Map or a Set will do. */
+export type ReservedLookup = { has(id: number): boolean };
+
+/**
+ * What visitors see: things still wanted first, in the order the owner dragged
+ * them into, and everything already received at the end.
+ *
+ * `priority` is deliberately not consulted. It used to outrank `weight`, which
+ * gave the list two ranking mechanisms fighting over one order: dragging writes
+ * weights only, so a drag across a priority boundary saved without complaint and
+ * then sprang back on the next load. Dragging is now the only thing that decides
+ * order; priority survives as a label on the card.
+ *
+ * `createdAt` only breaks ties among items that share a weight, which in
+ * practice means ones nobody has dragged yet — a new item is born above them all
+ * (the create endpoint hands it the highest weight) and stays where it is put.
+ */
+export function comparePublic(a: SortableItem, b: SortableItem): number {
+  if (a.received !== b.received) return a.received ? 1 : -1;
+  if (a.weight !== b.weight) return b.weight - a.weight;
+  return b.createdAt.getTime() - a.createdAt.getTime();
+}
+
+/**
+ * The owner's working order, which is not about desirability at all: whatever
+ * needs acting on floats up. Reserved items first, then the newest.
+ *
+ * A factory, unlike its sibling — the reservations live outside the item, so the
+ * comparator has to be handed them: `items.sort(compareAdmin(reservations))`.
+ */
+export function compareAdmin(
+  reserved: ReservedLookup,
+): (a: SortableItem, b: SortableItem) => number {
+  return (a, b) => {
+    const aReserved = reserved.has(a.id);
+    const bReserved = reserved.has(b.id);
+    if (aReserved !== bReserved) return aReserved ? -1 : 1;
+    return b.createdAt.getTime() - a.createdAt.getTime();
+  };
+}

--- a/src/lib/wishlist.ts
+++ b/src/lib/wishlist.ts
@@ -6,6 +6,7 @@ import {
   ExchangeRate,
 } from "@lib/db";
 import { priceInUsdCents, type Currency, type RubRates } from "@lib/price";
+import { comparePublic } from "@lib/wishlist-sort";
 import { CDN_DOMAIN, CDN_DEV_DOMAIN } from "astro:env/server";
 
 // CDN domain helper - uses production domain in prod, dev domain otherwise
@@ -125,13 +126,6 @@ export function isValidCategory(
 ): category is string {
   return typeof category === "string" && validCategoryIds.includes(category);
 }
-
-// Priority order for sorting
-const priorityOrder: Record<string, number> = {
-  high: 0,
-  medium: 1,
-  low: 2,
-};
 
 /** How a shop link reads on a card: bare host and path, no scheme, no trailing slash. */
 export function formatUrlLabel(url: string): string {
@@ -261,23 +255,7 @@ export async function getWishlistItems(
     });
   }
 
-  // Sort items: priority → weight (higher first) → createdAt (newest first) → received last
-  items.sort((a, b) => {
-    // Received items always go to the end
-    if (a.received && !b.received) return 1;
-    if (!a.received && b.received) return -1;
-
-    // Sort by priority (high first, no priority last)
-    const aPriority = a.priority ? (priorityOrder[a.priority] ?? 3) : 3;
-    const bPriority = b.priority ? (priorityOrder[b.priority] ?? 3) : 3;
-    if (aPriority !== bPriority) return aPriority - bPriority;
-
-    // Within same priority, sort by weight (higher weight first)
-    if (a.weight !== b.weight) return b.weight - a.weight;
-
-    // Within same weight, sort by createdAt (newest first)
-    return b.createdAt.getTime() - a.createdAt.getTime();
-  });
+  items.sort(comparePublic);
 
   return items;
 }

--- a/src/pages/api/~/items/[id].ts
+++ b/src/pages/api/~/items/[id].ts
@@ -17,7 +17,9 @@ const updateItemSchema = z.object({
   url: z.string().url().optional().or(z.literal("")),
   category: z.string().min(1).optional(),
   priority: z.enum(["high", "medium", "low"]).optional().or(z.literal("")),
-  weight: z.number().optional(),
+  // No weight: it is a position, and /api/~/items/batch is the one endpoint
+  // that writes positions — for the whole list at once, which is the only way a
+  // reorder makes sense.
   received: z.boolean().optional(),
   // Absent leaves the item's options alone; present replaces them wholesale,
   // so an empty array is how the last one gets removed.
@@ -82,7 +84,6 @@ export const PUT: APIRoute = async ({ params, request, cookies }) => {
     if (data.category !== undefined) updateData.category = data.category;
     if (data.priority !== undefined)
       updateData.priority = data.priority || null;
-    if (data.weight !== undefined) updateData.weight = data.weight;
     if (data.received !== undefined) updateData.received = data.received;
 
     if (Object.keys(updateData).length > 0) {

--- a/src/pages/api/~/items/index.ts
+++ b/src/pages/api/~/items/index.ts
@@ -17,7 +17,6 @@ const createItemSchema = z.object({
   url: z.string().url().optional().or(z.literal("")),
   category: z.string().min(1),
   priority: z.enum(["high", "medium", "low"]).optional().or(z.literal("")),
-  weight: z.number().default(0),
   options: z.array(itemOptionSchema).default([]),
 });
 
@@ -45,7 +44,11 @@ export const POST: APIRoute = async ({ request, cookies }) => {
     const data = parsed.data;
     const now = new Date().toISOString();
 
-    // Create item with atomic ID generation to avoid race condition
+    // Create item with atomic ID generation to avoid race condition. The weight
+    // is minted the same way, one above the highest in the table, so a new item
+    // arrives at the top of the wishlist — where the owner just decided it
+    // belonged — instead of at the bottom, which a default of 0 would mean now
+    // that weight alone decides the order.
     const result = await db.run(sql`
       INSERT INTO WishlistItem (id, title, titleRu, price, imageUrl, description, descriptionRu, url, category, priority, weight, received, createdAt)
       VALUES (
@@ -59,14 +62,16 @@ export const POST: APIRoute = async ({ request, cookies }) => {
         ${data.url || null},
         ${data.category},
         ${data.priority || null},
-        ${data.weight},
+        COALESCE((SELECT MAX(weight) FROM WishlistItem), 0) + 1,
         0,
         ${now}
       )
+      RETURNING id, weight
     `);
 
-    // Get the inserted ID
-    const newId = Number(result.lastInsertRowid);
+    const inserted = result.rows[0];
+    const newId = Number(inserted?.id ?? result.lastInsertRowid);
+    const newWeight = Number(inserted?.weight ?? 0);
 
     const options =
       data.options.length > 0
@@ -76,10 +81,10 @@ export const POST: APIRoute = async ({ request, cookies }) => {
     // Revalidate ISR
     await revalidateWishlist();
 
-    return new Response(JSON.stringify({ success: true, id: newId, options }), {
-      status: 201,
-      headers: { "Content-Type": "application/json" },
-    });
+    return new Response(
+      JSON.stringify({ success: true, id: newId, weight: newWeight, options }),
+      { status: 201, headers: { "Content-Type": "application/json" } },
+    );
   } catch (error) {
     console.error("Error creating item:", error);
     return new Response(JSON.stringify({ error: "Failed to create item" }), {

--- a/src/pages/wishlist/~/index.astro
+++ b/src/pages/wishlist/~/index.astro
@@ -6,6 +6,7 @@ import { Icon } from "astro-icon/components";
 import { AdminPanel } from "@components/wishlist/admin";
 import { verifySession } from "@lib/admin/auth";
 import { categories } from "@lib/wishlist";
+import { compareAdmin } from "@lib/wishlist-sort";
 import {
   db,
   WishlistItem,
@@ -72,18 +73,9 @@ for (const rate of exchangeRates) {
 // Create reservation map
 const reservationMap = new Map(reservations.map((r) => [r.itemId, r]));
 
-// Sort: reserved items first, then by createdAt (newest first)
-const sortedItems = [...items].sort((a, b) => {
-  const aReserved = reservationMap.has(a.id);
-  const bReserved = reservationMap.has(b.id);
-
-  // Reserved items first
-  if (aReserved && !bReserved) return -1;
-  if (!aReserved && bReserved) return 1;
-
-  // Then by createdAt (newest first)
-  return b.createdAt.getTime() - a.createdAt.getTime();
-});
+// The panel defaults to this same order, so sorting here is what keeps the
+// first paint from being rearranged by hydration a moment later.
+const sortedItems = [...items].sort(compareAdmin(reservationMap));
 
 // Convert Map to array for serialization
 const reservationsArray = Array.from(reservationMap.entries());

--- a/src/styles/admin/items.css
+++ b/src/styles/admin/items.css
@@ -469,12 +469,6 @@
   --tag-dot: light-dark(#bbb, #666);
 }
 
-.tag-weight {
-  color: light-dark(#888, #777);
-  font-family: ui-monospace, monospace;
-  font-size: 0.6rem;
-}
-
 /* Item Actions */
 .item-actions {
   display: flex;


### PR DESCRIPTION
Priority used to outrank weight, which left two mechanisms fighting over one order: dragging the admin list writes weights only, so a drag across a priority boundary saved without complaint and then sprang back on the next load. Weight alone decides it now, and priority stays as a label on the card.

The comparators move to a module of their own because three copies had grown — the public page, the admin page's SSR pass, and the panel's own preview — and `@lib/wishlist` cannot hold them, since it reads astro:env/server and the React hook has to import them too.

Weight was a position all along, so the places that treated it as a property go: the number field in the form, and weight on PUT. The create endpoint mints one above the highest instead, the way it already mints ids, so a new item arrives at the top rather than at the bottom a default of 0 would now mean. The w:N badge goes with them — it read as a setting worth knowing while a handful of items had one, and would now sit on every card saying what the card's own place in the list already says.

Migration 0004 writes the old order into the weights before any of this ships. Priority was set on every item and weight on eleven, so without it the live list would have collapsed into date order on deploy.

Fixes the meta chain drizzle-kit choked on along the way: 0002's snapshot pointed at 0000 rather than 0001, which is a collision it refuses to generate past. The two snapshots are identical in content, so the diff it computes is unchanged.