### PR TITLE
Reserving a present reaches the database again

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -279,8 +279,23 @@ export default defineConfig({
     isr: {
       // Bypass token for on-demand revalidation
       bypassToken: VERCEL_ISR_BYPASS_TOKEN,
-      // Exclude API routes and admin pages from ISR
-      exclude: [/^\/api\/.*/, /^\/wishlist\/~(\/.*)?$/],
+      // Exclude API routes, the actions endpoint and admin pages from ISR.
+      //
+      // /_actions is not optional and not a nicety: everything the adapter does
+      // not exclude is routed to the ISR function, and Vercel keys that cache on
+      // path and method alone — the request body is not part of it. So the first
+      // POST /_actions/reserve ran, wrote its row and had its `{success: true}`
+      // stored; every reserve after that, any item, any visitor, was answered
+      // from that entry without the function being invoked at all. The button
+      // reported success, nothing reached the database, and a reload showed no
+      // reservation. `expiration: false` below means "until revalidated", so
+      // that entry never aged out. Cancelling went the same way through
+      // /_actions/unreserve.
+      exclude: [
+        /^\/api\/.*/,
+        /^\/_actions(\/.*)?$/,
+        /^\/wishlist\/~(\/.*)?$/,
+      ],
     },
   }),
   image: {

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -2,8 +2,29 @@ import { defineAction, ActionError } from "astro:actions";
 import { z } from "astro/zod";
 import { db, Reservation, WishlistItem, and, eq, sql } from "@lib/db";
 import { RESERVATION_MESSAGE_MAX_LENGTH } from "@lib/wishlist";
+import { revalidateWishlist } from "@lib/admin/revalidate";
 
 const reservationsEnabled = import.meta.env.RESERVATIONS_ENABLED !== "false";
+
+/**
+ * Refresh the cached pages this item appears on, without letting that failure
+ * become the visitor's.
+ *
+ * The row is already written by the time this runs. ISR holds /wishlist until
+ * something asks it not to (`expiration: false`), so a card the server rendered
+ * as free stays free in the HTML for the next visitor; the per-visitor fetch in
+ * client/wishlist.ts corrects it on arrival, which is why this was survivable
+ * while it was missing, but it corrects it after first paint. If the refresh
+ * itself fails there is nothing to tell the reserver — they reserved it — so it
+ * is logged and swallowed.
+ */
+async function refreshWishlistPages(category: string): Promise<void> {
+  try {
+    await revalidateWishlist({ category });
+  } catch (error) {
+    console.error("Revalidation after a reservation change failed:", error);
+  }
+}
 
 export const server = {
   reserve: defineAction({
@@ -63,6 +84,8 @@ export const server = {
         )
       `);
 
+      await refreshWishlistPages(item[0].category);
+
       return { success: true };
     },
   }),
@@ -96,6 +119,16 @@ export const server = {
 
       // Delete reservation
       await db.delete(Reservation).where(eq(Reservation.itemId, itemId));
+
+      // Read after the delete, not before: the category is only wanted to name
+      // the page to refresh, and an item that vanished between the two is one
+      // whose pages an admin edit has already refreshed.
+      const item = await db
+        .select({ category: WishlistItem.category })
+        .from(WishlistItem)
+        .where(eq(WishlistItem.id, itemId));
+
+      if (item.length > 0) await refreshWishlistPages(item[0].category);
 
       return { success: true };
     },

--- a/src/lib/admin/revalidate.ts
+++ b/src/lib/admin/revalidate.ts
@@ -9,8 +9,19 @@ import { VERCEL_ISR_BYPASS_TOKEN } from "astro:env/server";
 /**
  * Trigger ISR revalidation for wishlist pages
  * Called after any mutation (create, update, delete)
+ *
+ * With no argument every wishlist page is revalidated, which is what an admin
+ * edit wants: it can change an item's category, so the page it left is as stale
+ * as the one it joined.
+ *
+ * `only` narrows that to the pages a single item actually appears on — /wishlist
+ * and its own category. Reserving is a visitor-facing action on a public
+ * endpoint, and refreshing all nine pages per click would put the ISR write bill
+ * in the hands of anyone willing to press a button twice.
  */
-export async function revalidateWishlist(): Promise<void> {
+export async function revalidateWishlist(only?: {
+  category: string;
+}): Promise<void> {
   const siteUrl = import.meta.env.SITE;
 
   if (!VERCEL_ISR_BYPASS_TOKEN || !siteUrl) {
@@ -23,7 +34,13 @@ export async function revalidateWishlist(): Promise<void> {
   const bypassToken = VERCEL_ISR_BYPASS_TOKEN;
 
   // Revalidate /wishlist and all category pages (/wishlist/<category>)
-  const paths = categories.map((c) => c.href);
+  const wanted = only
+    ? // "all" is /wishlist itself, which is in the list either way. An unknown
+      // category leaves just that page, which is the honest answer: there is no
+      // page for a category that does not exist.
+      categories.filter((c) => c.id === "all" || c.id === only.category)
+    : categories;
+  const paths = wanted.map((c) => c.href);
 
   const results = await Promise.allSettled(
     paths.map((path) =>


### PR DESCRIPTION
## Симптом

Кнопка «Зарезервировать» отвечает успехом, но после перезагрузки резервации нет. В проде на момент расследования:

```
GET /api/wishlist/reservations  →  {}          (db;dur=35ms — база жива, резерваций ноль)
GET /wishlist                   →  x-vercel-cache: HIT, age 60263
                                    57 карточек, все data-reservation="none"
```

## Причина

Всё, что адаптер Vercel не исключил из ISR, уходит в ISR-функцию — а `/_actions` исключён не был. В `.vercel/output/config.json` было:

```json
{"src": "^/_actions(?:/(.*?))?/?$", "dest": "/_isr?x_astro_path=$0&..."}
```

Vercel строит ключ этого кэша из пути и метода, тело запроса в него не входит. Первый `POST /_actions/reserve` после деплоя выполнялся, писал строку и отдавал `200 {success:true}` — ответ оседал в кэше под этим путём. Все последующие резервирования — любого товара, любым посетителем — получали тот же ответ, функция не запускалась. `expiration: false` означает «до ручной ревалидации», так что запись не устаревала. Отмена шла тем же путём через `/_actions/unreserve`; отсюда пустая таблица `Reservation` в проде.

Ошибки не кэшировались: Vercel хранит только 200/301/302/307/308/404/410, поэтому `409 CONFLICT` каждый раз доходил до функции. Не работал именно успешный путь.

## Что сделано

- `astro.config.mjs` — `/^\/_actions(\/.*)?$/` в `isr.exclude`. На пересобранном `.vercel/output/config.json` ISR-правило для actions исчезло, вместо него `{"src": "^/_actions(?:/(.*?))?$", "dest": "_render"}` перед всеми ISR-правилами.
- `reserve`/`unreserve` теперь ревалидируют страницы, на которых товар виден. `/wishlist` жил в ISR-копии, которую обновляли только правки из админки, так что только что занятая карточка оставалась в HTML свободной; клиентский фетч это исправлял, но уже после первой отрисовки.
- Ревалидация сужена до `/wishlist` и страницы категории. Без аргумента `revalidateWishlist()` по-прежнему обновляет все девять — это нужно админской правке, которая может перенести товар между категориями. Резервация не может, а эндпойнт публичный: девять HEAD-запросов на клик — это счёт за ISR-записи в руках любого, кто нажмёт кнопку дважды.

## Проверка

`astro check` — 0 ошибок, `bun test` — 96/96, прод-сборка проходит, роут-таблица проверена глазами.

Миграций нет, так что Vercel собирает и деплоит обычным путём. Кэш ISR у каждого деплоя свой — чистить старый не нужно. После выката: на `POST /_actions/reserve` не должно появляться `x-vercel-cache: HIT`.

## Замечание

Новое правило матчит `/_actions/reserve`, но не `/_actions/reserve/` со слэшем — прежнее ISR-правило ловило оба. `src` генерируется адаптером из паттерна роута, форма не наша. Клиент Astro всегда шлёт без слэша.