### PR TITLE
The dashboard shows where a dragged card will land

### DIFF
--- a/src/components/wishlist/admin/ItemList.tsx
+++ b/src/components/wishlist/admin/ItemList.tsx
@@ -1,5 +1,12 @@
-import { useState, useRef, useCallback } from "react";
+import { useState, useRef, useCallback, useMemo, useEffect } from "react";
 import { parsePrice } from "@lib/price";
+import {
+  insertionAt,
+  isNoOpInsertion,
+  applyMove,
+  type CardBox,
+  type Insertion,
+} from "@lib/grid-reorder";
 import type {
   WishlistItem,
   Reservation,
@@ -67,17 +74,15 @@ interface ItemCardProps {
   isDraggable: boolean;
   isDragging: boolean;
   isKeyboardMoving: boolean;
-  dragOverPosition: "before" | "after" | null;
+  /** Which side of this card the insertion beam belongs on, if it is here. */
+  dropEdge: "before" | "after" | null;
   onEdit: () => void;
   onDelete: () => void;
   onToggleReceived: () => Promise<void>;
   onToggleReserved: () => Promise<void>;
   onDragStart: (e: React.DragEvent) => void;
-  onDragEnd: (e: React.DragEvent) => void;
-  onDragEnter: (e: React.DragEvent) => void;
-  onDragOver: (e: React.DragEvent) => void;
-  onDragLeave: (e: React.DragEvent) => void;
-  onDrop: (e: React.DragEvent) => void;
+  onDragEnd: () => void;
+  onGripPointerDown: () => void;
   onKeyDown: (e: React.KeyboardEvent) => void;
 }
 
@@ -90,17 +95,14 @@ function ItemCard({
   isDraggable,
   isDragging,
   isKeyboardMoving,
-  dragOverPosition,
+  dropEdge,
   onEdit,
   onDelete,
   onToggleReceived,
   onToggleReserved,
   onDragStart,
   onDragEnd,
-  onDragEnter,
-  onDragOver,
-  onDragLeave,
-  onDrop,
+  onGripPointerDown,
   onKeyDown,
 }: ItemCardProps) {
   const isReserved = !!reservation;
@@ -112,8 +114,8 @@ function ItemCard({
     isDraggable ? "draggable" : "",
     isDragging ? "dragging" : "",
     isKeyboardMoving ? "keyboard-moving" : "",
-    dragOverPosition === "before" ? "drag-over-before" : "",
-    dragOverPosition === "after" ? "drag-over-after" : "",
+    dropEdge === "before" ? "drop-before" : "",
+    dropEdge === "after" ? "drop-after" : "",
   ]
     .filter(Boolean)
     .join(" ");
@@ -125,25 +127,50 @@ function ItemCard({
       draggable={isDraggable}
       tabIndex={isDraggable ? 0 : undefined}
       role={isDraggable ? "listitem" : undefined}
-      aria-grabbed={isDraggable ? isKeyboardMoving : undefined}
+      /* No aria-grabbed: it was dropped from ARIA years ago and screen readers
+         no longer act on it. What it was reaching for — telling the owner where
+         the card went — is the list's live region instead. */
+      aria-roledescription={isDraggable ? "Sortable item" : undefined}
       aria-label={
         isDraggable
-          ? `${item.title}. ${isKeyboardMoving ? "Moving. Use arrow keys to reorder, Enter to confirm, Escape to cancel." : "Press Space to start moving."}`
+          ? `${item.title}. ${isKeyboardMoving ? "Moving. Arrow keys to move, Enter to drop, Escape to cancel." : "Press Space to start moving."}`
           : item.title
       }
       onDragStart={onDragStart}
       onDragEnd={onDragEnd}
-      onDragEnter={onDragEnter}
-      onDragOver={onDragOver}
-      onDragLeave={onDragLeave}
-      onDrop={onDrop}
       onKeyDown={onKeyDown}
     >
+      {/* The grip, and the only thing that starts a drag. The card is
+          `draggable` because HTML5 asks the drag source to be, but a press that
+          began on Edit, on the photo, or on a title being selected is turned
+          away in onDragStart — which is what used to fling a card across the
+          grid on a twitchy click. */}
+      {isDraggable && (
+        <div
+          className="item-grip"
+          aria-hidden="true"
+          title="Drag to reorder"
+          onPointerDown={onGripPointerDown}
+        >
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+            <circle cx="9" cy="6" r="1.6" />
+            <circle cx="15" cy="6" r="1.6" />
+            <circle cx="9" cy="12" r="1.6" />
+            <circle cx="15" cy="12" r="1.6" />
+            <circle cx="9" cy="18" r="1.6" />
+            <circle cx="15" cy="18" r="1.6" />
+          </svg>
+        </div>
+      )}
+
       <div className="item-image">
         <img
           src={`https://${cdnDomain}/${item.imageUrl}`}
           alt={item.title}
           loading="lazy"
+          /* An <img> is draggable in its own right, so without this the photo
+             starts an image drag of its own and the card never moves. */
+          draggable={false}
         />
         {/* Status badge overlay */}
         {(isReserved || item.received) && (
@@ -337,16 +364,25 @@ export function ItemList({
   onToggleReserved,
   onReorder,
 }: ItemListProps) {
-  // Drag state
-  const [draggedItemId, setDraggedItemId] = useState<number | null>(null);
-  const [dragOverItemId, setDragOverItemId] = useState<number | null>(null);
-  const [dragOverPosition, setDragOverPosition] = useState<
-    "before" | "after" | null
-  >(null);
-  const dragCounter = useRef<Map<number, number>>(new Map());
+  const listRef = useRef<HTMLDivElement>(null);
 
-  // Keyboard reorder state
+  /* The grid, measured once when a drag begins. Nothing reflows during a native
+     drag, and asking sixty cards for their rect on every dragover forced a
+     layout per frame. Page coordinates rather than viewport ones, so the
+     numbers survive the page scrolling under the cursor. */
+  const boxesRef = useRef<CardBox[]>([]);
+
+  /* Set while a press that started on a grip is still live. onDragStart reads
+     it to decide whether this drag is one the panel asked for. */
+  const fromGripRef = useRef(false);
+
+  /* The order a keyboard move started from, so Escape can actually undo it. */
+  const keyboardOriginRef = useRef<WishlistItem[] | null>(null);
+
+  const [draggedId, setDraggedId] = useState<number | null>(null);
+  const [insertion, setInsertion] = useState<Insertion | null>(null);
   const [keyboardMovingId, setKeyboardMovingId] = useState<number | null>(null);
+  const [announcement, setAnnouncement] = useState("");
 
   const getCategoryLabels = useCallback(
     (categoryString: string): { id: string; label: string }[] => {
@@ -359,196 +395,284 @@ export function ItemList({
     [categories],
   );
 
-  // Drag handlers
-  const handleDragStart = useCallback((e: React.DragEvent, itemId: number) => {
-    setDraggedItemId(itemId);
-    e.dataTransfer.effectAllowed = "move";
-    e.dataTransfer.setData("text/plain", String(itemId));
-    requestAnimationFrame(() => {
-      const element = e.target as HTMLElement;
-      element.classList.add("dragging");
+  const draggedIndex =
+    draggedId === null ? -1 : items.findIndex((item) => item.id === draggedId);
+
+  /* One beam, in one gutter — the end of the gap the cursor is at, so it never
+     leaps across the screen at a row boundary. And none at all when the drop
+     would change nothing, so the feedback never promises a move it is going to
+     throw away. */
+  const beam = useMemo(() => {
+    if (insertion === null || draggedIndex === -1) return null;
+    if (isNoOpInsertion(draggedIndex, insertion.index)) return null;
+
+    const card = items[insertion.card];
+    return card ? { id: card.id, edge: insertion.edge } : null;
+  }, [insertion, draggedIndex, items]);
+
+  const measureCards = useCallback((): CardBox[] => {
+    const list = listRef.current;
+    if (!list) return [];
+
+    const { scrollX, scrollY } = window;
+    return Array.from(
+      list.querySelectorAll<HTMLElement>("[data-item-id]"),
+    ).map((element) => {
+      const rect = element.getBoundingClientRect();
+      return {
+        left: rect.left + scrollX,
+        right: rect.right + scrollX,
+        top: rect.top + scrollY,
+        bottom: rect.bottom + scrollY,
+      };
     });
   }, []);
 
-  const handleDragEnd = useCallback(() => {
-    setDraggedItemId(null);
-    setDragOverItemId(null);
-    setDragOverPosition(null);
-    dragCounter.current.clear();
+  const endDrag = useCallback(() => {
+    fromGripRef.current = false;
+    boxesRef.current = [];
+    setDraggedId(null);
+    setInsertion(null);
   }, []);
 
-  const handleDragOver = useCallback((e: React.DragEvent, itemId: number) => {
-    e.preventDefault();
-    e.dataTransfer.dropEffect = "move";
-
-    const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
-    const midpoint = rect.left + rect.width / 2;
-    const position = e.clientX < midpoint ? "before" : "after";
-
-    setDragOverItemId(itemId);
-    setDragOverPosition(position);
+  /* A press on a grip that never became a drag still has to let go. dragend
+     covers the drags; this covers everything else. */
+  useEffect(() => {
+    const release = () => {
+      fromGripRef.current = false;
+    };
+    document.addEventListener("pointerup", release);
+    return () => document.removeEventListener("pointerup", release);
   }, []);
 
-  const handleDragEnter = useCallback((e: React.DragEvent, itemId: number) => {
-    e.preventDefault();
-    const count = (dragCounter.current.get(itemId) || 0) + 1;
-    dragCounter.current.set(itemId, count);
-  }, []);
-
-  const handleDragLeave = useCallback(
-    (itemId: number) => {
-      const count = (dragCounter.current.get(itemId) || 0) - 1;
-      dragCounter.current.set(itemId, count);
-
-      if (count <= 0) {
-        dragCounter.current.delete(itemId);
-        if (dragOverItemId === itemId) {
-          setDragOverItemId(null);
-          setDragOverPosition(null);
-        }
+  const handleDragStart = useCallback(
+    (e: React.DragEvent, itemId: number) => {
+      if (!fromGripRef.current) {
+        e.preventDefault();
+        return;
       }
+
+      e.dataTransfer.effectAllowed = "move";
+      e.dataTransfer.setData("text/plain", String(itemId));
+
+      boxesRef.current = measureCards();
+
+      /* Held back a frame on purpose. The browser snapshots the card for the
+         drag image at the end of this event, so marking it as lifted now hands
+         the cursor a picture of the hole the card leaves behind. */
+      requestAnimationFrame(() => setDraggedId(itemId));
     },
-    [dragOverItemId],
+    [measureCards],
   );
 
-  const handleDrop = useCallback(
-    (e: React.DragEvent, targetItemId: number) => {
+  /* One dragover for the whole grid rather than one per card. The gutters
+     between cards belong to no card, so the old per-card handler lost the
+     cursor every time it crossed one and the marker strobed on the way past. */
+  const handleListDragOver = useCallback(
+    (e: React.DragEvent) => {
+      if (draggedId === null) return;
+      e.preventDefault();
+      e.dataTransfer.dropEffect = "move";
+      setInsertion(insertionAt(boxesRef.current, e.pageX, e.pageY));
+    },
+    [draggedId],
+  );
+
+  const handleListDragLeave = useCallback((e: React.DragEvent) => {
+    // dragleave bubbles up from every child; only the cursor leaving the grid
+    // itself should put the beam out.
+    const next = e.relatedTarget as Node | null;
+    if (next && e.currentTarget.contains(next)) return;
+    setInsertion(null);
+  }, []);
+
+  const handleListDrop = useCallback(
+    (e: React.DragEvent) => {
       e.preventDefault();
 
-      const draggedId = parseInt(e.dataTransfer.getData("text/plain"), 10);
-      if (isNaN(draggedId) || draggedId === targetItemId) {
-        handleDragEnd();
-        return;
+      if (draggedIndex !== -1 && insertion !== null) {
+        const next = applyMove(items, draggedIndex, insertion.index);
+        if (next) onReorder?.(next);
       }
 
-      const draggedIndex = items.findIndex((item) => item.id === draggedId);
-      const targetIndex = items.findIndex((item) => item.id === targetItemId);
-
-      if (draggedIndex === -1 || targetIndex === -1) {
-        handleDragEnd();
-        return;
-      }
-
-      const newItems = [...items];
-      const [draggedItem] = newItems.splice(draggedIndex, 1);
-
-      let newTargetIndex = targetIndex;
-      if (draggedIndex < targetIndex) {
-        newTargetIndex = targetIndex - 1;
-      }
-
-      if (dragOverPosition === "after") {
-        newItems.splice(newTargetIndex + 1, 0, draggedItem);
-      } else {
-        newItems.splice(newTargetIndex, 0, draggedItem);
-      }
-
-      onReorder?.(newItems);
-      handleDragEnd();
+      endDrag();
     },
-    [items, dragOverPosition, onReorder, handleDragEnd],
+    [draggedIndex, insertion, items, onReorder, endDrag],
   );
 
-  // Keyboard reorder: move item by delta positions
-  const moveItemByKeyboard = useCallback(
-    (itemId: number, delta: number) => {
-      const currentIndex = items.findIndex((item) => item.id === itemId);
-      if (currentIndex === -1) return;
+  /* How wide a row is, asked of the layout rather than of the media queries
+     that decide it — the grid is six columns wide, or four, or three, or two,
+     or one, and ArrowDown means "a row down" in every one of them. */
+  const columnCount = useCallback(() => {
+    const list = listRef.current;
+    if (!list) return 1;
 
-      const newIndex = currentIndex + delta;
-      if (newIndex < 0 || newIndex >= items.length) return;
+    const cards = Array.from(
+      list.querySelectorAll<HTMLElement>("[data-item-id]"),
+    );
+    if (cards.length === 0) return 1;
 
-      const newItems = [...items];
-      const [movedItem] = newItems.splice(currentIndex, 1);
-      newItems.splice(newIndex, 0, movedItem);
+    const top = cards[0].offsetTop;
+    let columns = 0;
+    while (columns < cards.length && cards[columns].offsetTop === top) {
+      columns++;
+    }
+    return Math.max(1, columns);
+  }, []);
 
-      onReorder?.(newItems);
+  const moveByKeyboard = useCallback(
+    (item: WishlistItem, delta: number) => {
+      const from = items.findIndex((candidate) => candidate.id === item.id);
+      if (from === -1) return;
+
+      // Clamped rather than refused: ArrowDown on the last row should land the
+      // card at the end, not do nothing because a whole row won't fit.
+      const to = Math.min(items.length - 1, Math.max(0, from + delta));
+
+      // applyMove counts gaps, not slots — landing *on* index `to` is the gap
+      // before it going up, and the gap after it going down.
+      const next = applyMove(items, from, to > from ? to + 1 : to);
+      if (!next) {
+        setAnnouncement(
+          `${item.title} is already at position ${from + 1} of ${items.length}.`,
+        );
+        return;
+      }
+
+      onReorder?.(next);
+      setAnnouncement(
+        `${item.title}, position ${to + 1} of ${items.length}.`,
+      );
     },
     [items, onReorder],
   );
 
-  // Keyboard handler for reordering
   const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent, itemId: number) => {
+    (e: React.KeyboardEvent, item: WishlistItem) => {
       if (!isDraggable) return;
 
-      // Space or Enter: toggle moving mode
+      const position = () =>
+        items.findIndex((candidate) => candidate.id === item.id) + 1;
+
       if (e.key === " " || e.key === "Enter") {
-        // Don't trigger if focus is on a button inside the card
-        if ((e.target as HTMLElement).tagName === "BUTTON") return;
-
+        // Not when the focus is on one of the card's own buttons.
+        if ((e.target as HTMLElement).closest("button")) return;
         e.preventDefault();
 
-        if (keyboardMovingId === itemId) {
-          // Confirm move
+        if (keyboardMovingId === item.id) {
+          keyboardOriginRef.current = null;
           setKeyboardMovingId(null);
+          setAnnouncement(
+            `${item.title} dropped at position ${position()} of ${items.length}.`,
+          );
         } else {
-          // Start moving
-          setKeyboardMovingId(itemId);
+          keyboardOriginRef.current = items;
+          setKeyboardMovingId(item.id);
+          setAnnouncement(
+            `${item.title} picked up, position ${position()} of ${items.length}. Arrow keys to move, Enter to drop, Escape to cancel.`,
+          );
         }
         return;
       }
 
-      // Escape: cancel moving
-      if (e.key === "Escape" && keyboardMovingId === itemId) {
+      if (keyboardMovingId !== item.id) return;
+
+      if (e.key === "Escape") {
         e.preventDefault();
+
+        /* A cancel that cancels. The card's own label has always offered this,
+           and the handler behind it only stopped moving — every step taken on
+           the way stayed exactly where the arrow keys had put it. */
+        const origin = keyboardOriginRef.current;
+        if (
+          origin &&
+          origin.some((candidate, i) => candidate.id !== items[i]?.id)
+        ) {
+          onReorder?.(origin);
+        }
+
+        keyboardOriginRef.current = null;
         setKeyboardMovingId(null);
+        setAnnouncement(`Move cancelled. ${item.title} is back where it was.`);
         return;
       }
 
-      // Arrow keys: move item when in moving mode
-      if (keyboardMovingId === itemId) {
-        if (e.key === "ArrowUp" || e.key === "ArrowLeft") {
-          e.preventDefault();
-          moveItemByKeyboard(itemId, -1);
-        } else if (e.key === "ArrowDown" || e.key === "ArrowRight") {
-          e.preventDefault();
-          moveItemByKeyboard(itemId, 1);
-        }
-      }
+      const columns = columnCount();
+      const delta =
+        e.key === "ArrowLeft"
+          ? -1
+          : e.key === "ArrowRight"
+            ? 1
+            : e.key === "ArrowUp"
+              ? -columns
+              : e.key === "ArrowDown"
+                ? columns
+                : 0;
+
+      if (delta === 0) return;
+      e.preventDefault();
+      moveByKeyboard(item, delta);
     },
-    [isDraggable, keyboardMovingId, moveItemByKeyboard],
+    [isDraggable, keyboardMovingId, items, onReorder, columnCount, moveByKeyboard],
   );
 
   if (items.length === 0) {
     return <p className="no-items">No items yet. Add your first item!</p>;
   }
 
+  const listClasses = [
+    "items-list",
+    draggedId !== null ? "is-sorting" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
   return (
-    <div
-      className={`items-list${isDraggable ? " drag-enabled" : ""}`}
-      role={isDraggable ? "list" : undefined}
-      aria-label={isDraggable ? "Reorderable items list" : undefined}
-    >
-      {items.map((item) => (
-        <ItemCard
-          key={item.id}
-          item={item}
-          reservation={reservations.get(item.id)}
-          categoryLabels={getCategoryLabels(item.category)}
-          cdnDomain={cdnDomain}
-          priceRub={convertToRub(item.price, exchangeRates)}
-          isDraggable={isDraggable}
-          isDragging={draggedItemId === item.id}
-          isKeyboardMoving={keyboardMovingId === item.id}
-          dragOverPosition={
-            dragOverItemId === item.id ? dragOverPosition : null
-          }
-          onEdit={() => onEdit(item)}
-          onDelete={() => onDelete(item.id, item.title)}
-          onToggleReceived={() => onToggleReceived(item.id, item.received)}
-          onToggleReserved={() =>
-            onToggleReserved(item.id, reservations.has(item.id))
-          }
-          onDragStart={(e) => handleDragStart(e, item.id)}
-          onDragEnd={handleDragEnd}
-          onDragEnter={(e) => handleDragEnter(e, item.id)}
-          onDragOver={(e) => handleDragOver(e, item.id)}
-          onDragLeave={() => handleDragLeave(item.id)}
-          onDrop={(e) => handleDrop(e, item.id)}
-          onKeyDown={(e) => handleKeyDown(e, item.id)}
-        />
-      ))}
-    </div>
+    <>
+      {/* Where a keyboard move says what it did. A drag has the beam to look
+          at; the arrow keys had nothing at all. */}
+      {isDraggable && (
+        <div className="drag-live-region" role="status" aria-live="polite">
+          {announcement}
+        </div>
+      )}
+
+      <div
+        ref={listRef}
+        className={listClasses}
+        role={isDraggable ? "list" : undefined}
+        aria-label={isDraggable ? "Reorderable items list" : undefined}
+        onDragOver={isDraggable ? handleListDragOver : undefined}
+        onDragLeave={isDraggable ? handleListDragLeave : undefined}
+        onDrop={isDraggable ? handleListDrop : undefined}
+      >
+        {items.map((item) => (
+          <ItemCard
+            key={item.id}
+            item={item}
+            reservation={reservations.get(item.id)}
+            categoryLabels={getCategoryLabels(item.category)}
+            cdnDomain={cdnDomain}
+            priceRub={convertToRub(item.price, exchangeRates)}
+            isDraggable={isDraggable}
+            isDragging={draggedId === item.id}
+            isKeyboardMoving={keyboardMovingId === item.id}
+            dropEdge={beam?.id === item.id ? beam.edge : null}
+            onEdit={() => onEdit(item)}
+            onDelete={() => onDelete(item.id, item.title)}
+            onToggleReceived={() => onToggleReceived(item.id, item.received)}
+            onToggleReserved={() =>
+              onToggleReserved(item.id, reservations.has(item.id))
+            }
+            onDragStart={(e) => handleDragStart(e, item.id)}
+            onDragEnd={endDrag}
+            onGripPointerDown={() => {
+              fromGripRef.current = true;
+            }}
+            onKeyDown={(e) => handleKeyDown(e, item)}
+          />
+        ))}
+      </div>
+    </>
   );
 }

--- a/src/lib/grid-reorder.test.ts
+++ b/src/lib/grid-reorder.test.ts
@@ -1,0 +1,162 @@
+import { expect, test } from "vitest";
+import {
+  insertionAt,
+  isNoOpInsertion,
+  applyMove,
+  type CardBox,
+} from "./grid-reorder";
+
+/**
+ * A grid of `columns` cards per row, each 100×100 with a 20px gutter — the
+ * admin panel's own gap, at a size the arithmetic below stays readable in.
+ * Card 0 spans x 0–100, card 1 spans 120–220, and so on; row 1 starts at y 120.
+ */
+function grid(count: number, columns: number): CardBox[] {
+  return Array.from({ length: count }, (_, i) => {
+    const col = i % columns;
+    const row = Math.floor(i / columns);
+    const left = col * 120;
+    const top = row * 120;
+    return { left, right: left + 100, top, bottom: top + 100 };
+  });
+}
+
+test("an empty grid takes its first item at the front", () => {
+  expect(insertionAt([], 500, 500).index).toBe(0);
+});
+
+test("the left half of a card is the gap before it", () => {
+  const boxes = grid(6, 3);
+  expect(insertionAt(boxes, 130, 50).index).toBe(1);
+});
+
+test("the right half of a card is the gap after it", () => {
+  const boxes = grid(6, 3);
+  expect(insertionAt(boxes, 210, 50).index).toBe(2);
+});
+
+test("the gutter between two cards is the gap they share", () => {
+  const boxes = grid(6, 3);
+  expect(insertionAt(boxes, 110, 50).index).toBe(1);
+});
+
+/**
+ * The bug the old per-card marker had: these are one gap, and the cursor near
+ * either end of it has to name the same index. Card 2 ends row 0, card 3 opens
+ * row 1, and index 3 is the gap between them whichever side you approach from.
+ */
+test("the end of a row and the start of the next are the same gap", () => {
+  const boxes = grid(6, 3);
+  // Past the right edge of card 2, which closes row 0 …
+  expect(insertionAt(boxes, 350, 50).index).toBe(3);
+  // … and before the left edge of card 3, which opens row 1. One gap, one index,
+  // approached from opposite ends of the screen.
+  expect(insertionAt(boxes, -10, 170).index).toBe(3);
+});
+
+/** …and the card and side it names are the end of that gap the cursor is at, so
+    the beam can be drawn where the cursor is rather than a screen away. */
+test("one gap is named at whichever end the cursor is at", () => {
+  const boxes = grid(6, 3);
+  expect(insertionAt(boxes, 350, 50)).toEqual({
+    index: 3,
+    card: 2,
+    edge: "after",
+  });
+  expect(insertionAt(boxes, -10, 170)).toEqual({
+    index: 3,
+    card: 3,
+    edge: "before",
+  });
+});
+
+test("a cursor inside a row ignores the row above it", () => {
+  const boxes = grid(6, 3);
+  // Just inside row 1's band, over card 4. Card 1 sits directly above and is
+  // barely further away in raw pixels; the row the cursor is *in* decides.
+  expect(insertionAt(boxes, 130, 130).index).toBe(4);
+});
+
+/**
+ * The case a flat nearest-edge search gets wrong. Six columns, a last row
+ * holding two cards, and a cursor out in the empty tail of it: card 5 in the
+ * row above shares its x exactly, so raw distance would drag the drop back up a
+ * row instead of putting it at the end where the cursor plainly is.
+ */
+test("the empty tail of a half-filled last row is the end of the list", () => {
+  const boxes = grid(8, 6);
+  expect(insertionAt(boxes, 650, 170).index).toBe(8);
+});
+
+test("past the last card is the end of the list", () => {
+  const boxes = grid(6, 3);
+  expect(insertionAt(boxes, 400, 400).index).toBe(6);
+});
+
+/** Below the grid the beam still tracks the cursor's column rather than jumping
+    to the end — the drop lands where it is drawn, which is the point. */
+test("below the grid the column still decides", () => {
+  const boxes = grid(6, 3);
+  expect(insertionAt(boxes, 240, 400).index).toBe(5);
+});
+
+test("above the first row is the front of the list", () => {
+  const boxes = grid(6, 3);
+  expect(insertionAt(boxes, 10, -200).index).toBe(0);
+});
+
+test("a single column reads top to bottom", () => {
+  const boxes = grid(3, 1);
+  expect(insertionAt(boxes, 50, 10).index).toBe(0);
+  expect(insertionAt(boxes, 50, 90).index).toBe(1);
+  // The gutter between the first two cards is the gap they share.
+  expect(insertionAt(boxes, 50, 110).index).toBe(1);
+  expect(insertionAt(boxes, 50, 250).index).toBe(2);
+  expect(insertionAt(boxes, 50, 400).index).toBe(3);
+});
+
+test("both gaps touching an item mean 'leave it alone'", () => {
+  expect(isNoOpInsertion(2, 2)).toBe(true);
+  expect(isNoOpInsertion(2, 3)).toBe(true);
+  expect(isNoOpInsertion(2, 1)).toBe(false);
+  expect(isNoOpInsertion(2, 4)).toBe(false);
+});
+
+test("moving forward accounts for the item leaving its own slot", () => {
+  expect(applyMove(["a", "b", "c", "d"], 0, 3)).toEqual(["b", "c", "a", "d"]);
+});
+
+test("moving backward inserts at the gap as counted", () => {
+  expect(applyMove(["a", "b", "c", "d"], 3, 1)).toEqual(["a", "d", "b", "c"]);
+});
+
+test("moving to the end", () => {
+  expect(applyMove(["a", "b", "c"], 0, 3)).toEqual(["b", "c", "a"]);
+});
+
+test("moving to the front", () => {
+  expect(applyMove(["a", "b", "c"], 2, 0)).toEqual(["c", "a", "b"]);
+});
+
+test("a move that changes nothing returns null", () => {
+  expect(applyMove(["a", "b", "c"], 1, 1)).toBeNull();
+  expect(applyMove(["a", "b", "c"], 1, 2)).toBeNull();
+});
+
+test("out-of-range indices return null rather than a mangled list", () => {
+  expect(applyMove(["a", "b"], -1, 0)).toBeNull();
+  expect(applyMove(["a", "b"], 2, 0)).toBeNull();
+  expect(applyMove(["a", "b"], 0, 3)).toBeNull();
+});
+
+test("every gap is reachable and the list keeps its members", () => {
+  const list = ["a", "b", "c", "d", "e"];
+  for (let from = 0; from < list.length; from++) {
+    for (let at = 0; at <= list.length; at++) {
+      const moved = applyMove(list, from, at);
+      if (moved === null) continue;
+      expect([...moved].sort()).toEqual([...list].sort());
+      expect(moved).toHaveLength(list.length);
+    }
+  }
+});

--- a/src/lib/grid-reorder.ts
+++ b/src/lib/grid-reorder.ts
@@ -1,0 +1,174 @@
+/**
+ * Where a drag would drop, in a grid that wraps.
+ *
+ * The admin panel lays its cards out in a CSS grid of one to six columns, and
+ * the thing being dragged lands *between* two of them. That gap is the unit
+ * this module works in: an insertion index in `0..list.length`, where `k` means
+ * "before the item currently at k", and `list.length` means "at the very end".
+ *
+ * Working in gaps rather than in "this card, on its left or right side" is what
+ * makes a wrapping grid behave. The end of one row and the start of the next
+ * are the same gap — index k — even though they sit at opposite edges of the
+ * screen, and a drop measured as a card plus a side has no way to say so. The
+ * panel used to answer "after the last card of row 1" and "before the first
+ * card of row 2" as two different drops, and drew them a screen apart.
+ *
+ * A module of its own, next to `@lib/wishlist-sort`, for the same reason that
+ * one exists: this is arithmetic, it is easy to get subtly wrong exactly at the
+ * row boundaries, and it is worth a test that doesn't need a browser.
+ */
+
+/** A card's box on the page. Page coordinates, not viewport ones — the page can
+    scroll mid-drag, and these are measured once, when the drag begins. */
+export type CardBox = {
+  left: number;
+  right: number;
+  top: number;
+  bottom: number;
+};
+
+/** Sub-pixel slack when deciding whether two cards share a row. */
+const ROW_TOLERANCE = 1;
+
+/** A run of boxes sharing a row, as a half-open range over the box array. */
+type Row = { start: number; end: number; top: number; bottom: number };
+
+/** How far outside `lo..hi` a value falls; zero anywhere inside it. */
+function bandDistance(value: number, lo: number, hi: number): number {
+  if (value < lo) return lo - value;
+  if (value > hi) return value - hi;
+  return 0;
+}
+
+/**
+ * The rows, read straight off the boxes. A grid in its default flow lays cards
+ * out in source order, so a row is simply a run of consecutive boxes sharing a
+ * top edge — no need to know the column count, which is a media query's
+ * business and changes four times between a phone and a wide monitor.
+ */
+function rowsOf(boxes: readonly CardBox[]): Row[] {
+  const rows: Row[] = [];
+
+  for (let i = 0; i < boxes.length; i++) {
+    const box = boxes[i];
+    const open = rows[rows.length - 1];
+
+    if (open && Math.abs(box.top - open.top) <= ROW_TOLERANCE) {
+      open.end = i + 1;
+      open.bottom = Math.max(open.bottom, box.bottom);
+    } else {
+      rows.push({ start: i, end: i + 1, top: box.top, bottom: box.bottom });
+    }
+  }
+
+  return rows;
+}
+
+/**
+ * A gap, named twice over: `index` is where the item would land, and `card` +
+ * `edge` are the side of the card the cursor is actually pointing at.
+ *
+ * Both, because one gap has two ends. The end of a row and the start of the
+ * next are the same index, and a beam drawn only ever at the index — always the
+ * left of the following card — leaps a screen's width away from the cursor the
+ * moment it crosses a row boundary. `card`/`edge` say which end to draw it at,
+ * which is the end the cursor is at. The drop is the same either way.
+ */
+export type Insertion = {
+  index: number;
+  card: number;
+  edge: "before" | "after";
+};
+
+/**
+ * The gap nearest to a point — for any point on the page, including the gutters
+ * between cards and the empty space past the last one. That generality is half
+ * the fix: the gutters belonged to no card, so an indicator driven by each
+ * card's own `dragover` blinked out every time the cursor crossed one.
+ *
+ * The search is hierarchical rather than a single nearest-edge sweep, because a
+ * grid is: pick the row the cursor is in (or nearest to), then the card within
+ * it, then the side. A flat sweep gets the tail of a half-empty last row wrong
+ * — the cursor sits in the last row's band with no card near it horizontally,
+ * and the card directly above wins on raw distance, so dropping into the empty
+ * space after the final card silently meant "back up into the previous row".
+ */
+export function insertionAt(
+  boxes: readonly CardBox[],
+  x: number,
+  y: number,
+): Insertion {
+  if (boxes.length === 0) return { index: 0, card: 0, edge: "before" };
+
+  const rows = rowsOf(boxes);
+
+  // A single column carries no horizontal information: every card's left and
+  // right edge is the same distance from the cursor, so the side has to be read
+  // off y instead. Asked of the grid as a whole, not of one row — a six-column
+  // grid whose last row holds one card still flows left to right.
+  const stacked = rows.every((row) => row.end - row.start === 1);
+
+  let row = rows[0];
+  let rowDistance = Infinity;
+  for (const candidate of rows) {
+    const distance = bandDistance(y, candidate.top, candidate.bottom);
+    if (distance < rowDistance) {
+      rowDistance = distance;
+      row = candidate;
+    }
+  }
+
+  let index = row.start;
+  let columnDistance = Infinity;
+  for (let i = row.start; i < row.end; i++) {
+    const distance = bandDistance(x, boxes[i].left, boxes[i].right);
+    if (distance < columnDistance) {
+      columnDistance = distance;
+      index = i;
+    }
+  }
+
+  const box = boxes[index];
+  const past = stacked
+    ? y > (box.top + box.bottom) / 2
+    : x > (box.left + box.right) / 2;
+
+  return {
+    index: past ? index + 1 : index,
+    card: index,
+    edge: past ? "after" : "before",
+  };
+}
+
+/**
+ * Whether dropping at `insertAt` would put the item back where it already is.
+ *
+ * Two indices mean that, not one: the gap before an item and the gap after it
+ * are both "don't move". The panel uses this to keep the beam off a drop that
+ * would change nothing, so the feedback never promises a move it won't make.
+ */
+export function isNoOpInsertion(from: number, insertAt: number): boolean {
+  return insertAt === from || insertAt === from + 1;
+}
+
+/**
+ * The list with one item moved into a gap, or `null` if nothing would change.
+ *
+ * `insertAt` is counted against the list as it stands *now*, before the item is
+ * lifted out — so once it has been removed, every gap past it has shifted down
+ * by one.
+ */
+export function applyMove<T>(
+  list: readonly T[],
+  from: number,
+  insertAt: number,
+): T[] | null {
+  if (from < 0 || from >= list.length) return null;
+  if (insertAt < 0 || insertAt > list.length) return null;
+  if (isNoOpInsertion(from, insertAt)) return null;
+
+  const next = list.slice();
+  const [moved] = next.splice(from, 1);
+  next.splice(insertAt > from ? insertAt - 1 : insertAt, 0, moved);
+  return next;
+}

--- a/src/styles/admin/items.css
+++ b/src/styles/admin/items.css
@@ -2,9 +2,12 @@
 
 /* Items Grid */
 .items-list {
+  /* Named, because the insertion beam has to be drawn in the middle of it. */
+  --grid-gap: 1.25rem;
+
   display: grid;
   grid-template-columns: repeat(6, 1fr);
-  gap: 1.25rem;
+  gap: var(--grid-gap);
 }
 
 @media (max-width: 1400px) {
@@ -118,28 +121,218 @@
   opacity: 0.55;
 }
 
-/* Draggable state */
-.item-card.draggable {
+/* =============================================================================
+   Reordering.
+
+   Three things have to be legible while a card is in the air: what is being
+   carried, where it would land, and that the rest of the grid is holding still
+   until it does. The panel used to say all three with box-shadows on the cards
+   themselves, which is why none of them read — a shadow is the card's own
+   depth, and every one of these is about the space between cards.
+   ============================================================================= */
+
+/* The grip. Nothing until the cursor finds the card, and even then a quiet
+   glass tab: the photograph is the card's subject and this is a control. It
+   sits on the image, so it takes the on-media tokens — the same neutral capsule
+   the status badges wear a few centimetres to its left. */
+.item-grip {
+  position: absolute;
+  top: 0.6rem;
+  right: 0.6rem;
+  /* Above the card's own rim, which is on ::before at 3. */
+  z-index: 4;
+  display: grid;
+  place-items: center;
+  width: 30px;
+  height: 30px;
+  border-radius: 10px;
   cursor: grab;
+  color: #fff;
+  background-color: var(--glass-bg-on-media);
+  backdrop-filter: var(--glass-filter);
+  border: var(--glass-border-on-media);
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.28);
+  opacity: 0;
+  transform: translateY(-6px);
+  transition:
+    opacity 0.25s ease,
+    transform 0.3s cubic-bezier(0.16, 1, 0.3, 1);
 }
 
-.item-card.draggable:active {
+.item-grip:active {
   cursor: grabbing;
 }
 
-.item-card.dragging {
-  opacity: 0.4;
-  transform: scale(0.98);
+.item-card:hover .item-grip,
+.item-card:focus-visible .item-grip,
+.item-card.keyboard-moving .item-grip {
+  opacity: 1;
+  transform: none;
 }
 
-/* Keyboard moving state — the accent ring and glow the wishlist's random pick
-   wears, which is the site's way of saying "this one, right now". */
-.item-card.keyboard-moving {
-  outline: 3px solid var(--accent-start);
-  outline-offset: 2px;
+/* No hover to arrive on, so it simply stays. */
+@media (hover: none) {
+  .item-grip {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@media (prefers-reduced-transparency: reduce) {
+  .item-grip {
+    background-color: rgb(24, 24, 28);
+    backdrop-filter: none;
+  }
+}
+
+/* The card being carried is not in the grid any more, and what is left in its
+   place is a slot. Fading it to 40% — what this used to do — reads as
+   "disabled", and it kept its shadow and its frost, so the grid looked like it
+   had grown one broken card rather than opened a space. */
+.item-card.dragging {
+  background: light-dark(rgba(237, 87, 96, 0.05), rgba(237, 98, 146, 0.06));
+  border-color: transparent;
+  box-shadow: none;
+  backdrop-filter: none;
+}
+
+.item-card.dragging::before {
+  box-shadow: none;
+  border: 2px dashed
+    light-dark(rgba(237, 87, 96, 0.4), rgba(237, 98, 146, 0.32));
+}
+
+.item-card.dragging > * {
+  opacity: 0.1;
+}
+
+/* Including the grip, which the hover rule above would otherwise keep lit on
+   the one card that has just left. */
+.item-card.dragging:hover .item-grip {
+  opacity: 0.1;
+}
+
+.item-image,
+.item-content {
+  transition: opacity 0.25s ease;
+}
+
+/* The insertion beam. It is drawn in the gutter, because that is what it means:
+   not "this card", but "here, between these two".
+
+   The marker it replaces was a 4px box-shadow on a card's own edge, and it had
+   both halves of the problem. It cost the card its shadow the moment it lit up,
+   since the two shared one property. And at the end of a row it pointed at the
+   right-hand edge of the screen for a drop that would land at the left of the
+   next one — the end of one row and the start of the next being one gap, drawn
+   twice, a screen apart. */
+.item-card.drop-before::after,
+.item-card.drop-after::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 3px;
+  border-radius: 999px;
+  z-index: 6;
+  pointer-events: none;
+  background: linear-gradient(180deg, var(--accent-start), var(--accent-end));
+  /* A hairline of the page's own colour first, so the beam stays a beam
+     against a card edge it happens to sit close to, then the glow. */
   box-shadow:
-    0 0 0 6px rgba(237, 87, 96, 0.22),
-    var(--glass-shadow);
+    0 0 0 1.5px light-dark(rgba(248, 248, 255, 0.75), rgba(25, 25, 25, 0.6)),
+    0 0 16px light-dark(rgba(237, 87, 96, 0.45), rgba(237, 98, 146, 0.5));
+  animation: drop-beam 0.2s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.item-card.drop-before::after {
+  left: calc(var(--grid-gap) / -2 - 1.5px);
+}
+
+.item-card.drop-after::after {
+  right: calc(var(--grid-gap) / -2 - 1.5px);
+}
+
+@keyframes drop-beam {
+  from {
+    transform: scaleY(0.25);
+    opacity: 0;
+  }
+  to {
+    transform: scaleY(1);
+    opacity: 1;
+  }
+}
+
+/* One column: the gutters are horizontal, and so is the beam. */
+@media (max-width: 500px) {
+  .item-card.drop-before::after,
+  .item-card.drop-after::after {
+    top: auto;
+    bottom: auto;
+    left: 0;
+    right: 0;
+    width: auto;
+    height: 3px;
+    background: linear-gradient(90deg, var(--accent-start), var(--accent-end));
+    animation-name: drop-beam-across;
+  }
+
+  .item-card.drop-before::after {
+    top: calc(var(--grid-gap) / -2 - 1.5px);
+  }
+
+  .item-card.drop-after::after {
+    bottom: calc(var(--grid-gap) / -2 - 1.5px);
+  }
+
+  @keyframes drop-beam-across {
+    from {
+      transform: scaleX(0.25);
+      opacity: 0;
+    }
+    to {
+      transform: scaleX(1);
+      opacity: 1;
+    }
+  }
+}
+
+/* While something is in the air the grid holds still. A card lifting under the
+   cursor would compete with the beam for attention and, worse, move the very
+   edges the drop is being measured against — the geometry is read once, when
+   the drag starts, and a hovered card that has risen 4px is no longer where the
+   arithmetic thinks it is. */
+.items-list.is-sorting .item-card:hover {
+  transform: none;
+  box-shadow: var(--glass-shadow);
+}
+
+.items-list.is-sorting .item-card:hover::before {
+  box-shadow: var(--glass-rim);
+}
+
+.items-list.is-sorting .item-card:hover .item-image img {
+  transform: none;
+}
+
+.items-list.is-sorting .item-card.dragging,
+.items-list.is-sorting .item-card.dragging:hover {
+  box-shadow: none;
+}
+
+/* Keyboard moving — the same card, lifted. There is no beam to draw here
+   because the card itself moves through the grid on every keystroke, so the
+   state has to say "you are holding this one": it rises, takes the lit rim the
+   hover state uses, and wears the accent ring. */
+.item-card.keyboard-moving {
+  z-index: 2;
+  outline: 2px solid var(--accent-end);
+  outline-offset: 3px;
+  transform: translateY(-4px);
+  box-shadow:
+    0 18px 36px -12px light-dark(rgba(237, 87, 96, 0.35), rgba(0, 0, 0, 0.6)),
+    0 0 0 7px light-dark(rgba(237, 87, 96, 0.13), rgba(237, 98, 146, 0.15));
 }
 
 .item-card.keyboard-moving::before {
@@ -156,21 +349,21 @@
   outline: none;
 }
 
-/* Drop markers — the accent bar on the side the card would land. */
-.item-card.drag-over-before {
-  box-shadow:
-    -4px 0 0 0 var(--accent-start),
-    var(--glass-shadow);
-}
+/* Selection is left alone. It used to be killed across the whole grid so that a
+   drag off a title wouldn't start one — with the grip owning drags, a title is
+   just text again, and copying one out of the panel works. */
 
-.item-card.drag-over-after {
-  box-shadow:
-    4px 0 0 0 var(--accent-start),
-    var(--glass-shadow);
-}
-
-.items-list.drag-enabled {
-  user-select: none;
+/* What a keyboard move says, for a reader that can't see the card move. */
+.drag-live-region {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
 }
 
 /* Item Image */


### PR DESCRIPTION
Reordering the wishlist worked, but nothing on screen said so convincingly. This
is the feedback, rebuilt on the unit a wrapping grid actually has.

## The problem

A drop was described as *"this card, on this side"*. A grid that wraps cannot
express a drop that way — the end of one row and the start of the next are **one
gap**, and naming it twice drew it at opposite edges of the screen for the same
outcome.

Three more things followed from the same design:

- The marker was a `box-shadow` on the card, the property already holding its
  shadow. A card went flat the moment the marker lit up.
- `dragover` sat on each card, so the gutters between them belonged to nobody
  and the marker blinked out every time the cursor crossed one.
- The whole card was `draggable`. A press on **Edit** that travelled a few
  pixels flung the card across the grid, the photograph started an image drag of
  its own, and the panel had to kill text selection everywhere to compensate.

## The fix

`src/lib/grid-reorder.ts` works in gaps — an insertion index in `0..length` —
against a snapshot of the grid taken once, when the drag begins. One `dragover`
for the whole list. The search runs row first, then column, then side: a flat
nearest-edge sweep sends a drop in the empty tail of a half-filled last row back
up into the row above. It returns both where the item lands and which end of the
gap the cursor is at, so the beam can be drawn under the cursor instead of a
screen away.

What the owner sees follows from that:

- The **beam** is drawn in the gutter, full height, and not at all when the drop
  would change nothing.
- The card being carried leaves a **dashed slot** rather than fading to 40%,
  which read as disabled.
- The grid **holds still** underneath — a card lifting on hover competed with
  the beam and moved the very edges the drop is measured against.
- Dragging is a **grip's** job now; a `dragstart` from anywhere else is refused.

## Fixed on the way

- The drag image was snapshotted *after* the card had been marked as lifted, so
  the cursor carried a picture of the hole.
- <kbd>Escape</kbd> has always offered to cancel a keyboard move and only ever
  stopped moving, leaving every step it had taken in place.
- <kbd>↑</kbd>/<kbd>↓</kbd> moved by one in a six-column grid, where down means
  a row.
- A live region announces keyboard moves; `aria-grabbed`, dropped from ARIA
  years ago, is gone.

## Testing

`src/lib/grid-reorder.test.ts` covers the arithmetic — row wrapping, gutters,
the half-filled last row, single-column stacking, and that every reachable gap
keeps the list's members. 67 tests pass, `astro check` is clean, the production
build succeeds.

Driven by hand against the real 62-card panel: a drag lands exactly where the
beam pointed and leaves no stray state, a `dragstart` not from the grip is
refused, and the full keyboard path (pick up → move a row → cancel) restores the
original order and announces each step. No console errors.

**Not verified visually:** the light scheme. `light-dark()` could not be flipped
from inside the page, and I left the system setting alone. Both branches are
authored to the file's existing convention, but I have not seen them rendered.

## Noticed, deliberately left alone

Received items can be dragged, but `calculateNewWeights` filters them out — the
move is silently discarded on save. That is behaviour rather than feedback, so
it is not in this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JbXbZK5UZxM7m3CC3Za8M4