### PR TITLE
A wishlist card asks for the picture it actually draws

### DIFF
--- a/src/lib/images.ts
+++ b/src/lib/images.ts
@@ -66,9 +66,24 @@ export function heightFor(width: number): number {
  * browser picks a candidate from srcset and sizes together, so two different
  * strings are two different choices — and the preload then fetches a file the
  * markup never asks for, which is the one outcome worse than no preload.
+ *
+ * Every branch here is `repeat(auto-fill, minmax(280px, 1fr))` with a 1.5rem
+ * gap, solved for the column count that fits: the container is 1200 wide at
+ * most, padded 24 a side, and the card's 1px border takes 2 more off the
+ * picture. Three columns start at 936 and four at 1240, where the container has
+ * stopped growing — so the widest desktop draws the *smallest* card of all,
+ * 280, and that is the number this used to get wrong.
+ *
+ * Overstating a width is not the safe direction it looks like. Claiming 380
+ * where the card is 280 asks a 2× screen for 760px, which lands on the 800w
+ * file — and the browser then resamples 800 down to 560 itself, on top of the
+ * 1024→800 the upload already did. Two reductions in a row cost 12–31% of the
+ * micro-contrast, measured in Chrome across eight items; the honest number
+ * fetches 560w and draws it pixel for pixel. It is also 41% fewer bytes, which
+ * is the smaller half of the reason.
  */
 export const WISHLIST_IMAGE_SIZES =
-  "(max-width: 768px) calc(100vw - 2rem), (max-width: 935px) 45vw, 380px";
+  "(max-width: 768px) calc(100vw - 2rem), (max-width: 935px) 45vw, (max-width: 1239px) calc((100vw - 96px) / 3), 280px";
 
 /**
  * The R2 key of one derivative, from the original's key.


### PR DESCRIPTION
Wishlist photographs looked soft on desktop. Not the files: every one of the
126 `.800.webp` objects is genuinely 800×600, none of the 400/560 widths is
upscaled, q65 sits at ~40 dB PSNR against the original (38–48 dB in the
shadows), and there is no transform, filter or compositing layer anywhere
around the `<img>`.

It was `sizes`. It claimed `380px` for every viewport past 935, and the widest
desktop draws the *narrowest* card of all — four 282px columns inside a
container that stopped growing at 1200, less the card's 1px border, so 280.
A 2× screen therefore asked for 760px, landed on the 800w file, and resampled
it down to 560 itself — on top of the 1024→800 the upload had already done.

Two reductions in a row, measured in Chrome (variance of the Laplacian over
the 560×420 the retina actually receives):

| item | 560w pixel-for-pixel | 800w, as shipped | loss |
|---|---|---|---|
| astro bot vinyl | 3977 | 3133 | −28% |
| titanium band | 645 | 553 | −31% |
| celeste desk mat | 207 | 169 | −24% |
| tpob clipper | 120 | 99 | −22% |
| florida project | 235 | 190 | −19% |
| tangerine | 149 | 131 | −12% |

All eight items sampled lost; the shipped candidate was the worst available
in every one of them.

The string now solves the grid it describes — `auto-fill` over
`minmax(280px, 1fr)` with a 1.5rem gap, three columns from 936 and four from
1240 — and gains the three-column step it never had. Verified against the live
layout at 557 / 837 / 1057 / 1749px; the promise matches the measured card
width to the pixel, and `<img sizes>` and `<link rel=preload imagesizes>` stay
identical, which is the whole reason the constant is shared.

Desktop now fetches 560w and draws it 1:1. The shop in one theme drops from
0.99 MB to 0.59 MB, which is the smaller half of the reason. No files change:
all four widths were already in R2.

Still no 1:1 candidate between 769 and 1239, where the card wants 600–760
physical pixels and the nearest width above is 800. That needs an entry in
`IMAGE_WIDTHS` and a backfill; measured at the worst point of that range the
gain is uneven (four items up 11–83%, one down 28%), so it is not worth a
fifth encode on every future upload without traffic data saying otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XgSC1DAhVmGaDAcBBd2oPy