### PR TITLE
The message a reserver leaves opens as a sheet on a phone

### DIFF
--- a/src/client/reservation-message.ts
+++ b/src/client/reservation-message.ts
@@ -9,6 +9,9 @@
 // Messages are held in a Map keyed by item id rather than on the DOM. They only
 // ever arrive for the visitor who wrote them, and a data attribute on a card is
 // a place for other people's scripts to read them from.
+//
+// Below 600px the panel is not that lens but a sheet at the bottom edge; see
+// "The sheet" below, and the block of the same name in styles/wishlist.css.
 
 import { actions } from "astro:actions";
 import { computePosition, autoUpdate, offset, flip, shift } from "@floating-ui/dom";
@@ -17,6 +20,12 @@ import type { Lang } from "@lib/i18n";
 import { getVisitorId } from "./visitor-id";
 
 const CLOSE_DURATION = 220; // must outlast the CSS exit transition
+/** The sheet's slide is 0.36s, and it is the exit the same rule applies to. */
+const SHEET_CLOSE_DURATION = 380;
+/** This page's phone line — where the filters become a bar on the bottom edge. */
+const SHEET_QUERY = "(max-width: 600px)";
+/** Under this, the visual viewport shrank for a toolbar and not for a keyboard. */
+const KEYBOARD_FLOOR = 120;
 
 let lang: Lang = "en";
 let popover: HTMLElement | null = null;
@@ -25,10 +34,15 @@ let counter: HTMLElement | null = null;
 let errorLine: HTMLElement | null = null;
 let dismissBtn: HTMLButtonElement | null = null;
 let saveBtn: HTMLButtonElement | null = null;
+let closeBtn: HTMLButtonElement | null = null;
+let scrim: HTMLElement | null = null;
 
 let anchor: HTMLButtonElement | null = null;
 let stopFollowing: (() => void) | null = null;
 let closeTimer: number | undefined;
+let sheetMedia: MediaQueryList | null = null;
+let scrimTimer: number | undefined;
+let stopWatchingKeyboard: (() => void) | null = null;
 /** A write is in flight. `setBusy` disables the buttons; this covers the rest. */
 let saving = false;
 
@@ -141,6 +155,10 @@ function originFor(placement: Placement): string {
 
 function position() {
   if (!popover || !anchor) return;
+  // A sheet is positioned by its edges. `autoUpdate` is stopped when the shape
+  // changes, but a frame already in flight would still land here and write the
+  // inline left/top that beats them.
+  if (isSheet()) return;
   computePosition(anchor, popover, {
     strategy: "fixed",
     placement: "top-end",
@@ -159,6 +177,154 @@ function position() {
     popover.style.top = `${y}px`;
     popover.style.setProperty("--popover-origin", originFor(placement));
   });
+}
+
+/* -------------------------------------------------------------------------
+   The sheet
+
+   Which shape the panel wears is a media query's answer, but three parts of
+   wearing it are not CSS's to give: Floating UI has to stop writing left/top,
+   the kit's control sizes have to step up for a thumb, and the sheet has to
+   ride above whatever the software keyboard is covering.
+   ------------------------------------------------------------------------- */
+
+function isSheet(): boolean {
+  return sheetMedia?.matches ?? false;
+}
+
+/** The grid must not scroll behind an open sheet: it is a modal, not a popover. */
+function lockPage(locked: boolean) {
+  document.body.style.overflow = locked ? "hidden" : "";
+}
+
+function hideScrim() {
+  if (!scrim) return;
+  scrim.classList.remove("is-open");
+  window.clearTimeout(scrimTimer);
+  // It leaves after the sheet has, so its fade is not cut short.
+  scrimTimer = window.setTimeout(() => {
+    if (scrim && !scrim.classList.contains("is-open")) scrim.hidden = true;
+  }, SHEET_CLOSE_DURATION);
+}
+
+/**
+ * A sheet pinned to the bottom edge and a software keyboard want the same
+ * pixels, and the sheet loses: `position: fixed` is measured against the layout
+ * viewport, which the keyboard does not shrink, so the field the whole sheet
+ * exists for ends up underneath it. `visualViewport` reports the difference and
+ * the sheet rides up by exactly that much.
+ *
+ * The floor is there because iOS reports a shrunken visual viewport for its own
+ * collapsing toolbars with no keyboard on screen at all, and a sheet hovering
+ * 50px above the bottom edge for no reason is worse than one that never moved.
+ * Nothing between a toolbar and a keyboard is that size.
+ */
+function watchKeyboard(on: boolean) {
+  const viewport = window.visualViewport;
+  if (!on || !viewport) {
+    stopWatchingKeyboard?.();
+    stopWatchingKeyboard = null;
+    return;
+  }
+  if (stopWatchingKeyboard) return;
+
+  const measure = () => {
+    if (!popover) return;
+    const covered = window.innerHeight - viewport.height - viewport.offsetTop;
+    const inset = covered > KEYBOARD_FLOOR ? Math.round(covered) : 0;
+    popover.style.setProperty("--sheet-keyboard", `${inset}px`);
+  };
+
+  viewport.addEventListener("resize", measure);
+  viewport.addEventListener("scroll", measure);
+  stopWatchingKeyboard = () => {
+    viewport.removeEventListener("resize", measure);
+    viewport.removeEventListener("scroll", measure);
+  };
+  measure();
+}
+
+/**
+ * Puts the shape the viewport asked for onto the panel.
+ *
+ * Runs on every open, and again whenever the breakpoint is crossed while the
+ * panel is up — re-shaping rather than closing, because the panel may be
+ * holding text that exists nowhere else and turning a phone sideways is not a
+ * decision to discard it.
+ */
+function applyShape() {
+  if (!popover || !textarea) return;
+  const sheet = isSheet();
+
+  // A sheet over a scrim with the page locked behind it is modal. An anchored
+  // popover is not, and must not claim to be: `aria-modal` hides the rest of
+  // the document, and the card this is about is the rest of the document.
+  if (sheet) popover.setAttribute("aria-modal", "true");
+  else popover.removeAttribute("aria-modal");
+
+  // On a phone this is not glass but the veil. Dropping the class is cheaper —
+  // and truer in the DOM — than out-specifying its four declarations from a
+  // page stylesheet.
+  popover.classList.toggle("liquid-glass", !sheet);
+
+  // The kit's own steps, swapped rather than copied: 44px under a thumb, 32px
+  // under a cursor, each bringing the padding, radius and type that go with it.
+  textarea.classList.toggle("kit-input--lg", sheet);
+  textarea.classList.toggle("kit-input--sm", !sheet);
+  for (const button of [dismissBtn, saveBtn]) {
+    button?.classList.toggle("kit-btn--lg", sheet);
+    button?.classList.toggle("kit-btn--sm", !sheet);
+  }
+
+  if (sheet) {
+    stopFollowing?.();
+    stopFollowing = null;
+    // Whatever Floating UI last wrote outranks the sheet's own edges.
+    popover.style.left = "";
+    popover.style.top = "";
+    popover.style.removeProperty("--popover-origin");
+    lockPage(true);
+    watchKeyboard(true);
+    // Only when the panel is already up. On the way in, the scrim needs the
+    // same frame of closed styles the sheet does, and `openPopover` gives the
+    // two of them that frame together.
+    if (popover.classList.contains("is-open") && scrim) {
+      window.clearTimeout(scrimTimer);
+      scrim.hidden = false;
+      scrim.classList.add("is-open");
+    }
+  } else {
+    lockPage(false);
+    watchKeyboard(false);
+    hideScrim();
+    popover.style.removeProperty("--sheet-keyboard");
+    if (anchor && !stopFollowing) {
+      stopFollowing = autoUpdate(anchor, popover, position);
+    }
+  }
+}
+
+/**
+ * Tab stays inside the sheet, and only inside the sheet. The anchored popover
+ * is not modal: tabbing off its last button and back into the card it belongs
+ * to is how it is meant to be left.
+ */
+function trapTab(event: KeyboardEvent) {
+  if (event.key !== "Tab" || !popover || !anchor || !isSheet()) return;
+  const stops = Array.from(
+    popover.querySelectorAll<HTMLElement>(
+      "button:not([disabled]), textarea:not([disabled])",
+    ),
+  );
+  if (stops.length === 0) return;
+
+  const active = document.activeElement;
+  const inside = popover.contains(active);
+  const leaving = event.shiftKey ? active === stops[0] : active === stops.at(-1);
+  if (!leaving && inside) return;
+
+  event.preventDefault();
+  (event.shiftKey ? stops.at(-1) : stops[0])?.focus();
 }
 
 function setError(message: string | null) {
@@ -208,6 +374,10 @@ function openPopover(bead: HTMLButtonElement, { focus = true } = {}) {
   if (anchor && anchor !== bead) anchor.setAttribute("aria-expanded", "false");
   window.clearTimeout(closeTimer);
   stopFollowing?.();
+  // Nulled as well as called: `applyShape` starts a fresh follow only when
+  // nothing is following, and a stopped cleanup left in the variable reads as
+  // one that is still running.
+  stopFollowing = null;
 
   anchor = bead;
   textarea.value = messages.get(itemId) ?? "";
@@ -220,17 +390,31 @@ function openPopover(bead: HTMLButtonElement, { focus = true } = {}) {
   updateCounter();
   syncDismissButton();
 
+  const sheet = isSheet();
   popover.hidden = false;
+  if (sheet && scrim) {
+    window.clearTimeout(scrimTimer);
+    scrim.hidden = false;
+  }
+  // Shape first: it is what decides whether the closed styles the next line
+  // freezes are a lens scaled out of its bead or a sheet below the edge. It
+  // also starts the follow, on the shape that has an anchor to follow.
+  applyShape();
   // The entrance transition needs a frame with the closed styles applied.
   void popover.offsetHeight;
   popover.classList.add("is-open");
+  if (sheet) scrim?.classList.add("is-open");
   bead.setAttribute("aria-expanded", "true");
-
-  stopFollowing = autoUpdate(bead, popover, position);
 
   if (focus) {
     textarea.focus();
     textarea.setSelectionRange(textarea.value.length, textarea.value.length);
+  } else if (sheet) {
+    // A modal must not leave focus out on the page it has just covered. The
+    // close button rather than the field, because this path is the panel
+    // opening by itself after a reservation and a keyboard is not what that
+    // moment asked for — the same reason the focus was declined here at all.
+    closeBtn?.focus();
   }
 }
 
@@ -238,20 +422,38 @@ function closePopover({ restoreFocus = true } = {}) {
   if (!popover || popover.hidden) return;
 
   const returnTo = anchor;
+  const sheet = isSheet();
+  // Read before anything moves it: the sheet gives the keyboard back by blurring
+  // below, which would otherwise answer the question this asks.
+  const hadFocus = popover.contains(document.activeElement);
+
   popover.classList.remove("is-open");
+  hideScrim();
+  lockPage(false);
+  watchKeyboard(false);
   anchor?.setAttribute("aria-expanded", "false");
   stopFollowing?.();
   stopFollowing = null;
   anchor = null;
 
+  // Hand the keyboard back while the sheet is still leaving rather than when it
+  // has gone. Focus in a field that is about to be `hidden` lands on <body>
+  // anyway, and on iOS it takes the keyboard with it a beat too late.
+  if (sheet && hadFocus) (document.activeElement as HTMLElement | null)?.blur();
+
   window.clearTimeout(closeTimer);
   closeTimer = window.setTimeout(() => {
-    if (popover && !popover.classList.contains("is-open")) popover.hidden = true;
-  }, CLOSE_DURATION);
+    if (popover && !popover.classList.contains("is-open")) {
+      popover.hidden = true;
+      // Cleared here and not above: dropping it while the sheet is still on
+      // screen would slam it down the keyboard's height first.
+      popover.style.removeProperty("--sheet-keyboard");
+    }
+  }, sheet ? SHEET_CLOSE_DURATION : CLOSE_DURATION);
 
-  // Only pull focus back if it is still inside the panel we just dismissed —
+  // Only pull focus back if it was still inside the panel we just dismissed —
   // clicking elsewhere on the page has already put it where it belongs.
-  if (restoreFocus && returnTo && popover.contains(document.activeElement)) {
+  if (restoreFocus && returnTo && hadFocus) {
     returnTo.focus();
   }
 }
@@ -323,6 +525,13 @@ export function initReservationMessages(initialLang: Lang): void {
   errorLine = popover.querySelector(".message-popover-error");
   dismissBtn = popover.querySelector(".message-popover-dismiss");
   saveBtn = popover.querySelector(".message-popover-save");
+  closeBtn = popover.querySelector(".message-popover-close");
+  scrim = document.getElementById("reservation-message-scrim");
+
+  sheetMedia = window.matchMedia(SHEET_QUERY);
+  sheetMedia.addEventListener("change", () => {
+    if (anchor) applyShape();
+  });
 
   // Delegated: beads are hidden at render time and revealed later, and the grid
   // is rebuilt whenever a category filter runs.
@@ -346,6 +555,8 @@ export function initReservationMessages(initialLang: Lang): void {
   });
 
   saveBtn?.addEventListener("click", commit);
+
+  closeBtn?.addEventListener("click", () => closePopover());
 
   dismissBtn?.addEventListener("click", () => {
     const itemId = itemIdOf(anchor);
@@ -378,6 +589,8 @@ export function initReservationMessages(initialLang: Lang): void {
       closePopover();
     }
   });
+
+  document.addEventListener("keydown", trapTab);
 }
 
 /** The language switcher fires while the popover may be open. */

--- a/src/components/wishlist/ReservationMessage.astro
+++ b/src/components/wishlist/ReservationMessage.astro
@@ -12,12 +12,20 @@
  * clipping, which is what the per-card version had to fight with `overflow:
  * visible` and `contain: none` overrides.
  *
- * Positioning is Floating UI's job (client/reservation-message.ts), anchored to
- * the message bead in the card's footer.
+ * One element, two shapes. On a pointer it is that lens, anchored to the
+ * message bead in the card's footer by Floating UI. On a phone it is a sheet at
+ * the bottom edge — the same one the blog's contents becomes, for the same
+ * reason: a 320px panel beside a bead is most of a 390px screen, and the
+ * software keyboard this panel exists to summon lands on top of wherever the
+ * bead was. Both shapes are driven from client/reservation-message.ts; the
+ * reasoning for the second lives with its rules in styles/wishlist.css.
  */
+import { Icon } from "astro-icon/components";
 import { RESERVATION_MESSAGE_MAX_LENGTH } from "@lib/wishlist";
 // The panel borrows the kit's field and buttons rather than growing its own;
-// neither stylesheet is pulled in by anything else the wishlist renders.
+// neither stylesheet is pulled in by anything else the wishlist renders. The
+// size classes below are the pointer's; the script swaps them for the 44px step
+// when the panel is a sheet.
 import "@styles/kit/input.css";
 import "@styles/kit/button.css";
 ---
@@ -29,14 +37,32 @@ import "@styles/kit/button.css";
   aria-labelledby="reservation-message-title"
   hidden
 >
-  <h2
-    class="message-popover-title"
-    id="reservation-message-title"
-    data-en="Leave a message"
-    data-ru="Оставить сообщение"
-  >
-    Leave a message
-  </h2>
+  <div class="message-popover-head">
+    <h2
+      class="message-popover-title"
+      id="reservation-message-title"
+      data-en="Leave a message"
+      data-ru="Оставить сообщение"
+    >
+      Leave a message
+    </h2>
+    {/*
+      The sheet's own way out, and only the sheet's. A pointer has Escape and
+      the whole page to click on; a thumb has the scrim, which is a target
+      nobody can see. "Skip" is not that button — it turns into "Delete" the
+      moment there is a message, and a sheet whose only visible exit is
+      sometimes destructive is not one.
+    */}
+    <button
+      type="button"
+      class="message-popover-close"
+      aria-label="Close"
+      data-aria-label-en="Close"
+      data-aria-label-ru="Закрыть"
+    >
+      <Icon name="chevron-up" width={18} height={18} aria-hidden="true" />
+    </button>
+  </div>
   <p
     class="message-popover-hint"
     data-en="Only the owner of the wishlist sees it."
@@ -88,3 +114,9 @@ import "@styles/kit/button.css";
     </div>
   </div>
 </div>
+
+{/* The sheet's scrim, and the reason a tap anywhere else closes it without the
+    document handler having to know a sheet exists: it is simply outside the
+    panel. Sits above the filter bar pinned to the same edge, so a chip under it
+    cannot be pressed through. */}
+<div class="message-scrim" id="reservation-message-scrim" hidden></div>

--- a/src/styles/wishlist.css
+++ b/src/styles/wishlist.css
@@ -1114,23 +1114,34 @@ html.lang-ru:not(.prices-ready) [data-price-original] {
   color: var(--ink-muted);
 }
 
-/* The field sits *inside* frosted glass, so it can't be the kit's opaque input:
-   a solid white box would punch a hole in the panel. Tint only, and the focus
-   ring is the kit's accent inset. */
 textarea.message-popover-input {
   resize: none;
-  background-color: light-dark(rgba(255, 255, 255, 0.5), rgba(0, 0, 0, 0.22));
-  box-shadow: inset 0 0 0 1px
-    light-dark(rgba(0, 0, 0, 0.12), rgba(255, 255, 255, 0.14));
 }
 
-textarea.message-popover-input:hover:not(:disabled):not(:focus) {
-  box-shadow: inset 0 0 0 1px
-    light-dark(rgba(0, 0, 0, 0.22), rgba(255, 255, 255, 0.24));
-}
+/* The field sits *inside* frosted glass, so it can't be the kit's opaque input:
+   a solid white box would punch a hole in the panel. Tint only, and the focus
+   ring is the kit's accent inset.
 
-textarea.message-popover-input:focus {
-  box-shadow: inset 0 0 0 2px var(--accent-start);
+   Scoped to the lens, because that is the only thing the tint was ever a
+   workaround for. The sheet is the veil and has no hole to punch, so its field
+   is the kit's own — the 80% ground and the 2px hairline ring every other field
+   on this site wears, which is also what stops the ring changing width when it
+   takes focus. */
+@media (min-width: 600.02px) {
+  textarea.message-popover-input {
+    background-color: light-dark(rgba(255, 255, 255, 0.5), rgba(0, 0, 0, 0.22));
+    box-shadow: inset 0 0 0 1px
+      light-dark(rgba(0, 0, 0, 0.12), rgba(255, 255, 255, 0.14));
+  }
+
+  textarea.message-popover-input:hover:not(:disabled):not(:focus) {
+    box-shadow: inset 0 0 0 1px
+      light-dark(rgba(0, 0, 0, 0.22), rgba(255, 255, 255, 0.24));
+  }
+
+  textarea.message-popover-input:focus {
+    box-shadow: inset 0 0 0 2px var(--accent-start);
+  }
 }
 
 .message-popover-error {
@@ -1186,6 +1197,208 @@ textarea.message-popover-input:focus {
   .message-btn::before,
   .message-popover {
     transition: none;
+  }
+}
+
+/* -----------------------------------------------------------------------------
+   The panel's second shape: a sheet, on a phone.
+
+   Anchoring is the wrong instrument on a 390px screen. The panel is 320px of a
+   375–430px viewport, so "beside the bead" is already most of the width — and
+   the bead sits in a card footer near the bottom edge, under the filter bar,
+   which is exactly where the software keyboard the panel exists to summon
+   arrives. Floating UI answers that by shifting the panel over the bead it
+   belongs to and overlapping it, which is the best a lens can do and still not
+   what a phone wants.
+
+   So below 600px — this page's own phone line, the width at which the filters
+   leave the top of the document for a bar pinned to the bottom edge — the panel
+   stops being a lens laid on the grid and becomes the page closing over it:
+   full width at the bottom edge, on the veil, over a scrim, with the grid's
+   scroll locked behind it. The blog's contents does this at its own breakpoint
+   for the same reason, and this is deliberately the same sheet.
+
+   The veil rather than glass, for the reason recorded there: a capsule is a
+   neutral tint you look through, and a sheet is not looked through. It also
+   answers `prefers-reduced-transparency` without a line here, since the tokens
+   collapse to the page's own colour in global.css.
+
+   Three things about the shape are not CSS, and the script owns them
+   (client/reservation-message.ts): Floating UI has to stop writing left/top,
+   the kit's control sizes step from 32px to 44px, and the sheet rides up by
+   however much visualViewport says the keyboard is covering. It also drops
+   `liquid-glass` from the element — on a phone this is not glass, and saying so
+   in the class list is cheaper, and truer, than out-specifying four
+   declarations from here.
+   ----------------------------------------------------------------------------- */
+
+/* Shape only — whether it is displayed at all is settled with the rest of the
+   sheet, below. */
+.message-popover-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.message-popover-close {
+  display: none;
+  flex: none;
+  align-items: center;
+  justify-content: center;
+  /* The sheet's fourth control, and every control in it is at the 44px step.
+     The glyph stays 18px: the target grows, the mark does not. */
+  width: 44px;
+  height: 44px;
+  /* Pulled back out to the padding line, so the chevron sits on the same edge
+     as the title beside it rather than a control's slack inside it. */
+  margin-right: -0.75rem;
+  border: none;
+  border-radius: 12px;
+  background: transparent;
+  color: var(--ink-muted);
+  cursor: pointer;
+  /* Points the way the sheet will go. */
+  transform: rotate(180deg);
+}
+
+.message-popover-close:hover {
+  color: var(--ink-strong);
+}
+
+.message-popover-close:focus-visible {
+  outline: 2px solid var(--accent-start);
+  outline-offset: 2px;
+}
+
+/* The scrim this site already uses, from the admin modal and the blog's sheet. */
+.message-scrim {
+  position: fixed;
+  inset: 0;
+  /* Over the filter bar pinned to the same edge (100), under the sheet (1000). */
+  z-index: 999;
+  display: none;
+  background: light-dark(rgba(0, 0, 0, 0.4), rgba(0, 0, 0, 0.7));
+  opacity: 0;
+  transition: opacity 0.36s ease;
+}
+
+.message-scrim.is-open {
+  opacity: 1;
+}
+
+.message-scrim[hidden] {
+  display: none;
+}
+
+@media (max-width: 600px) {
+  .message-scrim {
+    display: block;
+  }
+
+  .message-popover {
+    top: auto;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    width: auto;
+    /* Whatever the keyboard leaves, less a strip of page above it so the sheet
+       reads as sitting on something. Past that it scrolls itself rather than
+       growing off the top of the screen — a 320×568 phone with the keyboard up
+       has 271px to give and the sheet wants 320. */
+    max-height: calc(100dvh - var(--sheet-keyboard, 0px) - 2rem);
+    overflow-y: auto;
+    padding-block: 1.1rem calc(1.25rem + env(safe-area-inset-bottom, 0px));
+    padding-inline: max(1.25rem, env(safe-area-inset-left, 0px))
+      max(1.25rem, env(safe-area-inset-right, 0px));
+    /* A modal keeps its 16px and flattens the two corners it no longer has. */
+    border-radius: 16px 16px 0 0;
+    /* The one edge still on screen. --glass-border is a capsule's white rim and
+       is invisible on the light page, which is the complaint --rule-lit exists
+       to answer under sticky headings; a divider between two surfaces is what
+       --hairline is for. */
+    border-top: 1px solid var(--hairline);
+    background-color: var(--veil-bg);
+    backdrop-filter: var(--veil-filter);
+    /* No shadow. --glass-shadow points down, which from here is off the screen,
+       and the vocabulary has no upward variant to reach for. The scrim is the
+       separation and the hairline is the edge. */
+    box-shadow: none;
+    /* The lens fades and scales out of its bead; a sheet arrives from the edge
+       it is attached to and does nothing else. */
+    opacity: 1;
+    transform: translateY(101%);
+    transition: transform 0.36s cubic-bezier(0.16, 1, 0.3, 1);
+  }
+
+  .message-popover.is-open {
+    transform: translateY(calc(-1 * var(--sheet-keyboard, 0px)));
+  }
+
+  .message-popover-close {
+    display: inline-flex;
+  }
+
+  /* In the flow of a sheet the title is the sheet's landmark, at the size every
+     other group heading on this site takes. Beside a bead it was a label on a
+     lens and 0.9rem was right; standing alone above the fold it is not. */
+  .message-popover-title {
+    font-size: 1.25rem;
+    letter-spacing: -0.02em;
+  }
+
+  .message-popover-hint {
+    font-size: 0.8rem;
+  }
+
+  .message-popover-footer {
+    flex-wrap: wrap;
+    gap: 0.6rem;
+    margin-top: 0.5rem;
+  }
+
+  .message-popover-count,
+  .message-popover-error {
+    font-size: 0.75rem;
+  }
+
+  /* The count goes back to the field it counts. Three items on one line do not
+     fit a 320px screen once the buttons are at the 44px step, and the count is
+     the one of the three that was never a target. */
+  .message-popover-count {
+    order: -1;
+    width: 100%;
+    text-align: right;
+  }
+
+  .message-popover-actions {
+    width: 100%;
+  }
+
+  /* Save takes the rest of the line and Skip keeps its label's width. Halving
+     the row between them would give a destructive "Delete" — which is what Skip
+     becomes once there is a message — the same weight as the action it undoes. */
+  .message-popover-save {
+    flex: 1;
+  }
+}
+
+/* The sheet re-declares `transition`, so it has to re-answer this: the block
+   above it no longer wins. */
+@media (max-width: 600px) and (prefers-reduced-motion: reduce) {
+  .message-popover,
+  .message-scrim {
+    transition: none;
+  }
+}
+
+/* --hairline does not tighten at the token, whatever the shape of that sentence
+   in DESIGN.md suggests — each component asks for the contrast pair itself, as
+   the kit's fields and the filter bar both do. This edge is the only line
+   between a modal and the page it covers, so it asks too. */
+@media (max-width: 600px) and (prefers-contrast: more) {
+  .message-popover {
+    border-top: 2px solid light-dark(#999, #777);
   }
 }
 


### PR DESCRIPTION
Below 600px — the width at which this page's filters leave the top of the
document for a bar pinned to the bottom edge — the panel stops being a lens
anchored to the bead and becomes the sheet the blog's contents already is at its
own breakpoint: full width on the veil, over a scrim, with the grid's scroll
locked behind it.

Anchoring had not gone wrong so much as run out of room. The panel is 320px of a
375-430px viewport, so "beside the bead" was most of the width already, and the
bead sits in a card footer near the bottom edge, under the filter bar, which is
exactly where the software keyboard the panel exists to summon arrives. Floating
UI's answer there is to shift the panel over the bead it belongs to and overlap
it, which is the best a lens can do and still not what a phone wants.

Three parts of the shape are not the media query's to give, so the script owns
them. Floating UI stops writing left/top, which would otherwise beat the sheet's
own edges. The kit's control sizes step from 32px to 44px — swapped rather than
copied, so the sheet takes the padding, radius and type that go with the step
instead of a second copy of its numbers. And the sheet rides up by however much
visualViewport reports as covered: `position: fixed` is measured against the
layout viewport, which a keyboard does not shrink, so the field the sheet exists
for was landing underneath it. The script also drops `liquid-glass`, since a
sheet on the veil is not glass; saying so in the class list costs less, and is
truer, than out-specifying four declarations from a page stylesheet.

Crossing the breakpoint re-shapes the panel rather than closing it. Turning a
phone sideways is not a decision to discard a half-written message, and the
panel is the only place that message exists. The same width settles two smaller
things: the character count goes back under the field it counts, because three
items on one line do not fit a 320px screen once the buttons are at the 44px
step, and the field takes the kit's own ground back, because the tint it wore
was only ever there to keep a solid box from punching a hole in frosted glass
and the veil has no hole to punch.

A sheet over a scrim with the page locked behind it is modal in a way the
anchored popover is not, so only the sheet claims `aria-modal`, traps Tab, and
takes focus when it opens by itself after a reservation — the close button
rather than the field, because a keyboard is not what that moment asked for.