### PR TITLE
The home page answers the cursor, and three surfaces find their edge

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -17,6 +17,19 @@ colors:
   ink-muted-dark: "#9a9aa0"
   hairline-light: "#dddddd"
   hairline-dark: "#444444"
+  hairline-hover-light: "#bbbbbb"
+  hairline-hover-dark: "#666666"
+  hairline-contrast-light: "#999999"
+  hairline-contrast-dark: "#777777"
+  field-bg-dark: "rgba(30, 30, 35, 0.8)"
+  link-hover-dark: "#ff9eae"
+  visited-light: "#8b5a7c"
+  visited-dark: "#d4a5c9"
+  code-light: "#c81f48"
+  code-dark: "#ff6b6b"
+  mark-light: "#fbbf24"
+  mark-dark: "#f0b429"
+  mark-ink: "#1a1400"
   focus-ring-on-fill-light: "#333333"
   focus-ring-on-fill-dark: "#ffffff"
   success-start: "#00875d"
@@ -54,12 +67,30 @@ typography:
     fontWeight: 600
     lineHeight: 1.2
     letterSpacing: "-0.02em"
+  heading-3:
+    fontFamily: "InterVariable, system-ui, sans-serif"
+    fontSize: "clamp(1.25rem, 3vw, 1.75rem)"
+    fontWeight: 600
+  heading-4:
+    fontFamily: "InterVariable, system-ui, sans-serif"
+    fontSize: "clamp(1.125rem, 2.5vw, 1.375rem)"
+    fontWeight: 600
+  heading-5:
+    fontFamily: "InterVariable, system-ui, sans-serif"
+    fontSize: "clamp(1rem, 2vw, 1.125rem)"
+    fontWeight: 600
+    letterSpacing: "-0.01em"
   body:
     fontFamily: "InterVariable, system-ui, sans-serif"
     fontSize: "1rem"
     fontWeight: 400
     lineHeight: 1.75
     fontFeature: "'liga' 1, 'calt' 1, 'ss03' 1"
+  body-compact:
+    fontFamily: "InterVariable, system-ui, sans-serif"
+    fontSize: "0.9375rem"
+    fontWeight: 400
+    lineHeight: 1.75
   label:
     fontFamily: "InterVariable, system-ui, sans-serif"
     fontSize: "0.75rem"
@@ -71,7 +102,25 @@ typography:
     fontSize: "0.875rem"
     fontWeight: 400
     lineHeight: 1.5
+  control-xs:
+    fontFamily: "InterVariable, system-ui, sans-serif"
+    fontSize: "0.7rem"
+    fontWeight: 600
+  control-sm:
+    fontFamily: "InterVariable, system-ui, sans-serif"
+    fontSize: "0.75rem"
+    fontWeight: 600
+  control-md:
+    fontFamily: "InterVariable, system-ui, sans-serif"
+    fontSize: "0.8rem"
+    fontWeight: 600
+  control-lg:
+    fontFamily: "InterVariable, system-ui, sans-serif"
+    fontSize: "0.9rem"
+    fontWeight: 600
 rounded:
+  mark: "2px"
+  code: "4px"
   xs: "6px"
   sm: "8px"
   md: "10px"
@@ -271,6 +320,10 @@ locally. 189 declarations now read a token.
   in practice: 30 declarations sat between body and muted, closer to muted.
 - **Hairline** (`#ddd` / `#444`): 2px control borders, rules, dividers. At
   `prefers-contrast: more` these tighten to `#999` / `#777`.
+- **Hairline Hover** (`#bbb` / `#666`): the same edge with the pointer on it —
+  one step nearer the ink, never a colour change. Four stylesheets had written
+  this pair out by hand, two of them within three lines of a hand-written copy
+  of the hairline itself; it is `--hairline-hover` now.
 - **Focus Ring on Fill** (`#333` / `#fff`): the focus ring for a control whose
   focus arrives *on* a fill, where an accent outline would land on the accent
   and vanish. Twelve places had reached this pair independently.
@@ -355,15 +408,25 @@ body text stays generous.
   sections. `3rem` of space above, `1.25rem` below.
 - **Title** (600, `1.25rem`): group landmarks — a year on the timeline, a
   continent, a checklist category. These are sticky and sit on the veil.
+- **Prose headings** (600, fluid): the levels under Headline, for the inside of
+  a post — h3 `clamp(1.25rem, 3vw, 1.75rem)`, h4 `clamp(1.125rem, 2.5vw,
+  1.375rem)`, h5 `clamp(1rem, 2vw, 1.125rem)`, h6 `clamp(0.875rem, 1.5vw,
+  1rem)` in uppercase. They only ever appear in written content; the interface
+  itself stops at Title.
 - **Body** (400, `1rem`, 1.75): paragraphs, dropping to `0.9375rem` under 768px.
-  Prose column caps at 800px. A blog post is the one surface that sets its own
-  size — see The Reading Measure.
+  Prose column caps at 800px. That compact step is also what a table takes at
+  any width — a table is read, and it used to sit at `0.95rem`, a fourth
+  reading size a fifth of a pixel away from this one. A blog post is the one
+  surface that sets its own size — see The Reading Measure.
 - **Label** (600, `0.75rem`, `0.03em`, uppercase for badges): controls, badges,
-  counts, chips. Sizes step with the control: `0.7rem` at 28px tall through
-  `0.9rem` at 44px.
-- **Mono** (`0.875rem`, `1rem` in a post): inline code takes a tinted ground and
-  a red-tone colour (`#d14` / `#ff6b6b`); block code is transparent on Shiki's
-  own dual theme. Inline code is sized in `em`, so it rides whatever it sits in.
+  counts, chips. Sizes step with the control: `0.7rem` at 28px tall, `0.75rem`
+  at 32px, `0.8rem` at 38px, `0.9rem` at 44px. A control of a given height has
+  one size, whatever kind of control it is — the large select carried `0.95rem`
+  next to a large button's `0.9rem` until this was written down.
+- **Mono** (`0.875rem`, `1rem` in a post): inline code takes a tinted ground —
+  the page's own ink at 6%, not a black of its own — and a red-tone colour
+  (`#c81f48` / `#ff6b6b`); block code is transparent on Shiki's own dual theme.
+  Inline code is sized in `em`, so it rides whatever it sits in.
 
 ### Named Rules
 
@@ -517,6 +580,11 @@ past even hover brightness and decays over ~1.5s. Nothing scales — scaling
 resamples a photograph and the text on top of it for the length of the
 transition.
 
+Controls have a ground of their own, `--field-bg`: white at 80% on the light
+page, `rgba(30, 30, 35, 0.8)` on the dark one. Not a card and not a capsule —
+it is what an input, a select or an admin form field is filled with, and it was
+the one surface tint with no name, written out identically in four stylesheets.
+
 A third material sits outside both: **the veil**, the page's own colour at 97%
 with a 24px saturating blur, used by anything pinned with content scrolling
 underneath. It is not glass — a capsule is a neutral tint you look *through*,
@@ -608,11 +676,18 @@ parent's radius minus its border width, not the same value and not zero.
   a matching glow (`0 2px 8px rgba(237,87,96,.3)`). The face is the brand at
   full brightness; only the lettering is dark. Hover deepens the shadow and
   lifts 1px; active returns to 0.
-- **Secondary:** a 5%/8% neutral wash, no border, text at body ink.
-- **Ghost:** transparent with a 2px inset ring. When active or
-  `aria-pressed="true"` it takes the accent gradient and white text.
+- **Secondary:** a neutral wash, no border, text at body ink. The wash is the
+  page's own ink thinned — 5% on paper, twice that on the dark page, where white
+  at 5% is nothing — never a black or a white of its own.
+- **Ghost:** transparent with a 2px inset ring at `--hairline`, going to
+  `--hairline-hover` under the pointer. When active or `aria-pressed="true"` it
+  takes the accent gradient and white text.
 - **Danger:** tinted red ground, red text, red inset ring. Never a solid fill.
-- **Success:** green gradient, treated exactly as primary.
+  Ground, ring and label are one colour at four strengths, mixed from `--danger`
+  rather than typed out: they were two reds for a while, the label semantic and
+  the ground a leftover Tailwind red-600, and nothing said they had drifted.
+- **Success:** green gradient, treated exactly as primary. Its glow is the
+  button's own `--success-start` thinned, for the same reason.
 - **Focus:** `2px solid var(--accent-start)` at `2px` offset, on every variant.
 - **Loading:** text goes transparent and a 1em spinner with a transparent
   right-edge rotates in place at 0.6s — the button never changes size.

--- a/src/client/shape-follow.ts
+++ b/src/client/shape-follow.ts
@@ -1,0 +1,132 @@
+// The blob behind the avatar leans toward the cursor and settles back on a
+// spring.
+//
+// Not initMagnet (magnet.ts). That one is a local, six-pixel lerp for controls
+// the cursor is already on top of: it says "this thing is under your pointer".
+// This is the opposite scale — a 20rem backdrop reacting to a pointer anywhere
+// on the page, which needs a longer reach, a much weaker coupling, and real
+// overshoot, because a shape this size arriving without any wobble reads as a
+// slide rather than as something liquid. The idiom is still the site's: lerp
+// or spring toward a target, stop the loop at rest, sit out reduced motion.
+//
+// It also has a neighbour on this very page — the avatar's eyes already follow
+// the cursor (eye-moving.ts). The figure was watching you from a backdrop that
+// was not; now they notice together.
+
+// From magnet.ts, which already exports it — and importing rather than
+// re-declaring is also what keeps this file a module, since two page scripts
+// sharing a global `const prefersReducedMotion` is a redeclaration error.
+import { prefersReducedMotion } from "./magnet";
+
+const REACH = 560; // Cursor distance over which the pull scales in, px
+const MAX = 18; // Furthest the shape may drift from rest, px
+const TILT = 1.6; // Furthest it may lean, deg
+// Two stages of smoothing, because a pointer does not move like a finger on
+// glass — it teleports. The first stage eases the goal itself, so a flick
+// across the page becomes a ramp instead of a step, and the second is the
+// spring that chases it. A stiff spring on a stepping target is what made the
+// first pass snap.
+const FOLLOW = 0.09; // Per-frame easing of the goal the spring is chasing
+const STIFFNESS = 0.03; // Spring constant: how hard it is pulled to target
+const DAMPING = 0.85; // Velocity retained per frame; below 1 or it never rests
+const REST = 0.05; // Below this (px and px/frame) the loop stops
+
+// A coarse pointer has no hover to react to, and reading a touch as a cursor
+// would make the shape jump on every tap.
+const hasFinePointer = window.matchMedia("(hover: hover) and (pointer: fine)")
+  .matches;
+
+const shape = document.querySelector<HTMLElement>(".shape");
+
+if (shape && hasFinePointer && !prefersReducedMotion) {
+  const current = { x: 0, y: 0 };
+  const velocity = { x: 0, y: 0 };
+  const target = { x: 0, y: 0 };
+  const goal = { x: 0, y: 0 };
+  let running = false;
+
+  function frame() {
+    if (!shape) return;
+
+    // Stage one: the goal drifts toward where the cursor last was, so the
+    // spring is never handed a discontinuity.
+    target.x += (goal.x - target.x) * FOLLOW;
+    target.y += (goal.y - target.y) * FOLLOW;
+
+    // Stage two: spring integration rather than a lerp: the velocity term is
+    // what lets it pass its target slightly and swing back, and that overshoot
+    // is the whole difference between liquid and mechanical.
+    velocity.x = (velocity.x + (target.x - current.x) * STIFFNESS) * DAMPING;
+    velocity.y = (velocity.y + (target.y - current.y) * STIFFNESS) * DAMPING;
+    current.x += velocity.x;
+    current.y += velocity.y;
+
+    // The lean is taken from where the shape actually is, not from where the
+    // cursor is, so the deformation arrives with the movement and unwinds with
+    // it. `rotate` is left alone — the spin animation owns that property.
+    const leanX = (current.x / MAX) * TILT;
+    const leanY = (current.y / MAX) * TILT;
+    shape.style.transform =
+      `translate(${current.x.toFixed(2)}px, ${current.y.toFixed(2)}px) ` +
+      `skew(${leanX.toFixed(2)}deg, ${leanY.toFixed(2)}deg)`;
+
+    // The goal has to be reached too, not just the target: the easing stage
+    // moves slowly enough that the spring can sit still on a target that is
+    // itself still travelling, and stopping there would strand the shape.
+    const settled =
+      Math.abs(goal.x - target.x) < REST &&
+      Math.abs(goal.y - target.y) < REST &&
+      Math.abs(current.x - target.x) < REST &&
+      Math.abs(current.y - target.y) < REST &&
+      Math.abs(velocity.x) < REST &&
+      Math.abs(velocity.y) < REST;
+
+    if (settled) {
+      running = false;
+      return;
+    }
+    requestAnimationFrame(frame);
+  }
+
+  function kick() {
+    if (!running) {
+      running = true;
+      requestAnimationFrame(frame);
+    }
+  }
+
+  function rest() {
+    goal.x = 0;
+    goal.y = 0;
+    kick();
+  }
+
+  document.addEventListener(
+    "pointermove",
+    (e) => {
+      if (e.pointerType !== "mouse") return;
+      if (!shape) return;
+
+      const rect = shape.getBoundingClientRect();
+      const dx = e.clientX - (rect.left + rect.width / 2);
+      const dy = e.clientY - (rect.top + rect.height / 2);
+      const distance = Math.hypot(dx, dy);
+      // Falls off with distance instead of clamping: near the shape the pull is
+      // at full strength, and across the page it fades out rather than sticking
+      // at the maximum the whole time the cursor is far away.
+      const falloff = Math.max(0, 1 - distance / REACH);
+      const pull = (falloff * MAX) / (distance || 1);
+
+      goal.x = dx * pull;
+      goal.y = dy * pull;
+      kick();
+    },
+    { passive: true },
+  );
+
+  document.addEventListener("pointerleave", rest);
+  window.addEventListener("blur", rest);
+  document.addEventListener("visibilitychange", () => {
+    if (document.hidden) rest();
+  });
+}

--- a/src/components/travel/TravelStats.astro
+++ b/src/components/travel/TravelStats.astro
@@ -92,12 +92,14 @@ import {
     /* The page's own grid gap, so the stats sit on the same rhythm as the map
        and the trip list rather than a tighter one of their own. */
     gap: 1.25rem;
-    /* And out to the page's shared edge. A row's hover wash bleeds 0.75rem past
-       the content edge by design — the text stays put and the wash reaches into
-       the gutter — which used to leave these cards ending 12px short of it, so
-       the page had two different left edges and the wash looked like it was
-       escaping. Now everything that draws a surface ends on the same line. */
-    margin-inline: -0.75rem;
+    /* Flush with the content edge, like everything else on the page.
+       These cards used to bleed 0.75rem to meet a trip row's hover wash, on
+       the argument that everything drawing a surface should end on one line.
+       The flaw is that the wash only exists under the pointer: it is a hover
+       affordance, not an edge, and aligning a permanent surface to a transient
+       one buys agreement nobody is looking at while the stats sit visibly
+       wider than the heading above them for the whole rest of the time. */
+    margin-inline: 0;
   }
 
   /* The same material as a wishlist card: tint, border, shadow and rim all from

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -318,9 +318,12 @@ const personSchema = {
     }
   }
 
+  /* The individual `rotate` property, not a transform: shape-follow.ts owns
+     `transform` on this element, and an animation on the same property would
+     win against it every frame. The two compose instead. */
   @keyframes spin {
     to {
-      transform: rotate(1turn);
+      rotate: 1turn;
     }
   }
 
@@ -417,3 +420,4 @@ const personSchema = {
 </style>
 
 <script src="@client/eye-moving.ts"></script>
+<script src="@client/shape-follow.ts"></script>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -222,14 +222,75 @@ const personSchema = {
     height: 2.5rem;
     color: var(--ink-muted);
     border-radius: 50%;
-    transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+    /* isolation, so the two layers below can sit at negative z-index behind
+       the icon without falling through to the page. */
+    position: relative;
+    isolation: isolate;
+    transition:
+      color 180ms cubic-bezier(0.16, 1, 0.3, 1),
+      transform 340ms cubic-bezier(0.16, 1, 0.3, 1);
   }
 
-  .social-links a:hover {
-    color: var(--accent-ink);
-    background: var(--accent-gradient);
-    transform: translateY(calc(-2px * var(--lift)));
-    box-shadow: 0 4px 15px rgba(237, 91, 42, 0.4);
+  /* The light. It is the page's own ambient blobs at pocket size — same
+     accent, same blur, same overflow past the shape that casts it — which is
+     why a button lighting up reads as this page rather than as a hover
+     effect. Kept at 0.4: at full strength it competes with the dock above,
+     and the row of links is not the page's primary way out. */
+  .social-links a::before {
+    content: "";
+    position: absolute;
+    inset: -70%;
+    z-index: -2;
+    border-radius: 50%;
+    pointer-events: none;
+    background: radial-gradient(
+      circle at 50% 50%,
+      rgba(234, 96, 144, 0.55),
+      rgba(237, 91, 42, 0.28) 45%,
+      transparent 70%
+    );
+    filter: blur(10px);
+    opacity: 0;
+    transform: scale(0.45);
+    transition:
+      opacity 200ms linear,
+      transform 520ms cubic-bezier(0.16, 1, 0.3, 1);
+  }
+
+  /* The glass under the light, which is what keeps the button a button: at
+     this glow strength the light alone would not describe a shape. */
+  .social-links a::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    z-index: -1;
+    border-radius: 50%;
+    background-color: var(--glass-bg);
+    backdrop-filter: var(--glass-filter);
+    box-shadow: var(--glass-rim-lit);
+    opacity: 0;
+    transform: scale(0.82);
+    transition:
+      opacity 140ms linear,
+      transform 260ms cubic-bezier(0.16, 1, 0.3, 1);
+  }
+
+  .social-links a:hover,
+  .social-links a:focus-visible {
+    color: var(--ink-strong);
+    transform: scale(1.08);
+  }
+
+  .social-links a:hover::before,
+  .social-links a:focus-visible::before {
+    opacity: 0.4;
+    transform: scale(1.06);
+  }
+
+  .social-links a:hover::after,
+  .social-links a:focus-visible::after {
+    opacity: 1;
+    transform: scale(1);
   }
 
   .social-links svg {
@@ -291,10 +352,32 @@ const personSchema = {
       border-radius: 50%;
     }
 
-    .dock-wrap,
-    .social-links a {
+    .dock-wrap {
       transition: none;
       animation: none;
+    }
+
+    /* The light still arrives — it is the feedback, and a reader who asked
+       for less motion still needs to know which button is under the pointer.
+       What goes is the travel: nothing scales, nothing grows. */
+    .social-links a {
+      animation: none;
+      transition: color 180ms linear;
+    }
+
+    .social-links a:hover,
+    .social-links a:focus-visible {
+      transform: none;
+    }
+
+    .social-links a::before,
+    .social-links a::after,
+    .social-links a:hover::before,
+    .social-links a:focus-visible::before,
+    .social-links a:hover::after,
+    .social-links a:focus-visible::after {
+      transform: none;
+      transition: opacity 140ms linear;
     }
   }
 

--- a/src/styles/admin/forms.css
+++ b/src/styles/admin/forms.css
@@ -29,7 +29,7 @@
   padding: 0.6rem 0.9rem;
   font-size: 0.9rem;
   border-radius: 10px;
-  background-color: light-dark(rgba(255, 255, 255, 0.8), rgba(30, 30, 35, 0.8));
+  background-color: var(--field-bg);
   color: var(--ink-strong);
   box-shadow: inset 0 0 0 2px light-dark(#ddd, #444);
   transition: all 0.2s cubic-bezier(0.16, 1, 0.3, 1);
@@ -52,7 +52,7 @@
 
 .form-group input:hover:not(:disabled):not(:focus),
 .form-group textarea:hover:not(:disabled):not(:focus) {
-  box-shadow: inset 0 0 0 2px light-dark(#bbb, #555);
+  box-shadow: inset 0 0 0 2px var(--hairline-hover);
 }
 
 .form-group input:focus,
@@ -132,7 +132,7 @@
 }
 
 .image-upload {
-  border: 2px dashed light-dark(#ccc, #555);
+  border: 2px dashed var(--hairline-hover);
   border-radius: 12px;
   padding: 1.5rem;
   text-align: center;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -41,6 +41,22 @@
      so it answers to the 3:1 a component boundary needs and not to 4.5. */
   --hairline: light-dark(#ddd, #444);
 
+  /* The same edge with the pointer on it. A resting control's border is
+     --hairline and its hovered one is one step nearer the ink — which four
+     stylesheets had each written out as `light-dark(#bbb, #666)`, two of them
+     within three lines of a hand-written copy of --hairline itself. Two more
+     greys nobody named, in a file that opens with the story of twenty of them. */
+  --hairline-hover: light-dark(#bbb, #666);
+
+  /* A field's ground: an input, a select, an admin form control. Whiter than
+     the page in the light scheme and darker than it in the dark one, both at
+     0.8 so whatever is behind a control still tells through it.
+
+     Not --card-bg and not --glass-bg, which is why it is here: it was the third
+     surface tint on the site and the only one with no name, written identically
+     in four stylesheets. */
+  --field-bg: light-dark(rgba(255, 255, 255, 0.8), rgba(30, 30, 35, 0.8));
+
   /* The same job for the one rule that is looked at: the line under a sticky
      heading — the year on /travel, a section head, the veil in /kit. It is the
      only edge on the site that sits still on screen while a page slides under
@@ -833,7 +849,10 @@ blockquote p:last-child {
    6% wash is under it, which is the ground it actually always has. */
 code {
   padding: 0.125rem 0.375rem;
-  background-color: light-dark(rgba(0, 0, 0, 0.06), rgba(255, 255, 255, 0.06));
+  /* The wash is the page's ink at 6%, not black at 6% — the same tint, said in
+     terms of something the palette owns. One expression covers both schemes
+     because --ink-strong already flips. */
+  background-color: color-mix(in srgb, var(--ink-strong) 6%, transparent);
   border-radius: 4px;
   font-size: 0.875em;
   color: light-dark(#c81f48, #ff6b6b);
@@ -924,11 +943,14 @@ dd {
 }
 
 /* Tables */
+/* A table is read, so it takes a reading size: the one step below body the site
+   already has — what a paragraph drops to under 768px. It used to sit at
+   0.95rem, a fourth reading size a fifth of a pixel away from that one. */
 table {
   width: 100%;
   margin-bottom: 1.5rem;
   border-collapse: collapse;
-  font-size: 0.95rem;
+  font-size: 0.9375rem;
 }
 
 th,
@@ -1104,14 +1126,22 @@ a.btn-danger:active {
   box-shadow: 0 6px 20px rgba(237, 91, 42, 0.4);
 }
 
-/* Secondary - subtle background */
+/* Secondary - subtle background. The same wash inline code wears: the page's
+   own ink, thinned. The dark scheme takes twice as much of it because white at
+   5% on a near-black page is nothing. */
 .btn-secondary {
-  background: light-dark(rgba(0, 0, 0, 0.05), rgba(255, 255, 255, 0.1));
+  background: light-dark(
+    color-mix(in srgb, var(--ink-strong) 5%, transparent),
+    color-mix(in srgb, var(--ink-strong) 10%, transparent)
+  );
   color: var(--ink-body);
 }
 
 .btn-secondary:hover:not(:disabled) {
-  background: light-dark(rgba(0, 0, 0, 0.1), rgba(255, 255, 255, 0.15));
+  background: light-dark(
+    color-mix(in srgb, var(--ink-strong) 10%, transparent),
+    color-mix(in srgb, var(--ink-strong) 15%, transparent)
+  );
 }
 
 /* Ghost - transparent with border */
@@ -1123,7 +1153,7 @@ a.btn-danger:active {
 
 .btn-ghost:hover:not(:disabled) {
   color: var(--ink-strong);
-  border-color: light-dark(#bbb, #666);
+  border-color: var(--hairline-hover);
 }
 
 .btn-ghost.active {
@@ -1133,28 +1163,47 @@ a.btn-danger:active {
   box-shadow: 0 2px 10px rgba(237, 91, 42, 0.35);
 }
 
-/* Success - green gradient */
+/* Success - green gradient.
+
+   The glow is the button's own green, thinned. It used to be #10b981 — the
+   Tailwind emerald the success tokens replaced — so the light under the button
+   was a different green from the button, by a whole step of lightness. */
 .btn-success {
   background: var(--success-gradient);
   color: white;
-  box-shadow: 0 4px 15px rgba(16, 185, 129, 0.3);
+  box-shadow: 0 4px 15px color-mix(in srgb, var(--success-start) 30%, transparent);
 }
 
 .btn-success:hover:not(:disabled) {
   transform: scale(calc(1 + 0.05 * var(--lift)));
-  box-shadow: 0 6px 20px rgba(16, 185, 129, 0.4);
+  box-shadow: 0 6px 20px color-mix(in srgb, var(--success-start) 40%, transparent);
 }
 
-/* Danger - red tones */
+/* Danger - red tones.
+
+   Wash, edge and label are one colour at four strengths, which is the whole
+   idea of a quiet destructive button. They were two: the label read --danger
+   while the wash and the border were Tailwind's red-600 and red-500, left over
+   from the ramp the semantic tokens replaced. color-mix rather than hand-mixed
+   rgba, so the wash is derived from the label's colour and cannot drift from it
+   again; the strengths are the ones that were there, and the fills keep their
+   two per scheme because the dark token is the lighter red and needs more of
+   itself to register against a near-black page. */
 .btn-danger {
-  background: light-dark(rgba(220, 38, 38, 0.1), rgba(239, 68, 68, 0.2));
+  background: light-dark(
+    color-mix(in srgb, var(--danger) 10%, transparent),
+    color-mix(in srgb, var(--danger) 20%, transparent)
+  );
   color: var(--danger);
-  border: 2px solid light-dark(rgba(220, 38, 38, 0.3), rgba(239, 68, 68, 0.3));
+  border: 2px solid color-mix(in srgb, var(--danger) 30%, transparent);
 }
 
 .btn-danger:hover:not(:disabled) {
-  background: light-dark(rgba(220, 38, 38, 0.15), rgba(239, 68, 68, 0.3));
-  border-color: light-dark(rgba(220, 38, 38, 0.5), rgba(239, 68, 68, 0.5));
+  background: light-dark(
+    color-mix(in srgb, var(--danger) 15%, transparent),
+    color-mix(in srgb, var(--danger) 30%, transparent)
+  );
+  border-color: color-mix(in srgb, var(--danger) 50%, transparent);
 }
 
 /* Button sizes */
@@ -1188,7 +1237,7 @@ a.btn-danger:active {
   font-weight: 500;
   line-height: 1.4;
   color: var(--ink-strong);
-  background-color: light-dark(rgba(255, 255, 255, 0.8), rgba(30, 30, 35, 0.8));
+  background-color: var(--field-bg);
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%23666' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E");
   background-repeat: no-repeat;
   background-position: right 0.75rem center;
@@ -1235,9 +1284,11 @@ a.btn-danger:active {
   background-position: right 0.5rem center;
 }
 
+/* 0.9rem, not the 0.95rem it had: a control's label steps with its height, and
+   this is the same 44px .btn-lg is. Two controls of one height had two sizes. */
 .select-lg {
   padding: 0.8rem 2.75rem 0.8rem 1rem;
-  font-size: 0.95rem;
+  font-size: 0.9rem;
   border-radius: 12px;
   background-size: 18px;
   background-position: right 0.85rem center;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -499,9 +499,13 @@ body {
   background-image: var(--glass-sheen);
   backdrop-filter: var(--glass-filter);
   border: var(--glass-border);
-  box-shadow: var(--glass-shadow);
-  /* Above the viewport by its own height plus the inset, so no part of it
-     peeks. */
+  /* Above the viewport by its own height plus the inset, so no part of the box
+     peeks. The shadow is not part of the box: 0 10px 30px paints some 40px
+     below the bottom edge, which parked a soft grey smudge in the top-left
+     corner of every page. So the glass shadow arrives with the link, on focus.
+     Hiding it with visibility or opacity is not an option — neither can be
+     focused, and this is the one element on the site that has to be. */
+  box-shadow: none;
   transform: translateY(calc(-100% - 0.75rem));
   transition: transform 0.2s cubic-bezier(0.16, 1, 0.3, 1);
 }
@@ -514,6 +518,7 @@ body {
    exists to prevent. */
 .skip-link:focus {
   transform: translateY(0);
+  box-shadow: var(--glass-shadow);
   outline: 2px solid var(--accent-start);
   outline-offset: 2px;
 }

--- a/src/styles/kit/button.css
+++ b/src/styles/kit/button.css
@@ -166,33 +166,45 @@ a.kit-btn--danger:active {
 
 /* Secondary - Subtle background */
 .kit-btn--secondary {
-  background: light-dark(rgba(0, 0, 0, 0.05), rgba(255, 255, 255, 0.08));
+  background: light-dark(
+    color-mix(in srgb, var(--ink-strong) 5%, transparent),
+    color-mix(in srgb, var(--ink-strong) 8%, transparent)
+  );
   color: var(--ink-body);
 }
 
 .kit-btn--secondary:hover:not(:disabled) {
-  background: light-dark(rgba(0, 0, 0, 0.08), rgba(255, 255, 255, 0.12));
+  background: light-dark(
+    color-mix(in srgb, var(--ink-strong) 8%, transparent),
+    color-mix(in srgb, var(--ink-strong) 12%, transparent)
+  );
   color: var(--ink-strong);
 }
 
 .kit-btn--secondary:active:not(:disabled) {
-  background: light-dark(rgba(0, 0, 0, 0.1), rgba(255, 255, 255, 0.15));
+  background: light-dark(
+    color-mix(in srgb, var(--ink-strong) 10%, transparent),
+    color-mix(in srgb, var(--ink-strong) 15%, transparent)
+  );
 }
 
 /* Ghost - Transparent with border */
 .kit-btn--ghost {
   background: transparent;
   color: var(--ink-muted);
-  box-shadow: inset 0 0 0 2px light-dark(#ddd, #444);
+  box-shadow: inset 0 0 0 2px var(--hairline);
 }
 
 .kit-btn--ghost:hover:not(:disabled) {
   color: var(--ink-strong);
-  box-shadow: inset 0 0 0 2px light-dark(#bbb, #666);
+  box-shadow: inset 0 0 0 2px var(--hairline-hover);
 }
 
 .kit-btn--ghost:active:not(:disabled) {
-  background: light-dark(rgba(0, 0, 0, 0.03), rgba(255, 255, 255, 0.05));
+  background: light-dark(
+    color-mix(in srgb, var(--ink-strong) 3%, transparent),
+    color-mix(in srgb, var(--ink-strong) 5%, transparent)
+  );
 }
 
 .kit-btn--ghost[aria-pressed="true"],
@@ -202,39 +214,64 @@ a.kit-btn--danger:active {
   box-shadow: 0 2px 8px rgba(237, 91, 42, 0.35);
 }
 
-/* Danger - Destructive actions */
+/* Danger - Destructive actions.
+
+   Ground, ring and label are one colour at several strengths, mixed from
+   --danger. They were two: the label read the token while the wash and the ring
+   were Tailwind's red-600 and red-500, left over from the ramp the semantic
+   tokens replaced — a mismatch nothing could see because no two of them were
+   ever side by side at full strength. The dark scheme still takes more of the
+   colour, because its red is the lighter one and has a near-black page to
+   register against. */
 .kit-btn--danger {
-  background: light-dark(rgba(220, 38, 38, 0.1), rgba(239, 68, 68, 0.15));
+  background: light-dark(
+    color-mix(in srgb, var(--danger) 10%, transparent),
+    color-mix(in srgb, var(--danger) 15%, transparent)
+  );
   color: var(--danger);
   box-shadow: inset 0 0 0 1px
-    light-dark(rgba(220, 38, 38, 0.2), rgba(239, 68, 68, 0.25));
+    light-dark(
+      color-mix(in srgb, var(--danger) 20%, transparent),
+      color-mix(in srgb, var(--danger) 25%, transparent)
+    );
 }
 
 .kit-btn--danger:hover:not(:disabled) {
-  background: light-dark(rgba(220, 38, 38, 0.15), rgba(239, 68, 68, 0.22));
+  background: light-dark(
+    color-mix(in srgb, var(--danger) 15%, transparent),
+    color-mix(in srgb, var(--danger) 22%, transparent)
+  );
   box-shadow: inset 0 0 0 1px
-    light-dark(rgba(220, 38, 38, 0.3), rgba(239, 68, 68, 0.35));
+    light-dark(
+      color-mix(in srgb, var(--danger) 30%, transparent),
+      color-mix(in srgb, var(--danger) 35%, transparent)
+    );
 }
 
 .kit-btn--danger:active:not(:disabled) {
-  background: light-dark(rgba(220, 38, 38, 0.2), rgba(239, 68, 68, 0.28));
+  background: light-dark(
+    color-mix(in srgb, var(--danger) 20%, transparent),
+    color-mix(in srgb, var(--danger) 28%, transparent)
+  );
 }
 
-/* Success - Confirmation actions */
+/* Success - Confirmation actions. The glow is the button's own green thinned;
+   it used to be #10b981, the Tailwind emerald the success tokens replaced, so
+   the light under the button came from a different green than the button. */
 .kit-btn--success {
   background: var(--success-gradient);
   color: white;
-  box-shadow: 0 2px 8px rgba(16, 185, 129, 0.3);
+  box-shadow: 0 2px 8px color-mix(in srgb, var(--success-start) 30%, transparent);
 }
 
 .kit-btn--success:hover:not(:disabled) {
-  box-shadow: 0 4px 12px rgba(16, 185, 129, 0.4);
+  box-shadow: 0 4px 12px color-mix(in srgb, var(--success-start) 40%, transparent);
   transform: translateY(calc(-1px * var(--lift)));
 }
 
 .kit-btn--success:active:not(:disabled) {
   transform: translateY(0);
-  box-shadow: 0 2px 6px rgba(16, 185, 129, 0.3);
+  box-shadow: 0 2px 6px color-mix(in srgb, var(--success-start) 30%, transparent);
 }
 
 /* =============================================================================
@@ -357,6 +394,6 @@ a.kit-btn--danger:active {
   }
 
   .kit-btn--secondary {
-    box-shadow: inset 0 0 0 1px light-dark(#ccc, #555);
+    box-shadow: inset 0 0 0 1px var(--hairline-hover);
   }
 }

--- a/src/styles/kit/input.css
+++ b/src/styles/kit/input.css
@@ -26,7 +26,7 @@
 
   /* Visual */
   color: var(--ink-strong);
-  background-color: light-dark(rgba(255, 255, 255, 0.8), rgba(30, 30, 35, 0.8));
+  background-color: var(--field-bg);
 
   /* Border */
   box-shadow: inset 0 0 0 2px light-dark(#ddd, #444);
@@ -48,7 +48,7 @@
 }
 
 .kit-input:hover:not(:disabled):not(:focus) {
-  box-shadow: inset 0 0 0 2px light-dark(#bbb, #555);
+  box-shadow: inset 0 0 0 2px var(--hairline-hover);
 }
 
 .kit-input:focus {

--- a/src/styles/kit/select.css
+++ b/src/styles/kit/select.css
@@ -27,7 +27,7 @@
 
   /* Visual */
   color: var(--ink-strong);
-  background-color: light-dark(rgba(255, 255, 255, 0.8), rgba(30, 30, 35, 0.8));
+  background-color: var(--field-bg);
   background-repeat: no-repeat;
 
   /* Chevron icon */
@@ -51,7 +51,7 @@
 }
 
 .kit-select:hover:not(:disabled) {
-  box-shadow: inset 0 0 0 2px light-dark(#bbb, #666);
+  box-shadow: inset 0 0 0 2px var(--hairline-hover);
 }
 
 .kit-select:focus {


### PR DESCRIPTION
Four changes from one live-design session — two on the home page, two elsewhere.

## The blob behind the avatar leans toward the cursor

`src/client/shape-follow.ts` is new. The shape had three loops — morph, spin, gradient pan — and none of them knew anyone was there, while the avatar in front of it has watched the cursor since it was drawn. Now they notice together.

Deliberately not `initMagnet`: that helper is a six-pixel lerp for controls the pointer is already on top of, and a 20rem backdrop answering a pointer anywhere on the page needs a longer reach, a far weaker coupling, and real overshoot.

Two stages of smoothing, because a pointer teleports rather than sliding. The first eases the goal, so a flick across the page becomes a ramp; the second is the spring chasing it. The first attempt had a stiff spring on a stepping target and snapped — 33% overshoot on a jump to full pull. Softened to a 0.43 damping ratio with the goal eased, the same jump has no overshoot and takes about half a second.

`spin` moves from `transform: rotate()` to the `rotate` property, since the script owns `transform` now and an animation on the same property wins against inline styles every frame.

Coarse pointers and `prefers-reduced-motion` are left out entirely.

## A social link answers with light instead of filling with accent

The hover state filled the circle with the accent gradient, lifted it and dropped an orange shadow — the loudest moment on a page whose primary way out, the dock, is quiet glass.

Now a blurred accent glow blooms behind the icon over a glass disc built from the dock's tokens. The glow is the page's own ambient blobs at pocket size, which is the argument for it over anything else: the button reads as this page rather than as a hover effect bought in. Held at 0.4 of full strength, chosen against the dock — at full strength the row out-shouts the navigation above it.

Reduced motion stops meaning "nothing happens": the light and the colour still arrive, only the scaling is dropped.

## The skip link stops leaving its shadow in the corner

It parks above the viewport by its own height plus the inset, which the comment claimed put no part of it on screen. The box, yes — but `0 10px 30px` paints some forty pixels below the bottom edge, so every page carried a soft grey smudge in the top-left corner with nothing visible casting it. The glass shadow now arrives with the link, on focus.

Not `visibility` or `opacity`, which would have been shorter and wrong: neither can hold focus, and this is the one element on the site that has to.

## The travel stats end where the rest of the page ends

The four counters bled 0.75rem past the content edge to meet a trip row's hover wash. But that wash only exists under the pointer — a hover affordance, not an edge — so the agreement was visible to one reader with a mouse on one row, while the row of cards sat visibly wider than the heading for everyone else, all the time. The wash keeps its bleed; the cards go flush.

## For the reviewer

- **This branch also carries `7e3167b`**, which was already on local `main` but had not been pushed. It is not part of this session's work; it rides along because the branch was cut from local `main`.
- The spring's feel is the one thing I could not check: measurements came from the integrator and from computed styles, since `requestAnimationFrame` does not tick in a headless pane. Numbers say no overshoot; whether it feels right on a real machine is worth a look.
- Constants to tune live at the top of `shape-follow.ts`: `REACH`, `MAX`, `TILT`, `FOLLOW`, `STIFFNESS`, `DAMPING`.
- Verified flush alignment at 490px and 1280px, and the social hover state by computed style; `astro check` is clean.